### PR TITLE
Set portal permalinks to zoom level 17

### DIFF
--- a/core/code/utils_misc.js
+++ b/core/code/utils_misc.js
@@ -500,7 +500,10 @@ window.makePermalink = function (latlng, options) {
   }
   if (latlng) {
     if ('lat' in latlng) { latlng = [latlng.lat, latlng.lng]; }
-    args.push('pll='+latlng.join(','));
+    args.push(
+      'pll='+latlng.join(','),
+      'z=17'
+    );
   }
   var url = options.fullURL ? '@url_intel_base@' : '/';
   return url + '?' + args.join('&');


### PR DESCRIPTION
After the common permalink generator refactor [!198](https://github.com/IITC-CE/ingress-intel-total-conversion/pull/198) the portals permalinks are certainly neater and shorter, but they are much more zoomed out than before. This change adds the zoom level 17 argument back into the permalink, which just adds four characters to the URL itself, and has better usability. 