### PR TITLE
IITC-Mobile: 'Support DeX desktop mode' option

### DIFF
--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -247,8 +247,8 @@ public class IITC_Mobile extends AppCompatActivity
 
     @Override
     public void onSharedPreferenceChanged(final SharedPreferences sharedPreferences, final String key) {
-		if (key.equals("pref_force_desktop")) {
-			mDesktopMode = sharedPreferences.getBoolean("pref_force_desktop", false);
+        if (key.equals("pref_force_desktop")) {
+            mDesktopMode = sharedPreferences.getBoolean("pref_force_desktop", false);
             mNavigationHelper.onPrefChanged();
         } else if (key.equals("pref_dex_desktop")) {
             mDexDesktopMode = sharedPreferences.getBoolean( "pref_dex_desktop", true);

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -572,7 +572,7 @@ public class IITC_Mobile extends AppCompatActivity
     }
 
     public void switchToPane(final Pane pane) {
-        if ((mDesktopMode) || (mDexRunning && mDexDesktopMode)) return;
+        if (mNavigationHelper.isDesktopActive()) return;
         mIitcWebView.loadUrl("javascript: window.show('" + pane.name + "');");
     }
 
@@ -749,7 +749,7 @@ public class IITC_Mobile extends AppCompatActivity
 
     // vp=f enables mDesktopMode mode...vp=m is the default mobile view
     private String addUrlParam(final String url) {
-        return url + (url.contains("?") ? '&' : '?') + "vp=" + (((mDesktopMode) || (mDexRunning && mDexDesktopMode)) ? 'f' : 'm');
+        return url + (url.contains("?") ? '&' : '?') + "vp=" + (mNavigationHelper.isDesktopActive() ? 'f' : 'm');
     }
 
     public void reset() {

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -576,6 +576,10 @@ public class IITC_Mobile extends AppCompatActivity
         mIitcWebView.loadUrl("javascript: window.show('" + pane.name + "');");
     }
 
+    public boolean isDexRunning() {
+        return mDexRunning;
+    }
+
     @Override
     public boolean onKeyDown(final int keyCode, final KeyEvent event) {
         if (keyCode == KeyEvent.KEYCODE_SEARCH) {

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_NavigationHelper.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_NavigationHelper.java
@@ -124,7 +124,7 @@ public class IITC_NavigationHelper extends ActionBarDrawerToggle implements OnIt
             }
         }
 
-        final boolean mapVisible = mDesktopMode || mPane == Pane.MAP;
+        final boolean mapVisible = (mDesktopMode || (mDexRunning && mDexDesktopMode)) || mPane == Pane.MAP;
         if ("No Highlights".equals(mHighlighter) || isDrawerOpened() || mIitc.isLoading() || !mapVisible) {
             mActionBar.setSubtitle(null);
         } else {

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_NavigationHelper.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_NavigationHelper.java
@@ -42,6 +42,8 @@ public class IITC_NavigationHelper extends ActionBarDrawerToggle implements OnIt
     private final View mDrawerRight;
     private final IITC_NotificationHelper mNotificationHelper;
 
+    private boolean mDexRunning = false;
+    private boolean mDexDesktopMode = true;
     private boolean mDesktopMode = false;
     private Pane mPane = Pane.MAP;
     private String mHighlighter = null;
@@ -88,7 +90,7 @@ public class IITC_NavigationHelper extends ActionBarDrawerToggle implements OnIt
             mDrawerLeft.setItemChecked(mDrawerLeft.getCheckedItemPosition(), false);
         }
 
-        if (mDesktopMode) {
+        if ((mDesktopMode) || (mDexRunning && mDexDesktopMode)) {
             mActionBar.setDisplayHomeAsUpEnabled(false); // Hide "up" indicator
             mActionBar.setHomeButtonEnabled(false); // Make icon unclickable
             mActionBar.setTitle(mIitc.getString(R.string.app_name));
@@ -221,7 +223,14 @@ public class IITC_NavigationHelper extends ActionBarDrawerToggle implements OnIt
         syncState();
     }
 
+    // Samsung DeX mode has been changed
+    public void onDexModeChanged(boolean activity) {
+        mDexRunning = activity;
+        updateViews();
+    }
+
     public void onPrefChanged() {
+        mDexDesktopMode = mPrefs.getBoolean( "pref_dex_desktop", true);
         mDesktopMode = mPrefs.getBoolean("pref_force_desktop", false);
         updateViews();
     }

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_NavigationHelper.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_NavigationHelper.java
@@ -90,7 +90,7 @@ public class IITC_NavigationHelper extends ActionBarDrawerToggle implements OnIt
             mDrawerLeft.setItemChecked(mDrawerLeft.getCheckedItemPosition(), false);
         }
 
-        if ((mDesktopMode) || (mDexRunning && mDexDesktopMode)) {
+        if (isDesktopActive()) {
             mActionBar.setDisplayHomeAsUpEnabled(false); // Hide "up" indicator
             mActionBar.setHomeButtonEnabled(false); // Make icon unclickable
             mActionBar.setTitle(mIitc.getString(R.string.app_name));
@@ -124,7 +124,7 @@ public class IITC_NavigationHelper extends ActionBarDrawerToggle implements OnIt
             }
         }
 
-        final boolean mapVisible = (mDesktopMode || (mDexRunning && mDexDesktopMode)) || mPane == Pane.MAP;
+        final boolean mapVisible = isDesktopActive() || mPane == Pane.MAP;
         if ("No Highlights".equals(mHighlighter) || isDrawerOpened() || mIitc.isLoading() || !mapVisible) {
             mActionBar.setSubtitle(null);
         } else {
@@ -167,6 +167,10 @@ public class IITC_NavigationHelper extends ActionBarDrawerToggle implements OnIt
 
     public boolean isDrawerOpened() {
         return mDrawerLayout.isDrawerOpen(mDrawerLeft) || mDrawerLayout.isDrawerOpen(mDrawerRight);
+    }
+
+    public boolean isDesktopActive() {
+        return (mDesktopMode || (mDexRunning && mDexDesktopMode));
     }
 
     @Override

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_NavigationHelper.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_NavigationHelper.java
@@ -57,6 +57,7 @@ public class IITC_NavigationHelper extends ActionBarDrawerToggle implements OnIt
         mDrawerLeft = (ListView) iitc.findViewById(R.id.left_drawer);
         mDrawerRight = iitc.findViewById(R.id.right_drawer);
         mDrawerLayout = (DrawerLayout) iitc.findViewById(R.id.drawer_layout);
+        mDexRunning = mIitc.isDexRunning();
 
         mPrefs = PreferenceManager.getDefaultSharedPreferences(iitc);
 

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_NavigationHelper.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_NavigationHelper.java
@@ -57,7 +57,7 @@ public class IITC_NavigationHelper extends ActionBarDrawerToggle implements OnIt
         mDrawerLeft = (ListView) iitc.findViewById(R.id.left_drawer);
         mDrawerRight = iitc.findViewById(R.id.right_drawer);
         mDrawerLayout = (DrawerLayout) iitc.findViewById(R.id.drawer_layout);
-        mDexRunning = mIitc.isDexRunning();
+        mDexRunning = iitc.isDexRunning();
 
         mPrefs = PreferenceManager.getDefaultSharedPreferences(iitc);
 

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -113,6 +113,8 @@
         Note: IITCm can still be controlled via the Navigation Drawers</string>
     <string name="pref_force_desktop">Force desktop mode</string>
     <string name="pref_force_desktop_sum">Nice for tablets, looks awful on smartphones</string>
+    <string name="pref_dex_desktop">Force DeX desktop mode</string>
+    <string name="pref_dex_desktop_sum">Force desktop mode when DeX mode is active</string>
     <string name="pref_external_storage">Move tiles cache to external storage</string>
     <string name="pref_external_storage_sum">Restart required! Write cache to sdCard.
         External storage has to be mounted.</string>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -113,8 +113,8 @@
         Note: IITCm can still be controlled via the Navigation Drawers</string>
     <string name="pref_force_desktop">Force desktop mode</string>
     <string name="pref_force_desktop_sum">Nice for tablets, looks awful on smartphones</string>
-    <string name="pref_dex_desktop">Force DeX desktop mode</string>
-    <string name="pref_dex_desktop_sum">Force desktop mode when DeX mode is active</string>
+    <string name="pref_dex_desktop">Force Samsung DeX desktop mode</string>
+    <string name="pref_dex_desktop_sum">Force desktop mode on systems when Samsung DeX mode is active</string>
     <string name="pref_external_storage">Move tiles cache to external storage</string>
     <string name="pref_external_storage_sum">Restart required! Write cache to sdCard.
         External storage has to be mounted.</string>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
     <string name="pref_force_desktop">Force desktop mode</string>
     <string name="pref_force_desktop_sum">Nice for tablets, looks awful on smartphones</string>
     <string name="pref_dex_desktop">Force Samsung DeX desktop mode</string>
-    <string name="pref_dex_desktop_sum">Force desktop mode on systems where Samsung DeX mode is available and active</string>
+    <string name="pref_dex_desktop_sum">Force desktop mode when DeX mode is active</string>
     <string name="pref_external_storage">Move tiles cache to external storage</string>
     <string name="pref_external_storage_sum">Restart required! Write cache to sdCard.
         External storage has to be mounted.</string>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
     <string name="pref_force_desktop">Force desktop mode</string>
     <string name="pref_force_desktop_sum">Nice for tablets, looks awful on smartphones</string>
     <string name="pref_dex_desktop">Force Samsung DeX desktop mode</string>
-    <string name="pref_dex_desktop_sum">Force desktop mode on systems when Samsung DeX mode is active</string>
+    <string name="pref_dex_desktop_sum">Force desktop mode on systems where Samsung DeX mode is available and active</string>
     <string name="pref_external_storage">Move tiles cache to external storage</string>
     <string name="pref_external_storage_sum">Restart required! Write cache to sdCard.
         External storage has to be mounted.</string>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -113,7 +113,7 @@
         Note: IITCm can still be controlled via the Navigation Drawers</string>
     <string name="pref_force_desktop">Force desktop mode</string>
     <string name="pref_force_desktop_sum">Nice for tablets, looks awful on smartphones</string>
-    <string name="pref_dex_desktop">Force Samsung DeX desktop mode</string>
+    <string name="pref_dex_desktop">Support Samsung DeX Mode</string>
     <string name="pref_dex_desktop_sum">Force desktop mode when DeX mode is active</string>
     <string name="pref_external_storage">Move tiles cache to external storage</string>
     <string name="pref_external_storage_sum">Restart required! Write cache to sdCard.

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -113,8 +113,8 @@
         Note: IITCm can still be controlled via the Navigation Drawers</string>
     <string name="pref_force_desktop">Force desktop mode</string>
     <string name="pref_force_desktop_sum">Nice for tablets, looks awful on smartphones</string>
-    <string name="pref_dex_desktop">Force Samsung DeX desktop mode</string>
-    <string name="pref_dex_desktop_sum">Force desktop mode on systems where Samsung DeX mode is available and active</string>
+    <string name="pref_dex_desktop">Support Samsung DeX Mode</string>
+    <string name="pref_dex_desktop_sum">Force desktop mode when DeX mode is active</string>
     <string name="pref_external_storage">Move tiles cache to external storage</string>
     <string name="pref_external_storage_sum">Restart required! Write cache to sdCard.
         External storage has to be mounted.</string>

--- a/mobile/app/src/main/res/xml/preferences.xml
+++ b/mobile/app/src/main/res/xml/preferences.xml
@@ -31,6 +31,12 @@
             android:key="pref_force_desktop"
             android:summary="@string/pref_force_desktop_sum"
             android:title="@string/pref_force_desktop"/>
+
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="pref_dex_desktop"
+            android:summary="@string/pref_dex_desktop_sum"
+            android:title="@string/pref_dex_desktop"/>
     </PreferenceCategory>
     <PreferenceCategory
         android:key="pref_tweaks_cat"

--- a/mobile/app/src/main/res/xml/preferences.xml
+++ b/mobile/app/src/main/res/xml/preferences.xml
@@ -33,10 +33,10 @@
             android:title="@string/pref_force_desktop"/>
 
         <CheckBoxPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="pref_dex_desktop"
             android:summary="@string/pref_dex_desktop_sum"
-            android:title="@string/pref_dex_desktop"/>
+            android:title="@string/pref_dex_desktop" />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="pref_tweaks_cat"

--- a/mobile/app/src/main/res/xml/preferences.xml
+++ b/mobile/app/src/main/res/xml/preferences.xml
@@ -33,7 +33,7 @@
             android:title="@string/pref_force_desktop"/>
 
         <CheckBoxPreference
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:key="pref_dex_desktop"
             android:summary="@string/pref_dex_desktop_sum"
             android:title="@string/pref_dex_desktop" />

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/mobile/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Mon Apr 08 00:01:42 CDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
-
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
Useful for automatically making the display to be desktop when running on the Samsung DeX desktop system while allowing for showing in regular mode on a smartphone without having the switch back and forth between Desktop and regular when moving between the two environments.