### PR TITLE
bump version to 0.30

### DIFF
--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -1,6 +1,6 @@
 // @author         jonatkins
 // @name           IITC: Ingress intel map total conversion
-// @version        0.29.1
+// @version        0.30
 // @description    Total conversion for the ingress intel map.
 // @run-at         document-end
 

--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 
-final BUILD_DATE = new Date().format('yyyy-MM-dd_HH:mm:ss')
+final BUILD_DATE = new Date().format('yyyy.MM.dd-HH:mm')
 
 def getVersionCode = { ->
     def git = 'git rev-list HEAD --count'
@@ -53,7 +53,7 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix ".debug"
-            versionNameSuffix "-test$BUILD_DATE"
+            versionNameSuffix "-test-$BUILD_DATE"
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
             signingConfig signingConfigs.debug

--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -25,7 +25,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 28
         versionCode = getVersionCode()
-        versionName "0.29.1"
+        versionName "0.30"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     signingConfigs {

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -21,33 +21,41 @@
     <string name="pref_about_text">
         <![CDATA[
         <h1>Ingress Intel Total Conversion Mobile</h1>
-        <b>Build Version: %1$s</b><br>
-        <b>IITC Version: %2$s</b><br>
-        <br>
-        <b>by <a href="https://github.com/leCradle">cradle</a>, <a href="https://github.com/fkloft">fkloft</a> and
-        contributors</b><br><br>
-        <b>Icon by <a href="http://be.net/giuseppelucido">Giuseppe Lucido</a></b><br><br>
-        IITC Mobile is an optimized mobile browser for the
-        Ingress Intel Total Conversion (IITC) userscript by <a href="https://github.com/breunigs"><b>breunigs</b></a>.
-        After Niantic asked the main developer to shut down his github project, development
-        is continued on a fork of <a href="https://github.com/jonatkins"><b>jonatkins</b></a>.
-        <h3>Community:</h3>
-        • Visit the <a href="https://iitc.modos189.ru/">IITC website</a> for new releases and the desktop version.<br>
-        • Follow the <a href="https://plus.google.com/105383756361375410867">IITC Google+ page</a>
-        for release announcements.<br>
-        • Join the <a href="https://plus.google.com/communities/105647403088015055797">IITC Google+ community</a>
-        - a place to ask for help and discuss with other users.
-        <h3>Developers:</h3>
-        <a href="https://github.com/iitc-project/ingress-intel-total-conversion">IITC on Github</a>
-        <h3>IITC Licence:</h3>
-        Copyright © 2013 Stefan Breunig, Jon Atkins, Philipp Schäfer and others<br><br>
 
-        Permission to use, copy, modify, and/or distribute this software for
+        <p><b>Build version: %1$s</b>
+        <br><b>IITC version: %2$s</b>
+
+        <p><b>by <a href="https://github.com/leCradle">cradle</a>,
+        <a href="https://github.com/fkloft">fkloft</a> and contributors</b>
+
+        <p><b>Icon by <a href="http://be.net/giuseppelucido">Giuseppe Lucido</a></b>
+
+        <p><b>IITC Mobile</b> is an optimized mobile browser for the
+        <i>Ingress Intel Total Conversion (IITC)</i> userscript.
+
+        <h3>Community:</h3>
+
+        • Visit the <a href="https://iitc.modos189.ru/">IITC website</a> for new releases
+          and the desktop version.<br>
+        • Follow the <a href="https://t.me/iitc_news">IITC News</a> Telegram channel
+          for announcements and join <a href="https://t.me/iitc_group">IITC Group</a> chat.<br>
+        • Join the <a href="https://www.reddit.com/r/IITC/">r/IITC/</a> Reddit community
+          - a place to ask for help and discuss with other users.<br>
+        • Report issues and propose enhancements at <a href="https://github.com/IITC-CE/ingress-intel-total-conversion/issues/new">bugtracker</a>.<br>
+
+        <h3>Developers:</h3>
+        <a href="https://github.com/IITC-CE/ingress-intel-total-conversion">IITC <i>"Community Edition"</i></a> on Github.
+
+        <h3>IITC Licence:</h3>
+        <tt>
+        <p>Copyright © 2013 Stefan Breunig, Jon Atkins, Philipp Schäfer and others
+
+        <p>Permission to use, copy, modify, and/or distribute this software for
         any purpose with or without fee is hereby granted, provided that the
         above copyright notice and this permission notice appear in all
-        copies.<br><br>
+        copies.
 
-        THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL
+        <p>THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL
         WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
         WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
         AUTHORS BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
@@ -55,46 +63,64 @@
         OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
         TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
         PERFORMANCE OF THIS SOFTWARE.
+        </tt>
         ]]>
     </string>
     <string name="notice_how_to">
-        <![CDATA[<b>How to use IITCm:</b><br><br>
-        • Navigation: swipe from the left edge of your screen (or click the app icon) to evoke the Navigation Drawer.
-        Click the app icon again to return to the map.<br><br>
-        • Layers/Highlights: swipe from the right edge of your screen (or click the layer-chooser icon in the ActionBar)
-        to evoke the Layer Drawer.<br><br>
-        • You can quickly send the current portal link/permalink to another device if both devices support NFC (hold
-        both devices back-to-back and tap the screen to beam the map to the other device).<br><br>
-        • You can add official plugins in the settings.<br><br>
-        • For external plugins please have a look at the <a href="https://iitc.modos189.ru/faq.html">FAQ.]]>
+        <![CDATA[
+        <h3>How to use IITCm:</h3>
+
+        • Navigation: swipe from the left edge of your screen (or click the app icon)
+          to evoke the <em>Navigation Drawer</em>.<br>
+          Click the app icon again to return to the map.<br>
+        • Layers/Highlights: swipe from the right edge of your screen 
+          (or click the layer-chooser icon in the ActionBar)
+          to evoke the <em>Layer Drawer</em>.<br>
+        • You can quickly send the current portal link/permalink to another device
+          if both devices support NFC (hold both devices back-to-back and
+          tap the screen to beam the map to the other device).<br>
+        • You can add official plugins in the settings.<br>
+        • For external plugins please have a look at the
+          <a href="https://iitc.modos189.ru/faq.html">FAQ.<br>
+        ]]>
     </string>
     <string name="notice_info">
-        <![CDATA[Hint: Alternative ways to open the info screen:<br><br>
+        <![CDATA[
+        <p>Hint: Alternative ways to open the info screen:
+        <p>
         • tap and hold a portal for a second<br>
-        • tap on the left half of the status bar]]>
+        • tap on the left half of the status bar<br>
+        ]]>
     </string>
     <string name="notice_panes">
-        <![CDATA[Hint:<br><br>
-        Some plugins (e.g. portals list and bookmarks) now appear in the navigation drawer for quick access.<br>
-        They won\'t appear in the info pane any more.<br><br>
-        Swipe from the left edge of your screen (or click the app icon) to seem them.]]>
+        <![CDATA[
+        <p>Hint:
+        <p>Some plugins (e.g. <em>portals list</em> and <em>bookmarks</em>) now appear
+        in the <em>Navigation Drawer</em> for quick access.
+        <p>They won\'t appear in the info pane any more.
+        <p>Swipe from the left edge of your screen (or click the app icon) to seem them.
+        ]]>
     </string>
     <string name="notice_extplugins">
-        <![CDATA[Hint:<br><br>
-        IITC Mobile is able to load external plugins too!<br><br>
-        Add them by clicking the (+) icon at the top right.
-        The plugin files have to end with \'.user.js\' and are copied to <b>%1$s</b><br>]]>
+        <![CDATA[
+        <p>Hint:
+        <p>IITC Mobile is able to load external plugins too!
+        <p>Add them by clicking the (+) icon at the top right.
+        The plugin files have to end with \'.user.js\' and are copied to <b>%1$s</b>
+        ]]>
     </string>
     <string name="notice_sharing">
-        <![CDATA[With <em>Share portal</em> you can:<br>
+        <![CDATA[
+        <p>With <em>Share portal</em> you can:
+        <p>
         • send the portal link to other people<br>
         • view the selected portal\'s position in another app<br>
         • open the portal link in a webbrowser<br>
-        <br>
-        Hint: By selecting Google Maps (or any other installed navigation software), you can quickly navigate to the
-        selected portal.<br>
-        <br>
-        These hints also apply for the <em>permalink</em>.]]>
+
+        <p>Hint: By selecting Google Maps (or any other installed navigation software), 
+        you can quickly navigate to the selected portal.
+        <p>These hints also apply for the <em>permalink</em>.
+        ]]>
     </string>
 
     <string name="pref_ui_cat">UI</string>
@@ -175,9 +201,11 @@
 
     <string name="install_dialog_top">Install external plugin?</string>
     <string name="install_dialog_msg">
-        <![CDATA[IITCm was requested to install the following javascript file:<br><br>%1$s<br><br>
-        <b>Be careful:</b> Javascript from external sources may contain harmful code (spyware etc.)!<br><br>
-        Are you sure you want to proceed?]]>
+        <![CDATA[
+        <p>IITCm was requested to install the following javascript file:
+        <p>%1$s
+        <p><b>Be careful:</b> Javascript from external sources may contain harmful code (spyware etc.)!
+        <p>Are you sure you want to proceed?]]>
     </string>
 
 </resources>


### PR DESCRIPTION
# Release notes

## IITC main script

### enhancements
- Update most upstream sources, and significantly enhance several plugins #134 (a lot of changes, follow the link to see)
- Fix performance drop when displaying a large number of ornaments #181
- Improve RegionScoreboard #179 © McBen + some fixes
- Remove confusing message from artifacts dialog #216
- Portal info: display coordinates without angled brackets #233
- Leaflet controls: prevent mobile style on desktop #189
- Increase map renderer padding (and make value customizable) #201
- Portal info: `shielding` tooltip: round mitigation `excess` to cope with lack of js float precision #279

### bugfixes
- Fix miscellaneous bugs in core and plugins #157
- Change default intel url (to match stock) #267

### development
- Implement plugins priority control #205
- Stop console 'spam' using customizable logger #235
- Consistent errors throwing #248
- API for local files (up|down)loading #243
- Remove some unused stuff from window object #101
- Refactor to use common function `window.makePermalink` (utils_misc.js) #198
- Isolate every core module in separate IIFE #234
- Move wrapper template to separate file #238
- DEFAULT_ZOOM = 15 (to match stock intel) #281
- #229:
  - Refactor build system into several modules (can be used as cli utilities).
    Implement `watch` mode to auto-rebuild on source changes.
  - Escape macros in code in order to keep js-validity, fix #50.
    Use template from settings instead of url harcoding (closes #150).
  - Simplify userscripts source template, rename plugin sources:  `*.user.js` -> `*.js`, rearrange source directories.
  - Remove timestamp component from `version` of Release scripts (closes #99).
  - Additional dev tools: `web_meta_gen.py`, `web_server_local.py`, `tampermonkey_stubs_gen.py`.
- Other
  - see #134 (solve #70: Manage upstream externals)
  - Update docs #264, remove outdated (info transferred to [wiki](https://github.com/IITC-CE/ingress-intel-total-conversion/wiki))

## Plugins

### enhancements
- Improve scale-bar and scoreboard plugins #158
- Improve styles of text labels (portal-level-numbers, portal-names, portal-names, regions, keys-on-map) #104
- Other
  - draw-tools, bookmarks: (make use of #243) support file import/export on desktop too
  - see #134: significantly enhance several plugins : overlay-kml, minimap, basemap-bing, basemap-yandex, tidy-links, pan-control, etc (see commit messages)

### bugfixes
- sync: fix and update #212
- draw-tools: fix mobile-related bugs; add Circle again #175
- bookmarks: fix iitc download url #150
- portals-list: filter out portal without real data (bug in intel) #265
- Other: see #157 (cache-portals-on-map, layer-count, draw-tools, bookmarks, missions)

## IITC-Mobile app

### enhancements
- 'Support DeX desktop mode' option #161
- Add 'Plugins' shortcut to main menu #266
- Adapt to changes in Google authorization #283

### bugfixes
- fix bugs on login page #164
- fix some bugs in plugins handling #245
- fix 'Send screenshot' function #169
- fix error that made it difficult to pick plugin file #239
- fix plugin initialization bug #270

### development
- better handling of uploads #250

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iitc-ce/ingress-intel-total-conversion/282)
<!-- Reviewable:end -->
