### PR TITLE
Update SDK min version to 21 (Lollipop)

### DIFF
--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
         applicationId "org.exarhteam.iitc_mobile"
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode = getVersionCode()
         versionName "0.30"


### PR DESCRIPTION
In current form IITC is not working on android before lollipop. Given significant limitations in debugging and small audience of users of this version of Android, it was decided to increase the requirements for Android version. See https://github.com/IITC-CE/ingress-intel-total-conversion/issues/300