### PR TITLE
Leaflet controls: prevent mobile style on desktop

### DIFF
--- a/code/boot.js
+++ b/code/boot.js
@@ -784,6 +784,7 @@ function boot() {
 @@INCLUDERAW:external/load.js@@
 
 try { console.log('Loading included JS now'); } catch(e) {}
+window.L_NO_TOUCH = navigator.maxTouchPoints===0; // prevent mobile style on desktop https://github.com/IITC-CE/ingress-intel-total-conversion/pull/189
 @@INCLUDERAW:external/leaflet-src.js@@
 @@INCLUDERAW:external/L.Geodesic.js@@
 @@INCLUDERAW:external/Leaflet.GoogleMutant.js@@

--- a/external/leaflet.draw-src.css
+++ b/external/leaflet.draw-src.css
@@ -150,53 +150,52 @@
 /* ================================================================== */
 
 .leaflet-draw-toolbar .leaflet-draw-draw-polyline {
-    background-position: 0 0;
+    background-position: -2px -2px;
 }
 
 .leaflet-touch .leaflet-draw-toolbar .leaflet-draw-draw-polyline {
-    background-position: 0 -1px;
+    background-position: 0 0;
 }
 
 .leaflet-draw-toolbar .leaflet-draw-draw-polygon {
-    background-position: -30px 0;
+    background-position: -31px -2px;
 }
 
 .leaflet-touch .leaflet-draw-toolbar .leaflet-draw-draw-polygon {
-    background-position: -29px -1px;
+    background-position: -30px 0;
 }
 
 .leaflet-draw-toolbar .leaflet-draw-draw-rectangle {
-    background-position: -60px 0;
+    background-position: -62px -2px;
 }
 
 .leaflet-touch .leaflet-draw-toolbar .leaflet-draw-draw-rectangle {
-    background-position: -60px -1px;
+    background-position: -60px 0;
 }
 
 .leaflet-draw-toolbar .leaflet-draw-draw-circle {
-    background-position: -90px 0;
+    background-position: -92px -2px;
 }
 
 .leaflet-touch .leaflet-draw-toolbar .leaflet-draw-draw-circle {
-    background-position: -90px -1px;
+    background-position: -90px 0;
 }
 
 .leaflet-draw-toolbar .leaflet-draw-draw-marker {
-    background-position: -120px 0;
+    background-position: -122px -2px;
 }
 
 .leaflet-touch .leaflet-draw-toolbar .leaflet-draw-draw-marker {
-    background-position: -120px -1px;
+    background-position: -120px 0;
 }
 
 .leaflet-draw-toolbar .leaflet-draw-draw-circlemarker {
-    background-position: -270px 0;
+    background-position: -272px -2px;
 }
 
 .leaflet-touch .leaflet-draw-toolbar .leaflet-draw-draw-circlemarker {
-    background-position: -271px -1px;
+    background-position: -270px 0;
 }
-
 
 /* ================================================================== */
 /* Edit toolbar

--- a/external/leaflet.draw-src.js
+++ b/external/leaflet.draw-src.js
@@ -532,7 +532,7 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 	// @method initialize(): void
 	initialize: function (map, options) {
 		// if touch, switch to touch icon
-		if (window.isSmartphone()) {
+		if (L.Browser.touch) {
 			this.options.icon = this.options.touchIcon;
 		}
 
@@ -786,12 +786,12 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 			if (this.options.maxPoints > 1 && this.options.maxPoints == this._markers.length + 1) {
 				this.addVertex(e.latlng);
 				this._finishShape();
-			} else if (lastPtDistance < 10 && window.isSmartphone()) {
+			} else if (lastPtDistance < 10 && L.Browser.touch) {
 				this._finishShape();
 			} else if (Math.abs(dragCheckDistance) < 9 * (window.devicePixelRatio || 1)) {
 				if (this.options.snapPoint) {
 					e.latlng = this.options.snapPoint(e.latlng);
-				}
+				}	
 				this.addVertex(e.latlng);
 			}
 			this._enableNewMarkers(); // after a short pause, enable new markers
@@ -1889,7 +1889,7 @@ L.Edit.PolyVerticesEdit = L.Handler.extend({
 	// @method intialize(): void
 	initialize: function (poly, latlngs, options) {
 		// if touch, switch to touch icon
-		if (window.isSmartphone()) {
+		if (L.Browser.touch) {
 			this.options.icon = this.options.touchIcon;
 		}
 		this._poly = poly;
@@ -2373,7 +2373,7 @@ L.Edit.SimpleShape = L.Handler.extend({
 	// @method intialize(): void
 	initialize: function (shape, options) {
 		// if touch, switch to touch icon
-		if (window.isSmartphone()) {
+		if (L.Browser.touch) {
 			this.options.moveIcon = this.options.touchMoveIcon;
 			this.options.resizeIcon = this.options.touchResizeIcon;
 		}


### PR DESCRIPTION
1. Modify `L.Browser.touch` in order to prevent mobile-styled controls in desktop (Leaflet v1 issue)

2. Fix leaflet.draw toolbar icons alignment in desktop mode