### PR TITLE
IITC-Mobile: fix 'Send screenshot' function

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -155,6 +155,16 @@
             android:noHistory="false"
             android:theme="@android:style/Theme.Holo.Dialog"/>
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths"/>
+        </provider>
+
         <!-- START Used for Samsung Multi-Window support -->
         <uses-library
             android:name="com.sec.android.app.multiwindow"

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -15,6 +15,7 @@ import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
+import android.graphics.Canvas;
 import android.net.Uri;
 import android.nfc.NdefMessage;
 import android.nfc.NdefRecord;
@@ -956,20 +957,13 @@ public class IITC_Mobile extends AppCompatActivity
     }
 
     private void sendScreenshot() {
-        Bitmap bitmap = mIitcWebView.getDrawingCache();
-        if (bitmap == null) {
-            mIitcWebView.buildDrawingCache();
-            bitmap = mIitcWebView.getDrawingCache();
-            if (bitmap == null) {
-                Log.e("could not get bitmap!");
-                return;
-            }
-            bitmap = Bitmap.createBitmap(bitmap);
-            if (!mIitcWebView.isDrawingCacheEnabled()) mIitcWebView.destroyDrawingCache();
-        }
-        else {
-            bitmap = Bitmap.createBitmap(bitmap);
-        }
+        Bitmap bitmap = Bitmap.createBitmap(mIitcWebView.getMeasuredWidth(),
+                mIitcWebView.getMeasuredHeight(), Bitmap.Config.ARGB_8888);
+
+        Canvas bigcanvas = new Canvas(bitmap);
+        int iHeight = bitmap.getHeight();
+        bigcanvas.drawBitmap(bitmap, 0, iHeight, null);
+        mIitcWebView.draw(bigcanvas);
 
         try {
             final File cache = getExternalCacheDir();

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -28,6 +28,7 @@ import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.Window;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
@@ -37,6 +38,7 @@ import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemLongClickListener;
 import android.widget.EditText;
 import android.widget.ImageButton;
+import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.PopupMenu;
 import android.widget.TextView;
@@ -957,30 +959,39 @@ public class IITC_Mobile extends AppCompatActivity
     }
 
     private void sendScreenshot() {
-        Bitmap bitmap = Bitmap.createBitmap(mIitcWebView.getMeasuredWidth(),
-                mIitcWebView.getMeasuredHeight(), Bitmap.Config.ARGB_8888);
+        Toast.makeText(this, R.string.msg_prepare_screenshot, Toast.LENGTH_SHORT).show();
 
-        Canvas bigcanvas = new Canvas(bitmap);
-        int iHeight = bitmap.getHeight();
-        bigcanvas.drawBitmap(bitmap, 0, iHeight, null);
-        mIitcWebView.draw(bigcanvas);
+        // Hack for Android >= 5.0 Lollipop
+        // When hardware acceleration is enabled, it is not possible to create a screenshot.
+        mIitcWebView.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+        // After switch to software render, we need to redraw the webview, but of all the ways I have worked only resizing.
+        final ViewGroup.LayoutParams savedLayoutParams = mIitcWebView.getLayoutParams();
+        mIitcWebView.setLayoutParams(new LinearLayout.LayoutParams(mIitcWebView.getWidth()+10, LinearLayout.LayoutParams.FILL_PARENT));
+        // This takes some time, so a timer is set.
+        // After the screenshot is taken, the webview size and render type are returned to their original state.
 
-        try {
-            final File cache = getExternalCacheDir();
-            final File file = File.createTempFile("IITC screenshot", ".png", cache);
-            if (!bitmap.compress(CompressFormat.PNG, 100, new FileOutputStream(file))) {
-                // quality is ignored by PNG
-                throw new IOException("Could not compress bitmap!");
-            }
-            startActivityForResult(ShareActivity.forFile(this, file, "image/png"), new ResponseHandler() {
-                @Override
-                public void onActivityResult(final int resultCode, final Intent data) {
-                    file.delete();
+        new Handler().postDelayed(() -> {
+            final Bitmap bitmap = Bitmap.createBitmap(mIitcWebView.getWidth(),mIitcWebView.getHeight(), Bitmap.Config.ARGB_8888);
+            mIitcWebView.draw(new Canvas(bitmap));
+
+            try {
+                mIitcWebView.setLayoutParams(savedLayoutParams);
+                mIitcWebView.setLayerType(View.LAYER_TYPE_HARDWARE, null);
+                Toast.makeText(this, R.string.msg_take_screenshot, Toast.LENGTH_SHORT).show();
+                final File file = File.createTempFile("IITC screenshot", ".png", getExternalCacheDir());
+                if (!bitmap.compress(CompressFormat.PNG, 100, new FileOutputStream(file))) {
+                    // quality is ignored by PNG
+                    throw new IOException("Failed to compress bitmap");
                 }
-            });
-        } catch (final IOException e) {
-            Log.e("Could not generate screenshot", e);
-        }
+                startActivityForResult(ShareActivity.forFile(this, file, "image/png"), (resultCode, data) -> {
+                    file.delete();
+                });
+            } catch (final IOException e) {
+                Log.e("Failed to generate screenshot", e);
+            }
+
+        }, 2000);
+
     }
 
     @Override

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/share/ShareActivity.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/share/ShareActivity.java
@@ -6,14 +6,17 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.view.MenuItem;
 
 import androidx.core.app.NavUtils;
+import androidx.core.content.FileProvider;
 import androidx.fragment.app.FragmentActivity;
 import androidx.viewpager.widget.ViewPager;
 
+import org.exarhteam.iitc_mobile.BuildConfig;
 import org.exarhteam.iitc_mobile.Log;
 import org.exarhteam.iitc_mobile.R;
 
@@ -29,10 +32,14 @@ public class ShareActivity extends FragmentActivity implements ActionBar.TabList
     private static final String TYPE_STRING = "string";
 
     public static Intent forFile(final Context context, final File file, final String type) {
+        final Uri uri = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+                ? FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".provider", file)
+                : Uri.fromFile(file);
         return new Intent(context, ShareActivity.class)
                 .putExtra(EXTRA_TYPE, TYPE_FILE)
-                .putExtra("uri", Uri.fromFile(file))
-                .putExtra("type", type);
+                .putExtra("uri", uri)
+                .putExtra("type", type)
+                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
     }
 
     public static Intent forPosition(final Context context, final double lat, final double lng, final int zoom,

--- a/mobile/app/src/main/res/layout/activity_main.xml
+++ b/mobile/app/src/main/res/layout/activity_main.xml
@@ -37,13 +37,14 @@
             android:id="@+id/viewDebug"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
+            android:background="@color/iitc_blue_dark"
             android:orientation="horizontal">
 
             <ImageButton
                 android:id="@+id/btnToggleMapVisibility"
                 android:layout_width="@dimen/button_size"
                 android:layout_height="@dimen/button_size"
-                android:layout_gravity="bottom"
+                android:layout_gravity="center_vertical"
                 android:background="@android:color/transparent"
                 android:contentDescription="@string/toggle_map"
                 android:onClick="onToggleMapVisibility"
@@ -53,7 +54,7 @@
                 android:id="@+id/btnClearLog"
                 android:layout_width="@dimen/button_size"
                 android:layout_height="@dimen/button_size"
-                android:layout_gravity="bottom"
+                android:layout_gravity="center_vertical"
                 android:background="@android:color/transparent"
                 android:contentDescription="@string/clear_log"
                 android:onClick="onClearLog"
@@ -72,7 +73,7 @@
             <ImageButton
                 android:layout_width="@dimen/button_size"
                 android:layout_height="@dimen/button_size"
-                android:layout_gravity="bottom"
+                android:layout_gravity="center_vertical"
                 android:background="@android:color/transparent"
                 android:contentDescription="@string/debug_run"
                 android:onClick="onBtnRunCodeClick"

--- a/mobile/app/src/main/res/values/arrays.xml
+++ b/mobile/app/src/main/res/values/arrays.xml
@@ -33,7 +33,6 @@
         <item>@string/menu_layer_chooser</item>
         <item>@string/menu_toggle_fullscreen</item>
         <item>@string/menu_reload</item>
-        <item>@string/menu_send_screenshot</item>
     </string-array>
 
     <string-array name="pref_user_location_titles">

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -153,6 +153,8 @@
     <string name="search_hint">Search locations</string>
     <string name="intent_error">Address could not be opened</string>
     <string name="msg_copied">Copied to clipboard…</string>
+    <string name="msg_prepare_screenshot">Preparing…</string>
+    <string name="msg_take_screenshot">Taking screenshot…</string>
     <string name="notice_do_not_show_again">Do not show again</string>
 
     <string name="sign_in_to">Sign in to %1$s %2$s"</string>

--- a/mobile/app/src/main/res/xml/provider_paths.xml
+++ b/mobile/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+</paths>


### PR DESCRIPTION
Canvas mode is default in IITC-CE, and due to hardware acceleration, portals and links were not displayed when using build-in screenshot function.
Fix #140.

Also:
- fix file sharing on Android >6
- (unrelated) fix #31: background color of debug command line

Note: current implementation is not reliable enough, so 'Send screenshot' menu item is not shown by default.

