### PR TITLE
sidebar: reset scroll position on new portal

### DIFF
--- a/code/boot.js
+++ b/code/boot.js
@@ -448,6 +448,7 @@ window.setupSidebarToggle = function() {
       toggle.css('right', '0');
     } else {
       sidebar.css('z-index', 1001).show();
+      window.resetScrollOnNewPortal();
       $('.leaflet-right').css('margin-right', SIDEBAR_WIDTH+1+'px');
       toggle.html('<span class="toggle close"></span>');
       toggle.css('right', SIDEBAR_WIDTH+1+'px');

--- a/code/portal_detail_display.js
+++ b/code/portal_detail_display.js
@@ -2,8 +2,19 @@
 // main code block that renders the portal details in the sidebar and
 // methods that highlight the portal in the map view.
 
+window.resetScrollOnNewPortal = function() {
+  if (selectedPortal !== window.renderPortalDetails.lastVisible) {
+    // another portal selected so scroll position become irrelevant to new portal details
+    $("#sidebar").scrollTop(0); // NB: this works ONLY when #sidebar:visible
+  }
+};
+
 window.renderPortalDetails = function(guid) {
   selectPortal(window.portals[guid] ? guid : null);
+  if ($('#sidebar').is(':visible')) {
+    window.resetScrollOnNewPortal();
+    window.renderPortalDetails.lastVisible = guid;
+  }
 
   if (guid && !portalDetail.isFresh(guid)) {
     portalDetail.request(guid);

--- a/code/smartphone.js
+++ b/code/smartphone.js
@@ -44,6 +44,7 @@ window.runOnSmartphonesBeforeBoot = function() {
 
   window.smartphone.sideButton = $('<a>info</a>').click(function() {
     $('#scrollwrapper').show();
+    window.resetScrollOnNewPortal();
     $('.active').removeClass('active');
     $("#chatcontrols a:contains('info')").addClass('active');
   });


### PR DESCRIPTION
After another portal get selected it's more naturally to reset scroll position back to top, 'cause all portal details get changed.