### PR TITLE
build.py: fix deprecation warnings

### DIFF
--- a/build.py
+++ b/build.py
@@ -122,8 +122,7 @@ def loaderRaw(var):
 
 def loaderImage(var):
     fn = var.group(1)
-    return 'data:image/png;base64,{0}'.format(
-        base64.b64encode(open(fn, 'rb').read()).decode('utf8'))
+    return 'data:image/png;base64,' + base64.b64encode(open(fn, 'rb').read()).decode('utf8')
 
 
 def loadCode(ignore):

--- a/build.py
+++ b/build.py
@@ -106,7 +106,7 @@ pluginMetaBlock = """// @updateURL      @@UPDATEURL@@
 
 
 def readfile(fn):
-    with io.open(fn, 'Ur', encoding='utf8') as f:
+    with io.open(fn, 'r', encoding='utf8') as f:
         return f.read()
 
 
@@ -123,7 +123,7 @@ def loaderRaw(var):
 def loaderImage(var):
     fn = var.group(1)
     return 'data:image/png;base64,{0}'.format(
-        base64.encodestring(open(fn, 'rb').read()).decode('utf8').replace('\n', ''))
+        base64.b64encode(open(fn, 'rb').read()).decode('utf8'))
 
 
 def loadCode(ignore):


### PR DESCRIPTION
* U mode is default both in Python 2/3
* b64encode fits even better (encodestring inserts waste newlines)