### PR TITLE
Adapt to changes in Google authorization

### DIFF
--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_WebViewClient.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_WebViewClient.java
@@ -276,8 +276,8 @@ public class IITC_WebViewClient extends WebViewClient {
     @Override
     public boolean shouldOverrideUrlLoading(final WebView view, final String url) {
         Uri uri = Uri.parse(url);
-        
-        if (url.contains("conflogin") || url.contains("ServiceLogin") || url.contains("appengine.google.com")) {
+
+        if ((url.contains("accounts.google.com") && url.contains("oauth")) || url.contains("conflogin") || url.contains("ServiceLogin") || url.contains("appengine.google.com")) {
             Log.d("Google login");
             return false;
         }
@@ -289,11 +289,6 @@ public class IITC_WebViewClient extends WebViewClient {
                 && "/url".equals(uri.getPath()) && uri.getQueryParameter("q") != null) {
             Log.d("redirect to: " + uri.getQueryParameter("q"));
             return shouldOverrideUrlLoading(view, uri.getQueryParameter("q"));
-        }
-        else if (url.contains("accounts.google.com/o/oauth2")) {
-            Log.d("redirect to: " + url);
-            Log.d("Authorize Sync plugin");
-            return false;
         }
         else if (isIntelUrl(url)) {
             Log.d("intel link requested, reset app and load " + url);

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_WebViewClient.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_WebViewClient.java
@@ -287,7 +287,7 @@ public class IITC_WebViewClient extends WebViewClient {
             Log.d("Facebook login");
             return false;
         }
-        else if (uriHost.equals("accounts.google.com") && uriPath.contains("oauth") ||
+        else if (uriHost.equals("accounts.google.com") && (uriPath.contains("signin") || uriPath.contains("oauth")) ||
                 uriPath.contains("conflogin") ||
                 uriPath.contains("ServiceLogin") ||
                 uriHost.equals("appengine.google.com")) {


### PR DESCRIPTION
- Prevent external browser from opening during authorization
- Support two-factor authentication

After recent changes (in Google or Intel) some users suffers from external browser opening when logging in, that can lead to problems with authorization.

With this change the authorization in such cases performed inside of app's main WebView.