### PR TITLE
boot.js: fix handling of plugins setup 'highest' priority

### DIFF
--- a/core/code/boot.js
+++ b/core/code/boot.js
@@ -673,7 +673,7 @@ function prepPluginsToLoad() {
 
   function getPriority (data) {
     var v = data && data.priority || 'normal';
-    var prio = priorities[v] || v;
+    var prio = v in priorities ? priorities[v] : v;
     if (typeof prio !== 'number') {
       log.warn('wrong plugin priority specified: ', v);
       prio = priorities.normal;


### PR DESCRIPTION
By a coincedence numeric value was 0 which is considered as false in javascript

Note: avoid using of 'highest' value as it's not documented and is subject to change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iitc-ce/ingress-intel-total-conversion/307)
<!-- Reviewable:end -->
