### PR TITLE
fix-googlemap-china-offset: refactoring

### DIFF
--- a/plugins/fix-googlemap-china-offset.user.js
+++ b/plugins/fix-googlemap-china-offset.user.js
@@ -1,0 +1,8 @@
+// ==UserScript==
+// @id             iitc-plugin-fix-googlemap-china-offset@breezewish
+// @name           IITC plugin: Fix Google Map offsets in China
+// @category       Deleted
+// @version        0.0.1.@@DATETIMEVERSION@@
+// @description    [@@BUILDNAME@@-@@BUILDDATE@@] Deprecated, use fix-china-offset instead
+@@METAINFO@@
+// ==/UserScript==


### PR DESCRIPTION
divide PRCoords into 2 distinct functions:
* plugin.fixChinaOffset.isInGoogle
* plugin.fixChinaOffset.gcjObfs