### PR TITLE
Experimental: use the Android Sharelist instead of IITC custom chooser

### DIFF
--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/share/ShareActivity.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/share/ShareActivity.java
@@ -35,10 +35,12 @@ public class ShareActivity extends FragmentActivity implements ActionBar.TabList
         final Uri uri = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
                 ? FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".provider", file)
                 : Uri.fromFile(file);
-        return new Intent().setAction(Intent.ACTION_SEND)
+        Intent shareIntent = new Intent().setAction(Intent.ACTION_SEND)
                 .putExtra(Intent.EXTRA_STREAM, uri)
                 .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 .setType(type);
+        String title = context.getString(R.string.send_to);
+        return Intent.createChooser(shareIntent, title);
     }
 
     public static Intent forPosition(final Context context, final double lat, final double lng, final int zoom,

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/share/ShareActivity.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/share/ShareActivity.java
@@ -35,11 +35,10 @@ public class ShareActivity extends FragmentActivity implements ActionBar.TabList
         final Uri uri = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
                 ? FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".provider", file)
                 : Uri.fromFile(file);
-        return new Intent(context, ShareActivity.class)
-                .putExtra(EXTRA_TYPE, TYPE_FILE)
-                .putExtra("uri", uri)
-                .putExtra("type", type)
-                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        return new Intent().setAction(Intent.ACTION_SEND)
+                .putExtra(Intent.EXTRA_STREAM, uri)
+                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                .setType(type);
     }
 
     public static Intent forPosition(final Context context, final double lat, final double lng, final int zoom,

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -174,5 +174,6 @@
         <b>Be careful:</b> Javascript from external sources may contain harmful code (spyware etc.)!<br><br>
         Are you sure you want to proceed?]]>
     </string>
+    <string name="send_to">Send to...</string>
 
 </resources>


### PR DESCRIPTION
For screenshot sharing only.
Full implementation should include also text sharing ang geo sharing.

Currently IITC custom chooser seems more convenient due to tabs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iitc-ce/ingress-intel-total-conversion/261)
<!-- Reviewable:end -->
