### PR TITLE
Remove some unused stuff from window object

### DIFF
--- a/code/map_data_calc_tools.js
+++ b/code/map_data_calc_tools.js
@@ -165,20 +165,3 @@ window.pointToTileId = function(params, x, y) {
 
   return params.zoom + "_" + x + "_" + y + "_" + params.level + "_8_100";
 }
-
-
-window.getResonatorLatLng = function(dist, slot, portalLatLng) {
-  // offset in meters
-  var dn = dist*SLOT_TO_LAT[slot];
-  var de = dist*SLOT_TO_LNG[slot];
-
-  // Coordinate offset in radians
-  var dLat = dn/EARTH_RADIUS;
-  var dLon = de/(EARTH_RADIUS*Math.cos(Math.PI/180*portalLatLng[0]));
-
-  // OffsetPosition, decimal degrees
-  var lat0 = portalLatLng[0] + dLat * 180/Math.PI;
-  var lon0 = portalLatLng[1] + dLon * 180/Math.PI;
-
-  return [lat0, lon0];
-}

--- a/code/portal_info.js
+++ b/code/portal_info.js
@@ -186,9 +186,7 @@ window.potentialPortalLevel = function(d) {
 window.fixPortalImageUrl = function(url) {
   if (url) {
     if (window.location.protocol === 'https:') {
-      url = url.indexOf('www.panoramio.com') !== -1
-            ? url.replace(/^http:\/\/www/, 'https://ssl').replace('small', 'medium')
-            : url.replace(/^http:\/\//, '//');
+      url = url.replace(/^http:\/\//, '//');
     }
     return url;
   } else {

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -201,25 +201,6 @@ Constants
   Maps team to its CSS class. Presumably to be used like
   ``TEAM_TO_CSS[TEAM_ENL]``.
 
-.. data:: window.SLOT_TO_LAT
-          window.SLOT_TO_LNG
-
-  ::
-
-    [0, Math.sqrt(2)/2, 1, Math.sqrt(2)/2, 0, -Math.sqrt(2)/2, -1, -Math.sqrt(2)/2]
-    [1, Math.sqrt(2)/2, 0, -Math.sqrt(2)/2, -1, -Math.sqrt(2)/2, 0, Math.sqrt(2)/2]
-
-  Something to do with resonator slots?
-
-.. data:: window.EARTH_RADIUS
-
-  The Earth's approximate radius at the equator in metres.
-
-.. data:: window.DEG2RAD
-
-  ::
-
-    Math.PI / 180
 
 Variables
 ---------
@@ -265,12 +246,6 @@ Variables
 
   **Note:** Although these will be Leaflet objects, not all may be added to the
   map if render limits are reached.
-
-.. data:: window.resonators
-
-  My guess is that it used to be like :data:`~window.portals` but was deprecated
-  when Niantic stopped sending resonator positions to Intel, and kept in for
-  backwards compatibility with older plugins.
 
 .. data:: window.overlayStatus
 

--- a/main.js
+++ b/main.js
@@ -169,11 +169,6 @@ window.TEAM_RES = 1;
 window.TEAM_ENL = 2;
 window.TEAM_TO_CSS = ['none', 'res', 'enl'];
 
-window.SLOT_TO_LAT = [0, Math.sqrt(2)/2, 1, Math.sqrt(2)/2, 0, -Math.sqrt(2)/2, -1, -Math.sqrt(2)/2];
-window.SLOT_TO_LNG = [1, Math.sqrt(2)/2, 0, -Math.sqrt(2)/2, -1, -Math.sqrt(2)/2, 0, Math.sqrt(2)/2];
-window.EARTH_RADIUS=6367000;
-window.DEG2RAD = Math.PI / 180;
-
 // STORAGE ///////////////////////////////////////////////////////////
 // global variables used for storage. Most likely READ ONLY. Proper
 // way would be to encapsulate them in an anonymous function and write
@@ -193,8 +188,6 @@ var portalsFactionLayers, linksFactionLayers, fieldsFactionLayers;
 window.portals = {};
 window.links = {};
 window.fields = {};
-
-window.resonators = {};
 
 // contain current status(on/off) of overlay layerGroups.
 // But you should use isLayerGroupDisplayed(name) to check the status


### PR DESCRIPTION
Resonators info is not available since 2014, so get rid of unused stuff.
Also remove panoramio links processing as it's gone long time ago.
