### PR TITLE
quick-fix for old android versions with pre-ES2015 webview

### DIFF
--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -195,6 +195,11 @@ var ulog = (function (module) {
   return module;
 }({})).exports;
 
+// ulog currently fails in pre-ES2015 environment
+if (!Object.getOwnPropertyDescriptor(Function, 'name').configurable) {
+  ulog = function () { return console; }; // replace ulog with stub
+}
+
 '@bundle_code@';
 
   // fixed Addons


### PR DESCRIPTION
Issue observed under x86 android kitkat/lollypop emulator:
as appeared, ulog module fails trying to redefine function name property.
https://github.com/Download/ulog/issues/24

So now we detect this case and then replace ulog with a stub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iitc-ce/ingress-intel-total-conversion/309)
<!-- Reviewable:end -->
