### PR TITLE
Removed `Copy to clipboard` from share activity in another apps

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -143,13 +143,7 @@
             android:exported="false"
             android:icon="@drawable/ic_action_copy"
             android:label="@string/activity_share_to_clipboard"
-            android:noHistory="false">
-            <intent-filter>
-                <action android:name="android.intent.action.SEND"/>
-
-                <data android:mimeType="text/plain"/>
-            </intent-filter>
-        </activity>
+            android:noHistory="false"/>
 
         <activity
             android:name="org.exarhteam.iitc_mobile.share.SaveToFile"


### PR DESCRIPTION
For some reason, previously displayed in third-party applications, which should not be