### PR TITLE
Fix miscellaneous bugs in core and plugins 

### DIFF
--- a/code/boot.js
+++ b/code/boot.js
@@ -3,9 +3,9 @@
 // created a basic framework. All of these functions should only ever
 // be run once.
 
-window.setupLargeImagePreview = function() {
-  $('#portaldetails').on('click', '.imgpreview', function() {
-    var img = $(this).find('img')[0];
+window.setupLargeImagePreview = function () {
+  $('#portaldetails').on('click', '.imgpreview', function (e) {
+    var img = this.querySelector('img');
     var details = $(this).find('div.portalDetails')[0];
     //dialogs have 12px padding around the content
     var dlgWidth = Math.max(img.naturalWidth+24,500);
@@ -15,22 +15,17 @@ window.setupLargeImagePreview = function() {
     // To support that, we'd need a unique key per portal.  Example, guid.
     // So that would have to be in the html fetched into details.
 
-    var title = $(this).parent().find('h3.title')[0].innerText;
+    var preview = '<div style="text-align: center">' + img.outerHTML + '</div>';
+    var title = e.delegateTarget.querySelector('.title').innerText;
     if (details) {
-      dialog({
-        html: '<div style="text-align: center">' + img.outerHTML + '</div>' + details.outerHTML,
-        title: title,
-        id: 'iitc-portal-image',
-        width: dlgWidth,
-      });
-    } else {
-      dialog({
-        html: '<div style="text-align: center">' + img.outerHTML + '</div>',
-        title: title,
-        id: 'iitc-portal-image',
-        width: dlgWidth,
-      });
+      preview += details.outerHTML;
     }
+    dialog({
+      html: preview,
+      title: title,
+      id: 'iitc-portal-image',
+      width: dlgWidth,
+    });
   });
 }
 

--- a/code/boot.js
+++ b/code/boot.js
@@ -6,7 +6,6 @@
 window.setupLargeImagePreview = function () {
   $('#portaldetails').on('click', '.imgpreview', function (e) {
     var img = this.querySelector('img');
-    var details = $(this).find('div.portalDetails')[0];
     //dialogs have 12px padding around the content
     var dlgWidth = Math.max(img.naturalWidth+24,500);
     // This might be a case where multiple dialogs make sense, for example
@@ -17,9 +16,6 @@ window.setupLargeImagePreview = function () {
 
     var preview = '<div style="text-align: center">' + img.outerHTML + '</div>';
     var title = e.delegateTarget.querySelector('.title').innerText;
-    if (details) {
-      preview += details.outerHTML;
-    }
     dialog({
       html: preview,
       title: title,

--- a/code/boot.js
+++ b/code/boot.js
@@ -14,17 +14,19 @@ window.setupLargeImagePreview = function() {
     // usually we only want to show one version of each image.
     // To support that, we'd need a unique key per portal.  Example, guid.
     // So that would have to be in the html fetched into details.
+
+    var title = $(this).parent().find('h3.title')[0].innerText;
     if (details) {
       dialog({
         html: '<div style="text-align: center">' + img.outerHTML + '</div>' + details.outerHTML,
-        title: $(this).parent().find('h3.title').text(),
+        title: title,
         id: 'iitc-portal-image',
         width: dlgWidth,
       });
     } else {
       dialog({
         html: '<div style="text-align: center">' + img.outerHTML + '</div>',
-        title: $(this).parent().find('h3.title').text(),
+        title: title,
         id: 'iitc-portal-image',
         width: dlgWidth,
       });

--- a/code/boot.js
+++ b/code/boot.js
@@ -14,7 +14,9 @@ window.setupLargeImagePreview = function () {
     // To support that, we'd need a unique key per portal.  Example, guid.
     // So that would have to be in the html fetched into details.
 
-    var preview = '<div style="text-align: center">' + img.outerHTML + '</div>';
+    var preview = new Image(img.width, img.height);
+    preview.src = img.src;
+    preview.style = 'margin: auto; display: block';
     var title = e.delegateTarget.querySelector('.title').innerText;
     dialog({
       html: preview,

--- a/code/boot.js
+++ b/code/boot.js
@@ -498,14 +498,12 @@ window.setupLayerChooserApi = function() {
   //hook some additional code into the LayerControl so it's easy for the mobile app to interface with it
   //WARNING: does depend on internals of the L.Control.Layers code
   window.layerChooser.getLayers = function() {
-    var baseLayers = new Array();
-    var overlayLayers = new Array();
-    
-    for (i in this._layers) {
-      var obj = this._layers[i];
+    var baseLayers = [];
+    var overlayLayers = [];
+    this._layers.forEach(function (obj,idx) {
       var layerActive = window.map.hasLayer(obj.layer);
       var info = {
-        layerId: i,
+        layerId: idx,
         name: obj.name,
         active: layerActive
       }
@@ -514,7 +512,7 @@ window.setupLayerChooserApi = function() {
       } else {
         baseLayers.push(info);
       }
-    }
+    });
 
     var overlayLayersJSON = JSON.stringify(overlayLayers);
     var baseLayersJSON = JSON.stringify(baseLayers);

--- a/code/smartphone.js
+++ b/code/smartphone.js
@@ -203,18 +203,19 @@ window.useAndroidPanes = function() {
   return (typeof android !== 'undefined' && android && android.addPane && window.isSmartphone());
 }
 
-if(typeof android !== 'undefined' && android && android.getFileRequestUrlPrefix) {
+if (typeof android !== 'undefined' && android.getFileRequestUrlPrefix) {
   window.requestFile = function(callback) {
-    do {
-      var funcName = "onFileSelected" + parseInt(Math.random()*0xFFFF).toString(16);
-    } while(window[funcName] !== undefined)
-
-    window[funcName] = function(filename, content) {
+    var name = 'onFileSelected',
+      funcName = name;
+    for (var c=0; window[funcName]; funcName=name+c++);
+    window[funcName] = function (filename, content) {
       callback(decodeURIComponent(filename), atob(content));
+      delete window[funcName];
     };
     var script = document.createElement('script');
     script.src = android.getFileRequestUrlPrefix() + funcName;
     (document.body || document.head || document.documentElement).appendChild(script);
+    script.remove();
   };
 }
 

--- a/code/utils_misc.js
+++ b/code/utils_misc.js
@@ -302,7 +302,7 @@ window.escapeJavascriptString = function(str) {
 
 //escape special characters, such as tags
 window.escapeHtmlSpecialChars = function(str) {
-  var div = document.createElement(div);
+  var div = document.createElement('div');
   var text = document.createTextNode(str);
   div.appendChild(text);
   return div.innerHTML;

--- a/code/utils_misc.js
+++ b/code/utils_misc.js
@@ -409,13 +409,20 @@ window.addLayerGroup = function(name, layerGroup, defaultDisplay) {
 }
 
 window.removeLayerGroup = function(layerGroup) {
-  if(!layerChooser._layers[layerGroup._leaflet_id]) throw('Layer was not found');
+  function find (arr, callback) { // ES5 doesn't include Array.prototype.find()
+    for (var i=0; i<arr.length; i++) {
+      if (callback(arr[i], i, arr)) { return arr[i]; }
+    }
+  }
+  var element = find(layerChooser._layers, function (el) { return el.layer === layerGroup; });
+  if (!element) {
+    throw new Error('Layer was not found');
+  }
   // removing the layer will set it's default visibility to false (store if layer gets added again)
-  var name = layerChooser._layers[layerGroup._leaflet_id].name;
-  var enabled = isLayerGroupDisplayed(name);
+  var enabled = isLayerGroupDisplayed(element.name);
   map.removeLayer(layerGroup);
   layerChooser.removeLayer(layerGroup);
-  updateDisplayedLayerGroup(name, enabled);
+  updateDisplayedLayerGroup(element.name, enabled);
 };
 
 window.clampLat = function(lat) {

--- a/external/L.Geodesic.js
+++ b/external/L.Geodesic.js
@@ -146,6 +146,8 @@ Modified by qnstie 2013-07-17 to maintain compatibility with Leaflet.draw
     initialize: function (latlng, radius, options) {
       this._latlng = L.latLng(latlng);
       this._mRadius = radius;
+      this._radius = 11; // stub property to workaround https://github.com/IITC-CE/ingress-intel-total-conversion/issues/178
+                         // upstream report: https://github.com/Leaflet/Leaflet/issues/6656
 
       points = this._calcPoints();
 

--- a/external/leaflet.draw-src.js
+++ b/external/leaflet.draw-src.js
@@ -2779,8 +2779,8 @@ L.Edit.Circle = L.Edit.CircleMarker.extend({
 	},
 
 	_getResizeMarkerPoint: function (latlng) {
-		var latRadius = (this._shape.getRadius() / 40075017) * 360;
-		return L.latLng(latlng.lat+latRadius,latlng.lng);
+		var bounds = this._shape.getBounds(); // geodesic circle stores precalculated bounds
+		return L.latLng(bounds.getNorth(), latlng.lng);
 	},
 
 	_resize: function (latlng) {

--- a/external/leaflet.draw-src.js
+++ b/external/leaflet.draw-src.js
@@ -1660,7 +1660,7 @@ L.Draw.Circle = L.Draw.SimpleShape.extend({
 		}
 
 		if (!this._shape) {
-			this._shape = new L.Circle(this._startLatLng, distance, this.options.shapeOptions);
+			this._shape = new L.GeodesicCircle(this._startLatLng, distance, this.options.shapeOptions);
 			this._map.addLayer(this._shape);
 		} else {
 			this._shape.setRadius(distance);
@@ -1668,7 +1668,7 @@ L.Draw.Circle = L.Draw.SimpleShape.extend({
 	},
 
 	_fireCreatedEvent: function () {
-		var circle = new L.Circle(this._startLatLng, this._shape.getRadius(), this.options.shapeOptions);
+		var circle = new L.GeodesicCircle(this._startLatLng, this._shape.getRadius(), this.options.shapeOptions);
 		L.Draw.SimpleShape.prototype._fireCreatedEvent.call(this, circle);
 	},
 
@@ -2767,6 +2767,7 @@ L.Edit = L.Edit || {};
  * @aka Edit.Circle
  * @inherits L.Edit.CircleMarker
  */
+
 L.Edit.Circle = L.Edit.CircleMarker.extend({
 
 	_createResizeMarker: function () {
@@ -2778,10 +2779,8 @@ L.Edit.Circle = L.Edit.CircleMarker.extend({
 	},
 
 	_getResizeMarkerPoint: function (latlng) {
-		// From L.shape.getBounds()
-		var delta = this._shape._radius * Math.cos(Math.PI / 4),
-			point = this._map.project(latlng);
-		return this._map.unproject([point.x + delta, point.y - delta]);
+		var latRadius = (this._shape.getRadius() / 40075017) * 360;
+		return L.latLng(latlng.lat+latRadius,latlng.lng);
 	},
 
 	_resize: function (latlng) {

--- a/plugins/bookmarks.user.js
+++ b/plugins/bookmarks.user.js
@@ -606,7 +606,7 @@
       helper:'clone', // fix accidental click in firefox
       forcePlaceholderSize:true,
       update:function(event, ui) {
-        var typeList = $('#'+ui.item.context.id).parent().parent('.bookmarkList').attr('id');
+        var typeList = ui.item.parent().parent('.bookmarkList').attr('id');
         window.plugin.bookmarks.sortFolder(typeList);
       }
     });
@@ -619,7 +619,7 @@
       helper:'clone', // fix accidental click in firefox
       forcePlaceholderSize:true,
       update:function(event, ui) {
-        var typeList = $('#'+ui.item.context.id).parent().parent().parent().parent('.bookmarkList').attr('id');
+        var typeList = ui.item.parent().parent().parent().parent('.bookmarkList').attr('id');
         window.plugin.bookmarks.sortBookmark(typeList);
       }
     });

--- a/plugins/cache-portals-on-map.user.js
+++ b/plugins/cache-portals-on-map.user.js
@@ -18,7 +18,9 @@ window.plugin.cachePortalDetailsOnMap = function() {};
 window.plugin.cachePortalDetailsOnMap.MAX_AGE = 12*60*60;  //12 hours max age for cached data
 
 window.plugin.cachePortalDetailsOnMap.portalDetailLoaded = function(data) {
-  window.plugin.cachePortalDetailsOnMap.cache[data.guid] = { loadtime: Date.now(), ent: data.ent };
+  if (data.success) {
+    window.plugin.cachePortalDetailsOnMap.cache[data.guid] = { loadtime: Date.now(), ent: data.ent };
+  }
 };
 
 window.plugin.cachePortalDetailsOnMap.entityInject = function(data) {

--- a/plugins/layer-count.user.js
+++ b/plugins/layer-count.user.js
@@ -20,30 +20,9 @@ plugin.layerCount.onBtnClick = function(ev) {
 		layer = plugin.layerCount.layer;
 
 	if(btn.classList.contains("active")) {
-		if(window.plugin.drawTools !== undefined) {
-			window.plugin.drawTools.drawnItems.eachLayer(function(layer) {
-				if (layer instanceof L.GeodesicPolygon) {
-					L.DomUtil.addClass(layer._path, "leaflet-clickable");
-					layer._path.setAttribute("pointer-events", layer.options.pointerEventsBackup);
-					layer.options.pointerEvents = layer.options.pointerEventsBackup;
-					layer.options.interactive = true;
-				}
-			});
-		}
 		map.off("click", plugin.layerCount.calculate);
 		btn.classList.remove("active");
 	} else {
-		if(window.plugin.drawTools !== undefined) {
-			window.plugin.drawTools.drawnItems.eachLayer(function(layer) {
-				if (layer instanceof L.GeodesicPolygon) {
-					layer.options.pointerEventsBackup = layer.options.pointerEvents;
-					layer.options.pointerEvents = null;
-					layer.options.interactive = false;
-					L.DomUtil.removeClass(layer._path, "leaflet-clickable");
-					layer._path.setAttribute("pointer-events", "none");
-				}
-			});
-		}
 		map.on("click", plugin.layerCount.calculate);
 		btn.classList.add("active");
 		setTimeout(function(){

--- a/plugins/missions.user.js
+++ b/plugins/missions.user.js
@@ -1038,29 +1038,13 @@ window.plugin.missions = {
 
 		window.addHook('search', this.onSearch.bind(this));
 
-		/*
-		  I know iitc has portalAdded event but it is missing portalDeleted. So we have to resort to Object.observe
-		*/
 		var me = this;
-		if (Object.observe) { // Chrome
-			Object.observe(window.portals, function(changes) {
-				changes.forEach(function(change) {
-					me.onPortalChanged(change.type, change.name, change.oldValue);
-				});
-			});
-		} else { // Firefox why no Object.observer ? :<
-			window.addHook('portalAdded', function(data) {
-				me.onPortalChanged('add', data.portal.options.guid, data.portal);
-			});
-			// TODO: bug iitc dev for portalRemoved event
-			var oldDeletePortal = window.Render.prototype.deletePortalEntity;
-			window.Render.prototype.deletePortalEntity = function(guid) {
-				if (guid in window.portals) {
-					me.onPortalChanged('delete', guid, window.portals[guid]);
-				}
-				oldDeletePortal.apply(this, arguments);
-			};
-		}
+		window.addHook('portalAdded', function(data) {
+			me.onPortalChanged('add', data.portal.options.guid, data.portal);
+		});
+		window.addHook('portalRemoved', function(data) {
+			me.onPortalChanged('delete', data.portal.options.guid, data.portal);
+		});
 
 		this.missionStartLayer = new L.LayerGroup();
 		this.missionLayer = new L.LayerGroup();

--- a/plugins/missions.user.js
+++ b/plugins/missions.user.js
@@ -600,9 +600,10 @@ window.plugin.missions = {
 	},
 	
 	onWaypointsRefreshed: function() {
+		var checkedWaypoints = this.checkedWaypoints;
 		$('[data-mission_mwpid]').each(function(i, element) {
 			var mwpid = element.dataset['mission_mwpid'];
-			var checked = !!this.checkedWaypoints[mwpid];
+			var checked = !!checkedWaypoints[mwpid];
 			element.checked = checked;
 		});
 	},
@@ -629,9 +630,10 @@ window.plugin.missions = {
 	},
 	
 	onMissionsRefreshed: function() {
+		var checkedMissions = this.checkedMissions;
 		$('[data-mission_mid]').each(function(i, element) {
 			var mid = element.dataset['mission_mid'];
-			var checked = !!this.checkedMissions[mid];
+			var checked = !!checkedMissions[mid];
 			$(element).toggleClass('checked', checked);
 		});
 	},
@@ -973,7 +975,7 @@ window.plugin.missions = {
 			}
 			
 			query.addResult(result);
-		}.bind(this));
+		}, this);
 	},
 
 	onSearchResultSelected: function(result, event) {


### PR DESCRIPTION
- cache-portals-on-map: fix #103: _TypeError_ while running hook `mapDataEntityInject`
- layer-count: fix #149 (error accessing private property)
- bookmarks: fix #166: Bookmarks reorder error
- draw-tools: fix #174: Circle edit is broken (actually `GeodesicCircle` was lost at some point)
- draw-tools: fix #178: Circle is hard to draw
  Notes:
  - it's workaround only, actual bug is somewhere deeper
  - same problem is circumvented also by #175
- utils_misc.js:
  - fix `removeLayerGroup` (#190)
  - fix `escapeHtmlSpecialChars`  (#211)
- missions:
  - fix exception in `onWaypointsRefreshed`/`onMissionsRefreshed`
- boot.js: `setupLargeImagePreview`
  - fix title (#215)
  - fix dialog was not properly centered
- boot.js: fix `layerChooser.getLayers`
  to be again compatible with [existent](https://apps.apple.com/app/iitc-mobile/id1032695947) iOS mobile version