### PR TITLE
Refactor to use common function window.makePermalink (utils_misc.js)

### DIFF
--- a/code/chat.js
+++ b/code/chat.js
@@ -346,9 +346,9 @@ window.chat.writeDataToHash = function(newData, storageHash, isPublicChannel, is
         break;
 
       case 'PORTAL':
-        var latlng = [markup[1].latE6/1E6, markup[1].lngE6/1E6];
-        var perma = '/intel?ll='+latlng[0]+','+latlng[1]+'&z=17&pll='+latlng[0]+','+latlng[1];
-        var js = 'window.selectPortalByLatLng('+latlng[0]+', '+latlng[1]+');return false';
+        var lat = markup[1].latE6/1E6, lng = markup[1].lngE6/1E6;
+        var perma = window.makePermalink([lat,lng]);
+        var js = 'window.selectPortalByLatLng('+lat+', '+lng+');return false';
 
         msg += '<a onclick="'+js+'"'
           + ' title="'+markup[1].address+'"'

--- a/code/portal_detail_display.js
+++ b/code/portal_detail_display.js
@@ -81,7 +81,7 @@ window.renderPortalDetails = function(guid) {
   var linkDetails = [];
 
   var posOnClick = 'window.showPortalPosLinks('+lat+','+lng+',\''+escapeJavascriptString(title)+'\')';
-  var permalinkUrl = '/intel?ll='+lat+','+lng+'&z=17&pll='+lat+','+lng;
+  var permalinkUrl = window.makePermalink([lat,lng]);
 
   if (typeof android !== 'undefined' && android && android.intentPosLink) {
     // android devices. one share link option - and the android app provides an interface to share the URL,

--- a/code/smartphone.js
+++ b/code/smartphone.js
@@ -178,23 +178,11 @@ window.runOnSmartphonesAfterBoot = function() {
 
 }
 
-
-
 window.setAndroidPermalink = function() {
-  var c = window.map.getCenter();
-  var lat = Math.round(c.lat*1E6)/1E6;
-  var lng = Math.round(c.lng*1E6)/1E6;
-
-  var href = '/intel?ll='+lat+','+lng+'&z=' + map.getZoom();
-
-  if(window.selectedPortal && window.portals[window.selectedPortal]) {
-    var p = window.portals[window.selectedPortal].getLatLng();
-    lat = Math.round(p.lat*1E6)/1E6;
-    lng = Math.round(p.lng*1E6)/1E6;
-    href += '&pll='+lat+','+lng;
-  }
-
-  href = $('<a>').prop('href',  href).prop('href'); // to get absolute URI
+  var p = window.selectedPortal && window.portals[window.selectedPortal];
+  var href = $('<a>')
+    .prop('href',  window.makePermalink(p && p.getLatLng(), true))
+    .prop('href'); // to get absolute URI
   android.setPermalink(href);
 }
 

--- a/code/utils_misc.js
+++ b/code/utils_misc.js
@@ -230,15 +230,6 @@ window.androidCopy = function(text) {
   return false;
 }
 
-window.androidPermalink = function() {
-  if(typeof android === 'undefined' || !android || !android.intentPosLink)
-    return true; // i.e. execute other actions
-
-  var center = map.getCenter();
-  android.intentPosLink(center.lat, center.lng, map.getZoom(), "Selected map view", false);
-  return false;
-}
-
 window.getCurrentZoomTileParameters = function() {
   var zoom = getDataZoomForMapZoom( map.getZoom() );
   var tileParams = getMapZoomTileParameters(zoom);
@@ -310,10 +301,6 @@ window.escapeHtmlSpecialChars = function(str) {
 
 window.prettyEnergy = function(nrg) {
   return nrg> 1000 ? Math.round(nrg/1000) + ' k': nrg;
-}
-
-window.setPermaLink = function(elm) {
-  $(elm).attr('href', window.makePermalink(null,true));
 }
 
 window.uniqueArray = function(arr) {
@@ -458,3 +445,18 @@ window.makePermalink = function(latlng, mapView) {
   }
   return '/intel?' + args.join('&');
 };
+
+window.setPermaLink = function(elm) { // deprecated
+  $(elm).attr('href', window.makePermalink(null,true));
+}
+
+window.androidPermalink = function() { // deprecated
+  if(typeof android === 'undefined' || !android || !android.intentPosLink)
+    return true; // i.e. execute other actions
+
+  var center = map.getCenter();
+  android.intentPosLink(center.lat, center.lng, map.getZoom(), "Selected map view", false);
+  return false;
+}
+
+// todo refactor main.js to get rid of setPermaLink and androidPermalink

--- a/code/utils_misc.js
+++ b/code/utils_misc.js
@@ -313,11 +313,7 @@ window.prettyEnergy = function(nrg) {
 }
 
 window.setPermaLink = function(elm) {
-  var c = map.getCenter();
-  var lat = Math.round(c.lat*1E6)/1E6;
-  var lng = Math.round(c.lng*1E6)/1E6;
-  var qry = 'll='+lat+','+lng+'&z=' + map.getZoom();
-  $(elm).attr('href',  '/intel?' + qry);
+  $(elm).attr('href', window.makePermalink(null,true));
 }
 
 window.uniqueArray = function(arr) {
@@ -442,3 +438,23 @@ window.clampLatLng = function(latlng) {
 window.clampLatLngBounds = function(bounds) {
   return new L.LatLngBounds ( clampLatLng(bounds.getSouthWest()), clampLatLng(bounds.getNorthEast()) );
 }
+
+// @function makePermalink(latlng?: LatLng, mapView?: Boolean): String
+// Makes the permalink for the portal with specified latlng, incluging current map view.
+// At least one of the parameters have to be present.
+window.makePermalink = function(latlng, mapView) {
+  function ll2str (ll) { return ll[0] + ',' + ll[1]; }
+  function round (ll) { // ensures that lat,lng are with same precision as in stock intel permalinks
+    return ll.map(function (n) { return Math.trunc(n*1e6)/1e6; });
+  }
+  var args = [];
+  if (mapView) {
+    var c = window.map.getCenter();
+    args.push('ll='+ll2str(round([c.lat,c.lng])), 'z='+window.map.getZoom())
+  }
+  if (latlng) {
+    if ('lat' in latlng) { latlng = [latlng.lat, latlng.lng]; }
+    args.push('pll='+ll2str(latlng));
+  }
+  return '/intel?' + args.join('&');
+};

--- a/plugins/missions.user.js
+++ b/plugins/missions.user.js
@@ -506,7 +506,7 @@ window.plugin.missions = {
 			
 			var lat = waypoint.portal.latE6/1E6;
 			var lng = waypoint.portal.lngE6/1E6;
-			var perma = '/intel?ll='+lat+','+lng+'&z=17&pll='+lat+','+lng;
+			var perma = window.makePermalink([lat,lng]);
 			
 			title.href = perma;
 			title.addEventListener('click', function(ev) {

--- a/plugins/portals-list.user.js
+++ b/plugins/portals-list.user.js
@@ -356,7 +356,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 // code from getPortalLink function by xelio from iitc: AP List - https://raw.github.com/breunigs/ingress-intel-total-conversion/gh-pages/plugins/ap-list.user.js
 window.plugin.portalslist.getPortalLink = function(portal) {
   var coord = portal.getLatLng();
-  var perma = '/intel?ll='+coord.lat+','+coord.lng+'&z=17&pll='+coord.lat+','+coord.lng;
+  var perma = window.makePermalink(coord);
 
   // jQuery's event handlers seem to be removed when the nodes are remove from the DOM
   var link = document.createElement("a");


### PR DESCRIPTION
Portal permalink is now shorter as it contain only `pll=` part.