### PR TITLE
Increase map renderer padding (and make value customizable)

### DIFF
--- a/code/boot.js
+++ b/code/boot.js
@@ -175,7 +175,9 @@ window.setupMap = function() {
 //    zoomAnimation: false,
     markerZoomAnimation: false,
     bounceAtZoomLimits: false,
-    preferCanvas: true // Set to true if Leaflet should draw things using Canvas instead of SVG
+    preferCanvas: 'PREFER_CANVAS' in window
+      ? window.PREFER_CANVAS
+      : true // default
   });
   if (L.CRS.S2) { map.options.crs = L.CRS.S2; }
 

--- a/code/boot.js
+++ b/code/boot.js
@@ -179,18 +179,10 @@ window.setupMap = function() {
   });
   if (L.CRS.S2) { map.options.crs = L.CRS.S2; }
 
-  if (L.Path.CANVAS) {
-    // for canvas, 2% overdraw only - to help performance
-    L.Path.CLIP_PADDING = 0.02;
-  } else if (L.Path.SVG) {
-    if (L.Browser.mobile) {
-      // mobile SVG - 10% ovredraw. might help performance?
-      L.Path.CLIP_PADDING = 0.1;
-    } else {
-      // for svg, 100% overdraw - so we have a full screen worth in all directions
-      L.Path.CLIP_PADDING = 1.0;
-    }
-  }
+  L.Renderer.mergeOptions({
+    padding: window.RENDERER_PADDING ||
+             L.Browser.mobile ? 0.5 : 1
+  });
 
   // add empty div to leaflet control areas - to force other leaflet controls to move around IITC UI elements
   // TODO? move the actual IITC DOM into the leaflet control areas, so dummy <div>s aren't needed

--- a/code/map_data_debug.js
+++ b/code/map_data_debug.js
@@ -3,7 +3,7 @@
 
 
 window.RenderDebugTiles = function() {
-  this.CLEAR_CHECK_TIME = L.Path.CANVAS ? 2.0 : 0.5;
+  this.CLEAR_CHECK_TIME = window.map.options.preferCanvas ? 2.0 : 0.5;
   this.FADE_TIME = 2.0;
 
   this.debugTileLayer = L.layerGroup();

--- a/code/map_data_debug.js
+++ b/code/map_data_debug.js
@@ -3,8 +3,8 @@
 
 
 window.RenderDebugTiles = function() {
-  this.CLEAR_CHECK_TIME = window.map.options.preferCanvas ? 2.0 : 0.5;
-  this.FADE_TIME = 2.0;
+  this.CLEAR_CHECK_TIME = 0.1;
+  this.FADE_TIME = 1.0;
 
   this.debugTileLayer = L.layerGroup();
   window.addLayerGroup("DEBUG Data Tiles", this.debugTileLayer, false);
@@ -21,7 +21,7 @@ window.RenderDebugTiles.prototype.reset = function() {
 }
 
 window.RenderDebugTiles.prototype.create = function(id,bounds) {
-  var s = {color: '#666', weight: 2, opacity: 0.4, fillColor: '#666', fillOpacity: 0.1, interactive: false};
+  var s = {color: '#666', weight: 1, opacity: 0.4, fillColor: '#666', fillOpacity: 0.1, interactive: false};
 
   var bounds = new L.LatLngBounds(bounds);
   bounds = bounds.pad(-0.02);

--- a/code/map_data_request.js
+++ b/code/map_data_request.js
@@ -57,7 +57,7 @@ window.MapDataRequest = function() {
   // render queue
   // number of items to process in each render pass. there are pros and cons to smaller and larger values
   // (however, if using leaflet canvas rendering, it makes sense to push as much as possible through every time)
-  this.RENDER_BATCH_SIZE = L.Path.CANVAS ? 1E9 : 1500;
+  this.RENDER_BATCH_SIZE = window.map.options.preferCanvas ? 1E9 : 1500;
 
   // delay before repeating the render loop. this gives a better chance for user interaction
   this.RENDER_PAUSE = (typeof android === 'undefined') ? 0.1 : 0.2; //100ms desktop, 200ms mobile


### PR DESCRIPTION
- use renderer option instead of `L.Path.CLIP_PADDING` (which is not used in Leaflet 1.x)
- remove value customization code, as currently it doesn't make much sense
- experimental: set padding to `0.5`, both for Canvas and SVG
  This value can be overridden by option `window.PADDING`
  (need to be set in some plugin, before `setup`)

Fix https://github.com/IITC-CE/ingress-intel-total-conversion/issues/184

Other changes:
- possibility to not prefer canvas
- fix some code where canvas-related options need to be adapted lo leaflet 1.x
- change some values in `RenderDebugTiles`