### PR TITLE
Change default intel url (to match stock)

### DIFF
--- a/code/boot.js
+++ b/code/boot.js
@@ -422,7 +422,7 @@ window.setupPlayerStat = function() {
     + '<h2 title="'+t+'">'+level+'&nbsp;'
     + '<div id="name">'
     + '<span class="'+cls+'">'+PLAYER.nickname+'</span>'
-    + '<a href="/_ah/logout?continue=https://www.google.com/accounts/Logout%3Fcontinue%3Dhttps://appengine.google.com/_ah/logout%253Fcontinue%253Dhttps://intel.ingress.com/intel%26service%3Dah" id="signout">sign out</a>'
+    + '<a href="https://intel.ingress.com/logout" id="signout">sign out</a>'
     + '</div>'
     + '<div id="stats">'
     + '<sup>XM: '+xmRatio+'%</sup>'

--- a/code/smartphone.js
+++ b/code/smartphone.js
@@ -181,7 +181,7 @@ window.runOnSmartphonesAfterBoot = function() {
 window.setAndroidPermalink = function() {
   var p = window.selectedPortal && window.portals[window.selectedPortal];
   var href = $('<a>')
-    .prop('href',  window.makePermalink(p && p.getLatLng(), true))
+    .prop('href',  window.makePermalink(p && p.getLatLng(), {includeMapView: true}))
     .prop('href'); // to get absolute URI
   android.setPermalink(href);
 }

--- a/code/utils_misc.js
+++ b/code/utils_misc.js
@@ -477,10 +477,11 @@ window.clampLatLngBounds = function(bounds) {
   return new L.LatLngBounds ( clampLatLng(bounds.getSouthWest()), clampLatLng(bounds.getNorthEast()) );
 }
 
-// @function makePermalink(latlng?: LatLng, mapView?: Boolean): String
-// Makes the permalink for the portal with specified latlng, incluging current map view.
-// At least one of the parameters have to be present.
-window.makePermalink = function(latlng, mapView) {
+// @function makePermalink(latlng?: LatLng, mapView?: Boolean, absolute?: Boolean): String
+// Makes the permalink for the portal with specified latlng, possibly incluging current map view
+// (at least one of two parameters have to be present).
+// By default generate relative link, but absolute (full) also can be requested.
+window.makePermalink = function(latlng, mapView, absolute) {
   function ll2str (ll) { return ll[0] + ',' + ll[1]; }
   function round (ll) { // ensures that lat,lng are with same precision as in stock intel permalinks
     return ll.map(function (n) { return Math.trunc(n*1e6)/1e6; });
@@ -494,7 +495,8 @@ window.makePermalink = function(latlng, mapView) {
     if ('lat' in latlng) { latlng = [latlng.lat, latlng.lng]; }
     args.push('pll='+ll2str(latlng));
   }
-  return '/intel?' + args.join('&');
+  var url = absolute ? 'https://intel.ingress.com/' : '/';
+  return url + '/?' + args.join('&');
 };
 
 window.setPermaLink = function(elm) { // deprecated

--- a/code/utils_misc.js
+++ b/code/utils_misc.js
@@ -477,17 +477,22 @@ window.clampLatLngBounds = function(bounds) {
   return new L.LatLngBounds ( clampLatLng(bounds.getSouthWest()), clampLatLng(bounds.getNorthEast()) );
 }
 
-// @function makePermalink(latlng?: LatLng, mapView?: Boolean, absolute?: Boolean): String
-// Makes the permalink for the portal with specified latlng, possibly incluging current map view
-// (at least one of two parameters have to be present).
-// By default generate relative link, but absolute (full) also can be requested.
-window.makePermalink = function(latlng, mapView, absolute) {
+// @function makePermalink(latlng?: LatLng, options?: Object): String
+// Makes the permalink for the portal with specified latlng, possibly including current map view.
+// Portal latlng can be omitted to create mapview-only permalink.
+// @option: includeMapView: Boolean = null
+// Use to add zoom level and latlng of current map center.
+// @option: fullURL: Boolean = null
+// Use to make absolute fully qualified URL (default: relative link).
+window.makePermalink = function(latlng, options) {
+  options = options || {}
+
   function ll2str (ll) { return ll[0] + ',' + ll[1]; }
   function round (ll) { // ensures that lat,lng are with same precision as in stock intel permalinks
     return ll.map(function (n) { return Math.trunc(n*1e6)/1e6; });
   }
   var args = [];
-  if (mapView) {
+  if (!latlng || options.includeMapView) {
     var c = window.map.getCenter();
     args.push('ll='+ll2str(round([c.lat,c.lng])), 'z='+window.map.getZoom())
   }
@@ -495,7 +500,7 @@ window.makePermalink = function(latlng, mapView, absolute) {
     if ('lat' in latlng) { latlng = [latlng.lat, latlng.lng]; }
     args.push('pll='+ll2str(latlng));
   }
-  var url = absolute ? 'https://intel.ingress.com/' : '/';
+  var url = options.fullURL ? 'https://intel.ingress.com/' : '/';
   return url + '/?' + args.join('&');
 };
 

--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
                 <!-- No category needed, because the Intent will specify this class component -->
             </intent-filter>
 
-            <!-- Handles the implicit intent to VIEW the www.ingress.com/intel URI -->
+            <!-- Handles the implicit intent to VIEW the intel.ingress.com/ URI -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
                 <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
@@ -43,21 +43,8 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
 
                 <data
-                    android:host="*.ingress.com"
-                    android:pathPrefix="/intel"
+                    android:host="intel.ingress.com"
                     android:scheme="https"/>
-                <data
-                    android:host="*.ingress.com"
-                    android:pathPrefix="/intel"
-                    android:scheme="http"/>
-                <data
-                    android:host="*.ingress.com"
-                    android:pathPrefix="/mission/"
-                    android:scheme="https"/>
-                <data
-                    android:host="*.ingress.com"
-                    android:pathPrefix="/mission/"
-                    android:scheme="http"/>
             </intent-filter>
 
             <!-- Handles geo: URIs -->

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -73,7 +73,7 @@ import java.util.regex.Pattern;
 
 public class IITC_Mobile extends AppCompatActivity
         implements OnSharedPreferenceChangeListener, NfcAdapter.CreateNdefMessageCallback, OnItemLongClickListener {
-    private static final String mIntelUrl = "https://intel.ingress.com/intel";
+    private static final String mIntelUrl = "https://intel.ingress.com/";
 
     private SharedPreferences mSharedPrefs;
     private IITC_FileManager mFileManager;

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_WebViewClient.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_WebViewClient.java
@@ -285,7 +285,8 @@ public class IITC_WebViewClient extends WebViewClient {
             Log.d("Facebook login");
             return false;
         }
-        else if (uri.getHost().contains(".google.") && "/url".equals(uri.getPath()) && uri.getQueryParameter("q") != null) {
+        else if ((uri.getHost().startsWith("google.") || uri.getHost().contains(".google."))
+                && "/url".equals(uri.getPath()) && uri.getQueryParameter("q") != null) {
             Log.d("redirect to: " + uri.getQueryParameter("q"));
             return shouldOverrideUrlLoading(view, uri.getQueryParameter("q"));
         }

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/share/ShareActivity.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/share/ShareActivity.java
@@ -76,7 +76,7 @@ public class ShareActivity extends FragmentActivity implements ActionBar.TabList
     }
 
     private String getIntelUrl(final String ll, final int zoom, final boolean isPortal) {
-        String url = "https://intel.ingress.com/intel?ll=" + ll + "&z=" + zoom;
+        String url = "https://intel.ingress.com/?ll=" + ll + "&z=" + zoom;
         if (isPortal) {
             url += "&pll=" + ll;
         }

--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -342,7 +342,10 @@ window.plugin.drawTools.optCopy = function() {
           stockLinks.push([latLngs[latLngs.length-1].lat,latLngs[latLngs.length-1].lng,latLngs[0].lat,latLngs[0].lng]);
         }
       });
-      var stockUrl = window.makePermalink(false,true,true)+'&pls='+stockLinks.map(function(link){return link.join(',');}).join('_');
+      var stockUrl = window.makePermalink(null, {
+        includeMapView: true,
+        fullURL: true
+      }) + '&pls='+stockLinks.map(function(link){return link.join(',');}).join('_');
       var stockWarnTexts = [];
       if (stockWarnings.polyAsLine) stockWarnTexts.push('Note: polygons are exported as lines');
       if (stockLinks.length>40) stockWarnTexts.push('Warning: Stock intel may not work with more than 40 line segments - there are '+stockLinks.length);

--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -342,7 +342,7 @@ window.plugin.drawTools.optCopy = function() {
           stockLinks.push([latLngs[latLngs.length-1].lat,latLngs[latLngs.length-1].lng,latLngs[0].lat,latLngs[0].lng]);
         }
       });
-      var stockUrl = 'https://intel.ingress.com/intel?ll='+map.getCenter().lat+','+map.getCenter().lng+'&z='+map.getZoom()+'&pls='+stockLinks.map(function(link){return link.join(',');}).join('_');
+      var stockUrl = window.makePermalink(false,true,true)+'&pls='+stockLinks.map(function(link){return link.join(',');}).join('_');
       var stockWarnTexts = [];
       if (stockWarnings.polyAsLine) stockWarnTexts.push('Note: polygons are exported as lines');
       if (stockLinks.length>40) stockWarnTexts.push('Warning: Stock intel may not work with more than 40 line segments - there are '+stockLinks.length);
@@ -375,11 +375,15 @@ window.plugin.drawTools.optExport = function() {
 
 window.plugin.drawTools.optPaste = function() {
   var promptAction = prompt('Press CTRL+V to paste (draw-tools data or stock intel URL).', '');
-  if(promptAction !== null && promptAction !== '') {
+  promptAction = promptAction && promptAction.trim();
+  if (promptAction) {
     try {
       // first see if it looks like a URL-format stock intel link, and if so, try and parse out any stock drawn items
       // from the pls parameter
-      if (promptAction.match(new RegExp("^(https?://)?(www\.)|(intel\.)?ingress\\.com/intel.*[?&]pls="))) {
+
+      // var intel = new RegExp('(https?://)?(www\\.)?ingress\\.com/intel.*[?&]pls=').exec(promptAction); // old url
+      var matchIntel = new RegExp('(https://)?intel\\.ingress\\.com/.*[?&]pls=').exec(promptAction);
+      if (matchIntel && matchIntel.index === 0) {
         //looks like a ingress URL that has drawn items...
         var items = promptAction.split(/[?&]/);
         var foundAt = -1;

--- a/plugins/sync.user.js
+++ b/plugins/sync.user.js
@@ -593,7 +593,7 @@ window.plugin.sync.Authorizer.prototype.authorize = function(redirect) {
     'client_id': this.CLIENT_ID,
     'scope': this.SCOPES,
     ux_mode: 'redirect',
-    redirect_uri: 'https://intel.ingress.com/intel'
+    redirect_uri: 'https://intel.ingress.com/'
   }).then(function() {
     
     GoogleAuth = gapi.auth2.getAuthInstance();


### PR DESCRIPTION
Before this PR: our entry point was `intel.ingress.com/intel`.
Reason: that where stock intel redirects to when we try to use old deprecated link (www.ingress.com/intel).

But stock intel has bug there: 'sign out' link leads to https://intel.ingress.com/intel/logout, which seems broken (redirect back to logout even after re-login, over and over again).

As appeared, currently `intel.ingress.com/` is proper intel url (as linked from ingress.com).
It does not have sign-out issues.

So now we change base url in iitc and plugins.
