### PR TITLE
[sync] fix error in handleError(e)

### DIFF
--- a/plugins/sync.user.js
+++ b/plugins/sync.user.js
@@ -211,7 +211,7 @@ window.plugin.sync.RegisteredMap.prototype.loadDocument = function(callback) {
   handleError = function(e) {
     var error_type = e.type;
     
-    if(e.error.message === "A network error occurred, and the request could not be completed.") {
+    if(e.result.error.message === "A network error occurred, and the request could not be completed.") {
       error_type = "network error";
     }
     


### PR DESCRIPTION
When the plugin JSON on Google Drive was missing, Sync did nothing without any warnings but TypeError in debug console. I've spent some time to figure out that "error" object was enclosed within "result" object.