### PR TITLE
Restore and fix basemap-kartverket

### DIFF
--- a/plugins/basemap-kartverket.user.js
+++ b/plugins/basemap-kartverket.user.js
@@ -1,8 +1,35 @@
 // ==UserScript==
 // @id             iitc-plugin-basemap-kartverket@sollie
 // @name           IITC plugin: Kartverket.no map tiles
-// @category       Deleted
+// @category       Map Tiles
 // @version        0.1.0.@@DATETIMEVERSION@@
 // @description    [@@BUILDNAME@@-@@BUILDDATE@@] Add the color and grayscale map tiles from Kartverket.no as an optional layer.
 @@METAINFO@@
 // ==/UserScript==
+
+@@PLUGINSTART@@
+
+// PLUGIN START ////////////////////////////////////////////////////////
+
+
+// use own namespace for plugin
+window.plugin.mapTileKartverketMap = function() {};
+
+window.plugin.mapTileKartverketMap.addLayer = function() {
+
+  // Map data from Kartverket (http://statkart.no/en/)
+  kartverketAttribution = 'Map data © Kartverket';
+  var kartverketOpt = {attribution: kartverketAttribution, maxNativeZoom: 18, maxZoom: 21, subdomains: ['opencache', 'opencache2', 'opencache3']};
+  var kartverketTopo2 = new L.TileLayer('http://{s}.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo2&zoom={z}&x={x}&y={y}', kartverketOpt);
+  var kartverketTopo2Grayscale = new L.TileLayer('http://{s}.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo2graatone&zoom={z}&x={x}&y={y}', kartverketOpt);
+
+  layerChooser.addBaseLayer(kartverketTopo2, "Norway Topo");
+  layerChooser.addBaseLayer(kartverketTopo2Grayscale, "Norway Topo Grayscale");
+};
+
+var setup =  window.plugin.mapTileKartverketMap.addLayer;
+
+// PLUGIN END //////////////////////////////////////////////////////////
+
+@@PLUGINEND@@
+

--- a/plugins/basemap-kartverket.user.js
+++ b/plugins/basemap-kartverket.user.js
@@ -11,23 +11,32 @@
 
 // PLUGIN START ////////////////////////////////////////////////////////
 
-
 // use own namespace for plugin
-window.plugin.mapTileKartverketMap = function() {};
-
-window.plugin.mapTileKartverketMap.addLayer = function() {
-
-  // Map data from Kartverket (http://statkart.no/en/)
-  kartverketAttribution = 'Map data © Kartverket';
-  var kartverketOpt = {attribution: kartverketAttribution, maxNativeZoom: 18, maxZoom: 21, subdomains: ['opencache', 'opencache2', 'opencache3']};
-  var kartverketTopo2 = new L.TileLayer('http://{s}.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo2&zoom={z}&x={x}&y={y}', kartverketOpt);
-  var kartverketTopo2Grayscale = new L.TileLayer('http://{s}.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo2graatone&zoom={z}&x={x}&y={y}', kartverketOpt);
-
-  layerChooser.addBaseLayer(kartverketTopo2, "Norway Topo");
-  layerChooser.addBaseLayer(kartverketTopo2Grayscale, "Norway Topo Grayscale");
+  window.plugin.mapTileKartverketMap = {
+  addLayer: function() {
+    let kartverketOpt = {
+      attribution  : 'Map data © Kartverket', // Map data from Kartverket (http://statkart.no/en/)
+      maxNativeZoom: 18,
+      maxZoom      : 21,
+      subdomains   : [ 'opencache', 'opencache2', 'opencache3' ]
+    };
+    
+    let layers = {
+      'topo4'        : 'Norway Topo',
+      'topo4graatone': 'Norway Topo Grayscale',
+      'kartdata2'    : 'Norway Kartdata2',
+      'toporaster3'  : 'Norway Toporaster3',
+      'europa'       : 'Norway Europa',
+    };
+    
+    for(let i in layers) {
+      let layer = new L.TileLayer('https://{s}.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=' + i + '&zoom={z}&x={x}&y={y}', kartverketOpt);
+      layerChooser.addBaseLayer(layer, 'Kartverket ' + layers[ i ]);
+    }
+  },
 };
 
-var setup =  window.plugin.mapTileKartverketMap.addLayer;
+let setup = window.plugin.mapTileKartverketMap.addLayer;
 
 // PLUGIN END //////////////////////////////////////////////////////////
 

--- a/plugins/basemap-kartverket.user.js
+++ b/plugins/basemap-kartverket.user.js
@@ -24,8 +24,7 @@
     let layers = {
       'topo4'        : 'Norway Topo',
       'topo4graatone': 'Norway Topo Grayscale',
-      'kartdata2'    : 'Norway Kartdata2',
-      'toporaster3'  : 'Norway Toporaster3',
+      'toporaster3'  : 'Norway Topo Raster',
       'europa'       : 'Norway Europa',
     };
     
@@ -41,4 +40,3 @@ let setup = window.plugin.mapTileKartverketMap.addLayer;
 // PLUGIN END //////////////////////////////////////////////////////////
 
 @@PLUGINEND@@
-

--- a/plugins/basemap-kartverket.user.js
+++ b/plugins/basemap-kartverket.user.js
@@ -2,8 +2,8 @@
 // @id             iitc-plugin-basemap-kartverket@sollie
 // @name           IITC plugin: Kartverket.no map tiles
 // @category       Map Tiles
-// @version        0.1.0.@@DATETIMEVERSION@@
-// @description    [@@BUILDNAME@@-@@BUILDDATE@@] Add the color and grayscale map tiles from Kartverket.no as an optional layer.
+// @version        0.2.0.@@DATETIMEVERSION@@
+// @description    [@@BUILDNAME@@-@@BUILDDATE@@] Add map layers provided by Kartverket, the Norwegian Mapping Authority.
 @@METAINFO@@
 // ==/UserScript==
 

--- a/plugins/basemap-kartverket.user.js
+++ b/plugins/basemap-kartverket.user.js
@@ -22,10 +22,11 @@
     };
     
     let layers = {
-      'topo4'        : 'Norway Topo',
-      'topo4graatone': 'Norway Topo Grayscale',
-      'toporaster3'  : 'Norway Topo Raster',
-      'europa'       : 'Norway Europa',
+      'topo4'         : 'Norway Topo',
+      'topo4graatone' : 'Norway Topo Grayscale',
+      'toporaster3'   : 'Norway Topo Raster',
+      'sjokartraster' : 'Norway Nautical Raster',
+      'europa'        : 'Norway Europa',
     };
     
     for(let i in layers) {


### PR DESCRIPTION
Restore the deleted plugin for layers from the Norwegian Mapping Authority's cached GMaps compatible tile service.

This includes the fix [#1288](https://github.com/iitc-project/ingress-intel-total-conversion/pull/1288)  by [gusowski1](/gusowski1) tracked in #2, and supersedes the changes in the mentioned [#1006](https://github.com/iitc-project/ingress-intel-total-conversion/pull/1006) by [sollie](/sollie).

Included an additional nautical chart layer, useful for checking access to coastal portals.