### PR TITLE
draw-tools: fix mobile-related bugs; add Circle again

### DIFF
--- a/external/leaflet.draw-src.js
+++ b/external/leaflet.draw-src.js
@@ -1258,7 +1258,7 @@ L.Draw.SimpleShape = L.Draw.Feature.extend({
 			// (update): we have to send passive now to prevent scroll, because by default it is {passive: true} now, which means,
 			// handler can't event.preventDefault
 			// check the news https://developers.google.com/web/updates/2016/06/passive-event-listeners
-			document.addEventListener('touchstart', L.DomEvent.preventDefault, {passive: false});
+			this._map.getPanes().mapPane.addEventListener('touchstart', L.DomEvent.preventDefault, {passive: false});
 		}
 	},
 
@@ -1283,7 +1283,7 @@ L.Draw.SimpleShape = L.Draw.Feature.extend({
 			L.DomEvent.off(document, 'mouseup', this._onMouseUp, this);
 			L.DomEvent.off(document, 'touchend', this._onMouseUp, this);
 
-			document.removeEventListener('touchstart', L.DomEvent.preventDefault);
+			this._map.getPanes().mapPane.removeEventListener('touchstart', L.DomEvent.preventDefault);
 
 			// If the box element doesn't exist they must not have moved the mouse, so don't need to destroy/return
 			if (this._shape) {

--- a/external/leaflet.draw-src.js
+++ b/external/leaflet.draw-src.js
@@ -855,7 +855,7 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 		var markerCount = this._markers.length;
 		// The last marker should have a click handler to close the polyline
 		if (markerCount > 1) {
-			this._markers[markerCount - 1].on('click', this._finishShape, this);
+			//this._markers[markerCount - 1].on('click', this._finishShape, this); // workaround for https://github.com/Leaflet/Leaflet.draw/issues/789
 		}
 
 		// Remove the old marker click handler (as only the last point should close the polyline)
@@ -1128,7 +1128,7 @@ L.Draw.Polygon = L.Draw.Polyline.extend({
 
 		// The first marker should have a click handler to close the polygon
 		if (markerCount === 1) {
-			this._markers[0].on('click', this._finishShape, this);
+			//this._markers[0].on('click', this._finishShape, this); // workaround for https://github.com/Leaflet/Leaflet.draw/issues/789
 		}
 
 		// Add and update the double click handler

--- a/external/leaflet.draw-src.js
+++ b/external/leaflet.draw-src.js
@@ -855,7 +855,7 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 		var markerCount = this._markers.length;
 		// The last marker should have a click handler to close the polyline
 		if (markerCount > 1) {
-			//this._markers[markerCount - 1].on('click', this._finishShape, this); // workaround for https://github.com/Leaflet/Leaflet.draw/issues/789
+			this._markers[markerCount - 1].on('click', this._finishShape, this);
 		}
 
 		// Remove the old marker click handler (as only the last point should close the polyline)
@@ -1128,7 +1128,7 @@ L.Draw.Polygon = L.Draw.Polyline.extend({
 
 		// The first marker should have a click handler to close the polygon
 		if (markerCount === 1) {
-			//this._markers[0].on('click', this._finishShape, this); // workaround for https://github.com/Leaflet/Leaflet.draw/issues/789
+			this._markers[0].on('click', this._finishShape, this);
 		}
 
 		// Add and update the double click handler

--- a/mobile/smartphone.css
+++ b/mobile/smartphone.css
@@ -225,8 +225,3 @@ body {
   border: 1px outset #20A8B1;
   margin-top: 2px;
 }
-
-/* Hide drawtools circle on mobile */
-.leaflet-draw-draw-circle {
-  display: none !important;
-}

--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -100,7 +100,6 @@ window.plugin.drawTools.addDrawControl = function() {
       },
 
       circle: {
-        circlemarker: false,
         shapeOptions: window.plugin.drawTools.polygonOptions,
         snapPoint: window.plugin.drawTools.getSnapLatLng,
       },
@@ -583,7 +582,22 @@ window.plugin.drawTools.snapToPortals = function() {
   window.plugin.drawTools.save();
 }
 
+window.plugin.drawTools.drawstart = function (e) {
+  var mouseActive = L.Browser.touch && matchMedia('(hover:hover)').matches; // workaround for https://github.com/IITC-CE/ingress-intel-total-conversion/issues/162
+  if (mouseActive || e.layerType === 'circle' || e.layerType === 'rectangle') {
+    e.target.touchExtend.enable()
+  } else {
+    e.target.touchExtend.disable()
+  };
+}
+
 window.plugin.drawTools.boot = function() {
+  // workaround for https://github.com/Leaflet/Leaflet.draw/issues/923
+  map.addHandler('touchExtend', L.Map.TouchExtend);
+
+  // trying to circumvent touch bugs: https://github.com/Leaflet/Leaflet.draw/issues/789
+  map.on('draw:drawstart', plugin.drawTools.drawstart);
+
   // add a custom hook for draw tools to share it's activity with other plugins
   pluginCreateHook('pluginDrawTools');
 

--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -582,21 +582,9 @@ window.plugin.drawTools.snapToPortals = function() {
   window.plugin.drawTools.save();
 }
 
-window.plugin.drawTools.drawstart = function (e) {
-  var mouseActive = L.Browser.touch && matchMedia('(hover:hover)').matches; // workaround for https://github.com/IITC-CE/ingress-intel-total-conversion/issues/162
-  if (mouseActive || e.layerType === 'circle' || e.layerType === 'rectangle') {
-    e.target.touchExtend.enable()
-  } else {
-    e.target.touchExtend.disable()
-  };
-}
-
 window.plugin.drawTools.boot = function() {
   // workaround for https://github.com/Leaflet/Leaflet.draw/issues/923
   map.addHandler('touchExtend', L.Map.TouchExtend);
-
-  // trying to circumvent touch bugs: https://github.com/Leaflet/Leaflet.draw/issues/789
-  map.on('draw:drawstart', plugin.drawTools.drawstart);
 
   // add a custom hook for draw tools to share it's activity with other plugins
   pluginCreateHook('pluginDrawTools');

--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -582,9 +582,21 @@ window.plugin.drawTools.snapToPortals = function() {
   window.plugin.drawTools.save();
 }
 
+window.plugin.drawTools.drawstart = function (e) {
+  var mouseActive = L.Browser.touch && matchMedia('(hover:hover)').matches; // workaround for https://github.com/IITC-CE/ingress-intel-total-conversion/issues/162
+  if (mouseActive || e.layerType === 'circle' || e.layerType === 'rectangle') {
+    e.target.touchExtend.enable()
+  } else {
+    e.target.touchExtend.disable()
+  };
+}
+
 window.plugin.drawTools.boot = function() {
   // workaround for https://github.com/Leaflet/Leaflet.draw/issues/923
   map.addHandler('touchExtend', L.Map.TouchExtend);
+
+  // trying to circumvent touch bugs: https://github.com/Leaflet/Leaflet.draw/issues/789
+  map.on('draw:drawstart', plugin.drawTools.drawstart);
 
   // add a custom hook for draw tools to share it's activity with other plugins
   pluginCreateHook('pluginDrawTools');


### PR DESCRIPTION
### Summary:
* Fix Circle drawing on touch devices, so it's returned to toolbar.
* Fix drawing with mouse on touch device.
* Fix: it wasn't possible to cancel Circle drawing.

### Details:

1. To work on touch Leaflet.draw (for some internal purposes) uses `touchExtend` handler.
   Previously it was not initialized as map was created before Leaflet.draw loading
   (https://github.com/Leaflet/Leaflet.draw/issues/923)
   So we enable it:
   - It's now possible to draw Circle/Rectangle on touchscreens
      (fix https://github.com/iitc-project/ingress-intel-total-conversion/issues/1294)
   - It's now possible to use mouse on touchscreen devices
      (fix https://github.com/IITC-CE/ingress-intel-total-conversion/issues/162)

2. Unfortunately `touchExtend` handler is broken (seems in many ways), that leads to misc. issues,
    the most serious is https://github.com/Leaflet/Leaflet.draw/issues/789 (unable to draw polylines/polygons).
    Some workaround proposed in discussion of that issue, but none is perfect.
    Here in draw-tools we use another workaround: enable `touchExtend` handler only when it is needed (see 1)

3. And last fix required patching of a upstream sources 
   https://github.com/Leaflet/Leaflet.draw/issues/922
   - It's now possible to cancel Circle/Rectangle drawing.
     This fix works fine in IITC, but is not perfect (see discussion)

P.S.
Some more draw-related fixes here: #157 