### PR TITLE
Reduce the number of dots to the version number

### DIFF
--- a/build.py
+++ b/build.py
@@ -52,7 +52,7 @@ settings = buildSettings[buildName]
 utcTime = time.gmtime()
 buildDate = time.strftime('%Y-%m-%d-%H%M%S', utcTime)
 # userscripts have specific specifications for version numbers - the above date format doesn't match
-dateTimeVersion = time.strftime('%Y%m%d.', utcTime) + time.strftime('%H%M%S', utcTime).lstrip('0')
+dateTimeVersion = time.strftime('%Y%m%d', utcTime) + time.strftime('%H%M%S', utcTime).lstrip('0')
 
 # extract required values from the settings entry
 resourceUrlBase = settings.get('resourceUrlBase')


### PR DESCRIPTION
Some userscripts managers report an error #99

before PR:
// @version 0.3.0.20190103.162834
→ Required value' version' is missing or invalid. It must be between 1-4 dot-separated integers...

after PR:
// @version 0.3.0.20190103162834
→ You're beautiful :)