### PR TITLE
Better 'use strict';

### DIFF
--- a/build.py
+++ b/build.py
@@ -69,6 +69,10 @@ function wrapper(plugin_info) {
 // ensure plugin framework is there, even if iitc is not yet loaded
 if(typeof window.plugin !== 'function') window.plugin = function() {};
 
+"""
+
+pluginWrapperEnd = """
+
 //PLUGIN AUTHORS: writing a plugin outside of the IITC build environment? if so, delete these lines!!
 //(leaving them in place might break the 'About IITC' page or break update checks)
 plugin_info.buildName = '@@BUILDNAME@@';
@@ -76,9 +80,6 @@ plugin_info.dateTimeVersion = '@@DATETIMEVERSION@@';
 plugin_info.pluginId = '@@PLUGINNAME@@';
 //END PLUGIN AUTHORS NOTE
 
-"""
-
-pluginWrapperEnd = """
 setup.info = plugin_info; //add the script info data to the function as a property
 if(!window.bootPlugins) window.bootPlugins = [];
 window.bootPlugins.push(setup);

--- a/build.py
+++ b/build.py
@@ -65,7 +65,7 @@ gradleBuildFile = settings.get('gradleBuildFile', 'mobile/build.gradle')
 # 1. indentation caused by the "function wrapper()" doesn't apply to the plugin code body
 # 2. the wrapper is formatted correctly for removal by the IITC Mobile android app
 pluginWrapperStart = """
-function wrapper(plugin_info) {
+function wrapper(plugin_info) { 'use strict';
 // ensure plugin framework is there, even if iitc is not yet loaded
 if(typeof window.plugin !== 'function') window.plugin = function() {};
 

--- a/build.py
+++ b/build.py
@@ -69,10 +69,6 @@ function wrapper(plugin_info) {
 // ensure plugin framework is there, even if iitc is not yet loaded
 if(typeof window.plugin !== 'function') window.plugin = function() {};
 
-"""
-
-pluginWrapperEnd = """
-
 //PLUGIN AUTHORS: writing a plugin outside of the IITC build environment? if so, delete these lines!!
 //(leaving them in place might break the 'About IITC' page or break update checks)
 plugin_info.buildName = '@@BUILDNAME@@';
@@ -80,6 +76,9 @@ plugin_info.dateTimeVersion = '@@DATETIMEVERSION@@';
 plugin_info.pluginId = '@@PLUGINNAME@@';
 //END PLUGIN AUTHORS NOTE
 
+"""
+
+pluginWrapperEnd = """
 setup.info = plugin_info; //add the script info data to the function as a property
 if(!window.bootPlugins) window.bootPlugins = [];
 window.bootPlugins.push(setup);

--- a/build.py
+++ b/build.py
@@ -78,8 +78,6 @@ plugin_info.pluginId = '@@PLUGINNAME@@';
 
 """
 
-pluginWrapperStartUseStrict = pluginWrapperStart.replace("{\n", "{\n\"use strict\";\n", 1)
-
 pluginWrapperEnd = """
 setup.info = plugin_info; //add the script info data to the function as a property
 if(!window.bootPlugins) window.bootPlugins = [];
@@ -143,7 +141,6 @@ def doReplacements(script, updateUrl, downloadUrl, pluginName=None):
 
     script = script.replace('@@METAINFO@@', pluginMetaBlock)
     script = script.replace('@@PLUGINSTART@@', pluginWrapperStart)
-    script = script.replace('@@PLUGINSTART-USE-STRICT@@', pluginWrapperStartUseStrict)
     script = script.replace('@@PLUGINEND@@', pluginWrapperEnd)
 
     script = re.sub('@@INCLUDERAW:([0-9a-zA-Z_./-]+)@@', loaderRaw, script)


### PR DESCRIPTION
Nowadays there are no reasons why not use [`'use strict';`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) in all our scripts.

- core: could be inserted during build (#234)
- plugins cannot insert 'use strict' statement in random place, currently it must be part of wrapper (inside of wrapper function, but before any other statement).
  We have 0d571f4859c76dc117310eb8ef695c3ebbfec298, but imho that was not good, as we want strict for ALL standard plugins.
So instead of separate macro [`@@PLUGINSTART-USE-STRICT@@`](https://github.com/iitc-project/ingress-intel-total-conversion/pull/1187) it's more proper (and simple) just modify wrapper for all plugins (after #238).

But before we can make this modifications - we have to make sure that code itself is ready for strict mode.