### PR TITLE
boot.js: prevent 'baselayerchange' to fire second time (on mobile)

### DIFF
--- a/core/code/boot.js
+++ b/core/code/boot.js
@@ -542,12 +542,14 @@ window.setupLayerChooserApi = function() {
       }
     }
 
+    /* this code seems obsolete.
+
     //below logic based on code in L.Control.Layers _onInputClick
     if(!obj.overlay) {
       this._map.setZoom(this._map.getZoom());
       this._map.fire('baselayerchange', {layer: obj.layer});
     }
-
+    */
     return true;
   };
 


### PR DESCRIPTION
Fix issue with minimap.

Background: mobile app uses native layer chooser instead of standard `Control.Layers`,
so `window.layerChooser` has additional code to support that.

Perhaps it was needed to fire 'baselayerchange' manually a long time ago,
but not in leaflet 1.

**This is just quick fix for particular issue appeared with minimap on mobile**
But in fact the whole `layerChooser` should be reimplemented from scratch.
Mobile-specific parts of code should be separated.