### PR TITLE
sync: fix and update

### DIFF
--- a/plugins/sync.user.js
+++ b/plugins/sync.user.js
@@ -203,21 +203,22 @@ window.plugin.sync.RegisteredMap.prototype.loadDocument = function(callback) {
     _this.initialized = true;
     _this.initializing = false;
     plugin.sync.logger.log('Data loaded: ' + _this.pluginName + '[' + _this.fieldName + ']');
-    if(callback) callback();
+    if(_this.callback) _this.callback();
     if(_this.initializedCallback) _this.initializedCallback(_this.pluginName, _this.fieldName);
   };
 
   // Stop the sync if any error occur and try to re-authorize
   handleError = function(e) {
-    var error_type = e.type;
+    var isNetworkError = e.type;
+    var errorMessage = (e.error !== undefined) ? e.error.message : e.result.error.message;
     
-    if(e.error.message === "A network error occurred, and the request could not be completed.") {
-      error_type = "network error";
+    if(errorMessage === "A network error occurred, and the request could not be completed.") {
+      isNetworkError = true;
     }
     
-    plugin.sync.logger.log('Drive API Error: ' + error_type);
+    plugin.sync.logger.log('Drive API Error: ' + errorMessage);
     _this.stopSync();
-    if(error_type === "network error") {
+    if(isNetworkError === true) {
       setTimeout(function() {_this.authorizer.authorize();}, 50*1000);
     } else if(e.status === 401) { // Unauthorized
       _this.authorizer.authorize();
@@ -225,7 +226,7 @@ window.plugin.sync.RegisteredMap.prototype.loadDocument = function(callback) {
       _this.forceFileSearch = true;
       _this.initFile()
     } else {
-      alert('Plugin Sync error: ' + error_type + ', ' + e.message);
+      alert('Plugin Sync error: ' + errorMessage + ', ' + e.message);
     }
   };
 

--- a/plugins/sync.user.js
+++ b/plugins/sync.user.js
@@ -217,7 +217,6 @@ window.plugin.sync.RegisteredMap.prototype.loadDocument = function(callback) {
     }
     
     plugin.sync.logger.log('Drive API Error: ' + errorMessage);
-    _this.stopSync();
     if(isNetworkError === true) {
       setTimeout(function() {_this.authorizer.authorize();}, 50*1000);
     } else if(e.status === 401) { // Unauthorized
@@ -231,16 +230,6 @@ window.plugin.sync.RegisteredMap.prototype.loadDocument = function(callback) {
   };
 
   this.dataStorage.readFile(initializeFile, onFileLoaded, handleError);
-};
-
-window.plugin.sync.RegisteredMap.prototype.stopSync = function() {
-  clearInterval(this.intervalID);
-  this.intervalID = null;
-  this.map = null;
-  this.lastUpdateUUID = null;
-  this.initializing = false;
-  this.initialized = false;
-  plugin.sync.registeredPluginsFields.addToWaitingInitialize(this.pluginName, this.fieldName);
 };
 //// end RegisteredMap
 
@@ -275,19 +264,6 @@ window.plugin.sync.RegisteredPluginsFields.prototype.add = function(registeredMa
   this.waitingInitialize[registeredMap.getFileName()] = registeredMap;
 
   this.initializeWorker();
-};
-
-window.plugin.sync.RegisteredPluginsFields.prototype.addToWaitingInitialize = function(pluginName, fieldName) {
-  var registeredMap, _this;
-  _this = this;
-
-  registeredMap = this.get(pluginName, fieldName);
-  if(!registeredMap) return;
-  this.waitingInitialize[registeredMap.getFileName()] = registeredMap;
-
-  clearTimeout(this.timer);
-  this.timer = setTimeout(function() {_this.initializeWorker()}, 10000);
-  plugin.sync.logger.log('Retry in 10 sec.: ' +  pluginName + '[' + fieldName + ']');
 };
 
 window.plugin.sync.RegisteredPluginsFields.prototype.get = function(pluginName, fieldName) {

--- a/plugins/sync.user.js
+++ b/plugins/sync.user.js
@@ -41,6 +41,8 @@ window.plugin.sync.authorizer = null;
 window.plugin.sync.registeredPluginsFields = null;
 window.plugin.sync.logger = null;
 
+window.plugin.sync.checkInterval = 3 * 60 * 1000; // update data every 3 minutes
+
 // Other plugin call this function to push update to Google Drive API
 // example:
 // plugin.sync.updateMap('keys', 'keysdata', ['guid1', 'guid2', 'guid3'])
@@ -175,6 +177,7 @@ window.plugin.sync.RegisteredMap.prototype.loadDocument = function(callback) {
 
     _this.dataStorage.saveFile(_this.prepareFileData());
     plugin.sync.logger.log(_this.getFileName(), 'Model initialized');
+    setTimeout(function() {_this.loadDocument();}, window.plugin.sync.checkInterval);
   };
 
   // this function called when the document is loaded
@@ -187,7 +190,7 @@ window.plugin.sync.RegisteredMap.prototype.loadDocument = function(callback) {
     if (!_this.intervalID) {
       _this.intervalID = setInterval(function() {
         _this.loadDocument();
-      }, 3 * 60 * 1000); // update data every 3 minutes
+      }, window.plugin.sync.checkInterval);
     }
     
     // Replace local value if data is changed by others
@@ -223,7 +226,8 @@ window.plugin.sync.RegisteredMap.prototype.loadDocument = function(callback) {
       _this.authorizer.authorize();
     } else if(e.status === 404) { // Not found
       _this.forceFileSearch = true;
-      _this.initFile()
+      _this.initFile();
+      setTimeout(function() {_this.loadDocument();}, window.plugin.sync.checkInterval);
     } else {
       alert('Plugin Sync error: ' + errorMessage + ', ' + e.message);
     }

--- a/plugins/sync.user.js
+++ b/plugins/sync.user.js
@@ -228,8 +228,6 @@ window.plugin.sync.RegisteredMap.prototype.loadDocument = function(callback) {
       _this.forceFileSearch = true;
       _this.initFile();
       setTimeout(function() {_this.loadDocument();}, window.plugin.sync.checkInterval);
-    } else {
-      alert('Plugin Sync error: ' + errorMessage + ', ' + e.message);
     }
   };
 

--- a/plugins/sync.user.js
+++ b/plugins/sync.user.js
@@ -3,7 +3,7 @@
 // @name           IITC plugin: Sync
 // @category       Misc
 // @version        0.4.0.@@DATETIMEVERSION@@
-// @description    [@@BUILDNAME@@-@@BUILDDATE@@] Sync data between clients via Google Drive API. Only syncs data from specific plugins (currently: Keys, Bookmarks). Sign in via the 'Sync' link. Data is synchronized every 3 minutes.
+// @description    [@@BUILDNAME@@-@@BUILDDATE@@] Sync data between clients via Google Drive API. Only syncs data from specific plugins (currently: Keys, Bookmarks, Uniques). Sign in via the 'Sync' link. Data is synchronized every 3 minutes.
 @@METAINFO@@
 // ==/UserScript==
 


### PR DESCRIPTION
Fixed synchronization errors. Updated log view. 

* Fix of the first synchronization

* Removed an unnecessary timer that duplicates a repeated connection attempt in case of a network error

* Change the display of the change log. Only the last message is shown or each synchronized file.

* Disable error output with alert()

![изображение](https://user-images.githubusercontent.com/1785196/60247139-bd667380-98c8-11e9-9a9b-01741c46ec93.png)
