### PR TITLE
Fix performance issues of L.CanvasIconLayer

### DIFF
--- a/core/code/boot.js
+++ b/core/code/boot.js
@@ -177,8 +177,7 @@ window.setupMap = function() {
   if (L.CRS.S2) { map.options.crs = L.CRS.S2; }
 
   L.Renderer.mergeOptions({
-    padding: window.RENDERER_PADDING ||
-             (L.Browser.mobile ? 0.5 : 1)
+    padding: window.RENDERER_PADDING || 0.5
   });
 
   // add empty div to leaflet control areas - to force other leaflet controls to move around IITC UI elements

--- a/core/code/boot.js
+++ b/core/code/boot.js
@@ -178,7 +178,7 @@ window.setupMap = function() {
 
   L.Renderer.mergeOptions({
     padding: window.RENDERER_PADDING ||
-             L.Browser.mobile ? 0.5 : 1
+             (L.Browser.mobile ? 0.5 : 1)
   });
 
   // add empty div to leaflet control areas - to force other leaflet controls to move around IITC UI elements

--- a/core/code/ornaments.js
+++ b/core/code/ornaments.js
@@ -23,7 +23,7 @@ window.ornaments = {
   setup: function () {
     this._portals = {};
     var layerGroup = L.layerGroup;
-    if (window.map.options.preferCanvas && L.Browser.canvas) {
+    if (window.map.options.preferCanvas && L.Browser.canvas && !window.DISABLE_CANVASICONLAYER) {
       layerGroup = L.canvasIconLayer;
       L.CanvasIconLayer.mergeOptions({ padding: L.Canvas.prototype.options.padding });
     }

--- a/core/external/leaflet.canvas-markers.js
+++ b/core/external/leaflet.canvas-markers.js
@@ -111,6 +111,14 @@ function layerFactory (L) {
             this._latlngsIdx = new LatLngsIndex();
         },
 
+        _checkDisplay() {
+            if (this._latlngsIdx._total) {
+                this._container.style.display = 'initial';
+            } else {
+                this._container.style.display = 'none';
+            }
+        },
+
         onAdd: function () {
             L.Renderer.prototype.onAdd.call(this);
             L.DomUtil.toBack(this._container);
@@ -118,6 +126,7 @@ function layerFactory (L) {
 
         _initContainer: function () {
             L.Canvas.prototype._initContainer.call(this);
+            this._checkDisplay();
         },
 
         onRemove: function () {
@@ -331,6 +340,7 @@ function layerFactory (L) {
                 this._pointsIdx.insert(marker, batch);
             }
             this._latlngsIdx.insert(marker, batch);
+            this._checkDisplay();
         },
 
         // Adds single layer at a time. Less efficient for rBush
@@ -396,12 +406,14 @@ function layerFactory (L) {
             }).forEach(function (el) {
                 this._latlngsIdx.remove(el);
             }, this);
+            this._checkDisplay();
         },
 
         removeMarker: function (marker, redraw) {
             var latlng = marker.getLatLng();
             var isDisplaying = this._map && this._map.getBounds().pad(this.options.padding).contains(latlng);
             this._latlngsIdx.remove(marker);
+            this._checkDisplay();
 
             if (isDisplaying && redraw) {
                 this._redraw();
@@ -426,6 +438,7 @@ function layerFactory (L) {
             this._latlngsIdx.clear();
             this._pointsIdx.clear();
             this._clear();
+            this._checkDisplay();
             return this;
         }
     });

--- a/core/external/versions.md
+++ b/core/external/versions.md
@@ -41,6 +41,8 @@
 * https://github.com/IITC-CE/Leaflet.Canvas-Markers
   leaflet.canvas-markers.js: 12fb5afd0a8cb7101a2e8f931e20be76818fe917
   (https://github.com/Spaction/Leaflet.Canvas-Markers/pull/3)
+  + quickfix https://github.com/IITC-CE/Leaflet.Canvas-Markers/pull/14
+  https://github.com/IITC-CE/Leaflet.Canvas-Markers/blob/83d8ea3f0fb4d7e242914a9021270326a7a5c03b/src/plugin/leaflet.canvas-markers.js
   used in: ornaments.js
 
 


### PR DESCRIPTION
As it appeared, not all browsers canvas implementations are equal.
Performance issues reported for FF, Safari, and not up-to-date Android WebView.

Here we are trying to fix some issues by reducing `padding`, and setting `display: 'none';` style for empty canvases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iitc-ce/ingress-intel-total-conversion/313)
<!-- Reviewable:end -->
