### PR TITLE
draw-tools: fix touch on iOS

### DIFF
--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -573,7 +573,7 @@ window.plugin.drawTools.snapToPortals = function() {
   window.plugin.drawTools.save();
 }
 
-window.plugin.drawTools.drawstart = function (e) {
+window.plugin.drawTools.patch789 = function (e) {
   var mouseActive = L.Browser.touch && matchMedia('(hover:hover)').matches; // workaround for https://github.com/IITC-CE/ingress-intel-total-conversion/issues/162
   if (mouseActive || e.layerType === 'circle' || e.layerType === 'rectangle') {
     e.target.touchExtend.enable()
@@ -590,7 +590,13 @@ window.plugin.drawTools.boot = function() {
   map.addHandler('touchExtend', L.Map.TouchExtend);
 
   // trying to circumvent touch bugs: https://github.com/Leaflet/Leaflet.draw/issues/789
-  map.on('draw:drawstart', plugin.drawTools.drawstart);
+  // Browsers where leaflet.draw misbehaves:
+  // - all Chrominium-based
+  // - Firefox (except Android version up to 68)
+  // following condition was empirically picked and currently it covers all known cases:
+  if ('PointerEvent' in window && !L.Browser.safari) {
+    map.on('draw:drawstart', plugin.drawTools.patch789);
+  }
 
   window.plugin.drawTools.currentMarker = window.plugin.drawTools.getMarkerIcon(window.plugin.drawTools.currentColor);
 

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -5,6 +5,9 @@
 // @description    Allow drawing things onto the current map so you may plan your next move.
 
 
+// HOOK: pluginDrawTools
+// custom hook for draw tools to share it's activity with other plugins
+
 // use own namespace for plugin
 window.plugin.drawTools = function() {};
 
@@ -581,9 +584,6 @@ window.plugin.drawTools.patch789 = function (e) {
     e.target.touchExtend.disable()
   };
 }
-
-// HOOK: pluginDrawTools
-// custom hook for draw tools to share it's activity with other plugins
 
 window.plugin.drawTools.boot = function() {
   // workaround for https://github.com/Leaflet/Leaflet.draw/issues/923


### PR DESCRIPTION
As it appeared, our attempt to fix Leaflet.draw [bug] in #175
is not good for some environments, e.g. it prevents proper touch
detecting on iOS (observed while drawing polygons)

[bug]: https://github.com/Leaflet/Leaflet.draw/issues/789

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iitc-ce/ingress-intel-total-conversion/308)
<!-- Reviewable:end -->
