### PR TITLE
Portal level layer strikeout

### DIFF
--- a/code/boot.js
+++ b/code/boot.js
@@ -78,21 +78,6 @@ window.setupLayerChooserStatusRecorder = function() {
   });
 }
 
-window.layerChooserSetDisabledStates = function() {
-// layer selector - enable/disable layers that aren't visible due to zoom level
-  var minlvl = getMinPortalLevel();
-  var portalSelection = $('.leaflet-control-layers-overlays label');
-  //it's an array - 0=unclaimed, 1=lvl 1, 2=lvl 2, ..., 8=lvl 8 - 9 relevant entries
-  //mark all levels below (but not at) minlvl as disabled
-  portalSelection.slice(0, minlvl).addClass('disabled').attr('title', 'Zoom in to show those.');
-  //and all from minlvl to 8 as enabled
-  portalSelection.slice(minlvl, 8+1).removeClass('disabled').attr('title', '');
-
-//TODO? some generic mechanism where other layers can have their disabled state marked on/off? a few
-//plugins have code to do it by hand already
-}
-
-
 window.setupStyles = function() {
   $('head').append('<style>' +
     [ '#largepreview.enl img { border:2px solid '+COLORS[TEAM_ENL]+'; } ',
@@ -325,9 +310,6 @@ window.setupMap = function() {
   // ensures order of calls
   map.on('movestart', function() { window.mapRunsUserAction = true; window.requests.abort(); window.startRefreshTimeout(-1); });
   map.on('moveend', function() { window.mapRunsUserAction = false; window.startRefreshTimeout(ON_MOVE_REFRESH*1000); });
-
-  map.on('zoomend', function() { window.layerChooserSetDisabledStates(); });
-  window.layerChooserSetDisabledStates();
 
   // on zoomend, check to see the zoom level is an int, and reset the view if not
   // (there's a bug on mobile where zoom levels sometimes end up as fractional levels. this causes the base map to be invisible)

--- a/code/map_data_calc_tools.js
+++ b/code/map_data_calc_tools.js
@@ -87,25 +87,10 @@ window.debugMapZoomParameters = function() {
 
 window.getMapZoomTileParameters = function(zoom) {
 
-
-  // the current API allows the client to request a minimum portal level. the window.TILE_PARAMS.ZOOM_TO_LEVEL list are minimums
-  // however, in my view, this can return excessive numbers of portals in many cases. let's try an optional reduction
-  // of detail level at some zoom levels
-
-  var level = window.TILE_PARAMS.ZOOM_TO_LEVEL[zoom] || 0;  // default to level 0 (all portals) if not in array
-
-//  if (window.CONFIG_ZOOM_SHOW_LESS_PORTALS_ZOOMED_OUT) {
-//    if (level <= 7 && level >= 4) {
-//      // reduce portal detail level by one - helps reduce clutter
-//      level = level+1;
-//    }
-//  }
-
   var maxTilesPerEdge = window.TILE_PARAMS.TILES_PER_EDGE[window.TILE_PARAMS.TILES_PER_EDGE.length-1];
 
   return {
-    level: level,
-    maxLevel: window.TILE_PARAMS.ZOOM_TO_LEVEL[zoom] || 0,  // for reference, for log purposes, etc
+    level: window.TILE_PARAMS.ZOOM_TO_LEVEL[zoom] || 0,
     tilesPerEdge: window.TILE_PARAMS.TILES_PER_EDGE[zoom] || maxTilesPerEdge,
     minLinkLength: window.TILE_PARAMS.ZOOM_TO_LINK_LENGTH[zoom] || 0,
     hasPortals: zoom >= window.TILE_PARAMS.ZOOM_TO_LINK_LENGTH.length,  // no portals returned at all when link length limits things

--- a/code/map_data_request.js
+++ b/code/map_data_request.js
@@ -246,11 +246,7 @@ window.MapDataRequest.prototype.refresh = function() {
   this.render.processGameEntities(artifact.getArtifactEntities());
 
   var logMessage = 'requesting data tiles at zoom '+dataZoom;
-  if (tileParams.level != tileParams.maxLevel) {
-    logMessage += ' (L'+tileParams.level+'+ portals - could have done L'+tileParams.maxLevel+'+';
-  } else {
-    logMessage += ' (L'+tileParams.level+'+ portals';
-  }
+  logMessage += ' (L'+tileParams.level+'+ portals';
   logMessage += ', '+tileParams.tilesPerEdge+' tiles per global edge), map zoom is '+mapZoom;
 
   console.log(logMessage);

--- a/code/status_bar.js
+++ b/code/status_bar.js
@@ -7,11 +7,7 @@ window.renderUpdateStatusTimer_ = undefined;
 window.renderUpdateStatus = function() {
   var progress = 1;
 
-  // portal/limk level display
-
-  var zoom = map.getZoom();
-  zoom = getDataZoomForMapZoom(zoom);
-  var tileParams = getMapZoomTileParameters(zoom);
+  var tileParams = window.getCurrentZoomTileParameters();
 
   var t = '<span class="help portallevel" title="Indicates portal levels/link lengths displayed.  Zoom in to display more.">';
 

--- a/code/utils_misc.js
+++ b/code/utils_misc.js
@@ -243,12 +243,10 @@ window.androidPermalink = function() {
   return false;
 }
 
-
-
-window.getMinPortalLevel = function() {
-  var z = map.getZoom();
-  z = getDataZoomForMapZoom(z);
-  return getMapZoomTileParameters(z).level;
+window.getCurrentZoomTileParameters = function() {
+  var zoom = getDataZoomForMapZoom( map.getZoom() );
+  var tileParams = getMapZoomTileParameters(zoom);
+  return tileParams;
 }
 
 // returns number of pixels left to scroll down before reaching the

--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -524,7 +524,7 @@ window.plugin.drawTools.optReset = function() {
 }
 
 window.plugin.drawTools.snapToPortals = function() {
-  var dataParams = getMapZoomTileParameters(getDataZoomForMapZoom(map.getZoom()));
+  var dataParams = window.getCurrentZoomTileParameters();
   if (dataParams.level > 0) {
     if (!confirm('Not all portals are visible on the map. Snap to portals may move valid points to the wrong place. Continue?')) {
       return;

--- a/plugins/portal-counts.user.js
+++ b/plugins/portal-counts.user.js
@@ -84,7 +84,6 @@ window.plugin.portalcounts.getPortals = function (){
   });
 
   //get portals informations from IITC
-  var minlvl = getMinPortalLevel();
   var total = self.neuP + self.enlP + self.resP;
 
   var counts = '';
@@ -92,20 +91,14 @@ window.plugin.portalcounts.getPortals = function (){
     counts += '<table><tr><th></th><th class="enl">Enlightened</th><th class="res">Resistance</th></tr>';  //'+self.enlP+' Portal(s)</th></tr>';
     for(var level = window.MAX_PORTAL_LEVEL; level > 0; level--){
       counts += '<tr><td class="L'+level+'">Level '+level+'</td>';
-      if(minlvl > level)
-        counts += '<td colspan="2">zoom in to see portals in this level</td>';
-      else
-        counts += '<td class="enl">'+self.PortalsEnl[level]+'</td><td class="res">'+self.PortalsRes[level]+'</td>';
+      counts += '<td class="enl">'+self.PortalsEnl[level]+'</td><td class="res">'+self.PortalsRes[level]+'</td>';
       counts += '</tr>';
     }
 
     counts += '<tr><th>Total:</th><td class="enl">'+self.enlP+'</td><td class="res">'+self.resP+'</td></tr>';
 
     counts += '<tr><td>Neutral:</td><td colspan="2">';
-    if(minlvl > 0)
-      counts += 'zoom in to see unclaimed portals';
-    else
-      counts += self.neuP;
+    counts += self.neuP;
     counts += '</td></tr></table>';
 
     var svg = $('<svg width="300" height="200">').css('margin-top', 10);
@@ -186,10 +179,8 @@ window.plugin.portalcounts.getPortals = function (){
     counts += '<p>No Portals in range!</p>';
   }
 
-  // I've only seen the backend reduce the portals returned for L4+ or further out zoom levels - but this could change
-  // UPDATE: now seen for L2+ in dense areas (map zoom level 14 or lower)
-  if (getMinPortalLevel() >= 2) {
-   counts += '<p class="help" title="To reduce data usage and speed up map display, the backend servers only return some portals in dense areas."><b>Warning</b>: Portal counts can be inaccurate when zoomed out</p>';
+  if (!window.getCurrentZoomTileParameters().hasPortals) {
+    counts += '<p class="help"><b>Warning</b>: Portal counts is inaccurate when zoomed to link-level</p>';
   }
 
   var total = self.enlP + self.resP + self.neuP;


### PR DESCRIPTION
ATM there is no 'Portal-Level-Limit-By-Zoom'..so the old 'strike-out-portal-level-layer-if-not-visible' is obsolete.

https://github.com/iitc-project/ingress-intel-total-conversion/pull/1174
#2 