### PR TITLE
Prevent loop redirects on some older versions of WebView

### DIFF
--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -207,5 +207,8 @@
         <p><b>Be careful:</b> Javascript from external sources may contain harmful code (spyware etc.)!
         <p>Are you sure you want to proceed?]]>
     </string>
+    <string name="webview_requires_update_top">Unable to login</string>
+    <string name="webview_requires_update_msg">Google login continues redirecting to same URL. This is most likely caused by outdated Android System WebView component.</string>
+    <string name="open_google_play">Update WebView</string>
 
 </resources>


### PR DESCRIPTION
It was found out that Google authorization loops occur on some older versions of WebView. Therefore, when detecting an endless loop it is proposed to update Android WebView from Google Play