### PR TITLE
portals-list: filter out portal without real data (bug in intel)

### DIFF
--- a/plugins/portals-list.user.js
+++ b/plugins/portals-list.user.js
@@ -154,6 +154,14 @@ window.plugin.portalslist.getPortals = function() {
     // eliminate offscreen portals (selected, and in padding)
     if(!displayBounds.contains(portal.getLatLng())) return true;
 
+    if (!portal.options.data.title) { // no data about portal
+      // bug in intel, observed with ghost fields
+      // todo: check if such portal is really duplicate
+      // otherwise better keep it (with data filled by some defaults)
+      console.warn('filtering out "ghost" portal:', portal.options.data);
+      return true;
+    }
+
     retval=true;
 
     switch (portal.options.team) {


### PR DESCRIPTION
Portals with empty title causes exception when sorting
Anyway, table rows filled with `<undefined>` are not useful

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iitc-ce/ingress-intel-total-conversion/265)
<!-- Reviewable:end -->
