### PR TITLE
IITC-Mobile: add 'Plugins' shortcut to main menu

### DIFF
--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -49,6 +49,7 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.core.view.MenuItemCompat;
 
 import org.exarhteam.iitc_mobile.IITC_NavigationHelper.Pane;
+import org.exarhteam.iitc_mobile.prefs.PluginPreferenceActivity;
 import org.exarhteam.iitc_mobile.prefs.PreferenceActivity;
 import org.exarhteam.iitc_mobile.share.ShareActivity;
 
@@ -598,6 +599,10 @@ public class IITC_Mobile extends AppCompatActivity
                     item.setVisible(true);
                     break;
 
+                case R.id.menu_open_plugins:
+                    item.setVisible(enabled);
+                    break;
+
                 case R.id.toggle_fullscreen:
                     item.setChecked(mIitcWebView.isInFullscreen());
                     item.setIcon(mIitcWebView.isInFullscreen()
@@ -674,6 +679,10 @@ public class IITC_Mobile extends AppCompatActivity
                 return true;
             case R.id.menu_send_screenshot:
                 sendScreenshot();
+                return true;
+            case R.id.menu_open_plugins:
+                final Intent intent_plugins = new Intent(this, PluginPreferenceActivity.class);
+                startActivity(intent_plugins);
                 return true;
             case R.id.menu_debug:
                 mDebugging = !mDebugging;

--- a/mobile/app/src/main/res/menu/main.xml
+++ b/mobile/app/src/main/res/menu/main.xml
@@ -45,6 +45,11 @@
         app:showAsAction="never"
         android:title="@string/menu_send_screenshot"/>
     <item
+        android:id="@+id/menu_open_plugins"
+        android:orderInCategory="150"
+        app:showAsAction="never"
+        android:title="@string/menu_open_plugins"/>
+    <item
         android:id="@+id/action_settings"
         android:orderInCategory="200"
         app:showAsAction="never"

--- a/mobile/app/src/main/res/values/arrays.xml
+++ b/mobile/app/src/main/res/values/arrays.xml
@@ -25,6 +25,7 @@
         <item>@string/menu_reload</item>
         <item>@string/menu_send_screenshot</item>
         <item>@string/menu_clear_cookies</item>
+        <item>@string/menu_open_plugins</item>
         <item>@string/menu_debug</item>
     </string-array>
     <string-array name="pref_android_menu_default">
@@ -34,6 +35,7 @@
         <item>@string/menu_toggle_fullscreen</item>
         <item>@string/menu_reload</item>
         <item>@string/menu_send_screenshot</item>
+        <item>@string/menu_open_plugins</item>
     </string-array>
 
     <string-array name="pref_user_location_titles">

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -143,6 +143,7 @@
     <string name="menu_locate">Get Location</string>
     <string name="menu_clear_cookies">Clear cookies</string>
     <string name="menu_search">Search</string>
+    <string name="menu_open_plugins">Plugins</string>
     <string name="menu_debug">Debug</string>
     <string name="menu_send_screenshot">Send screenshot</string>
     <string name="menu_plugins_add">Add external plugins</string>


### PR DESCRIPTION
Direct menu link to quickly open Plugins settings (it is also available in Setting dialog).

Close #18

![изображение](https://user-images.githubusercontent.com/1785196/67244756-1bfcc200-f463-11e9-918b-2150ec3223b5.png)
