### PR TITLE
build.py: loaderString should escape \-characters? #762

### DIFF
--- a/build.py
+++ b/build.py
@@ -103,7 +103,7 @@ def readfile(fn):
 
 def loaderString(var):
     fn = var.group(1)
-    return readfile(fn).replace('\n', '\\n').replace('\'', '\\\'')
+    return readfile(fn).replace('\\', '\\\\').replace('\n', '\\n').replace('\'', '\\\'')
 
 def loaderRaw(var):
     fn = var.group(1)


### PR DESCRIPTION
https://github.com/iitc-project/ingress-intel-total-conversion/pull/762

#2 