### PR TITLE
draw-tools: fix touch issues in more proper way

### DIFF
--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -1,7 +1,7 @@
 // @author         breunigs
 // @name           Draw tools
 // @category       Draw
-// @version        0.7.1
+// @version        0.7.2
 // @description    Allow drawing things onto the current map so you may plan your next move.
 
 
@@ -576,21 +576,19 @@ window.plugin.drawTools.snapToPortals = function() {
   window.plugin.drawTools.save();
 }
 
-window.plugin.drawTools.drawstart = function (e) {
-  var mouseActive = L.Browser.touch && matchMedia('(hover:hover)').matches; // workaround for https://github.com/IITC-CE/ingress-intel-total-conversion/issues/162
-  if (mouseActive || e.layerType === 'circle' || e.layerType === 'rectangle') {
-    e.target.touchExtend.enable()
-  } else {
-    e.target.touchExtend.disable()
-  };
-}
-
-window.plugin.drawTools.boot = function() {
+window.plugin.drawTools.draw_hotfix = function() {
   // workaround for https://github.com/Leaflet/Leaflet.draw/issues/923
   map.addHandler('touchExtend', L.Map.TouchExtend);
 
-  // trying to circumvent touch bugs: https://github.com/Leaflet/Leaflet.draw/issues/789
-  map.on('draw:drawstart', plugin.drawTools.drawstart);
+  // disable tap handler as it conflicts with leaflet.draw
+  // https://github.com/Leaflet/Leaflet/issues/6977
+  // !Note: currently this may brake `contextmenu` handling on iOS
+  map.tap = map.tap ? map.tap.disable() : false;
+}
+
+window.plugin.drawTools.boot = function() {
+
+  window.plugin.drawTools.draw_hotfix();
 
   window.plugin.drawTools.currentMarker = window.plugin.drawTools.getMarkerIcon(window.plugin.drawTools.currentColor);
 

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -576,7 +576,7 @@ window.plugin.drawTools.snapToPortals = function() {
   window.plugin.drawTools.save();
 }
 
-window.plugin.drawTools.patch789 = function (e) {
+window.plugin.drawTools.drawstart = function (e) {
   var mouseActive = L.Browser.touch && matchMedia('(hover:hover)').matches; // workaround for https://github.com/IITC-CE/ingress-intel-total-conversion/issues/162
   if (mouseActive || e.layerType === 'circle' || e.layerType === 'rectangle') {
     e.target.touchExtend.enable()
@@ -590,13 +590,7 @@ window.plugin.drawTools.boot = function() {
   map.addHandler('touchExtend', L.Map.TouchExtend);
 
   // trying to circumvent touch bugs: https://github.com/Leaflet/Leaflet.draw/issues/789
-  // Browsers where leaflet.draw misbehaves:
-  // - all Chrominium-based
-  // - Firefox (except Android version up to 68)
-  // following condition was empirically picked and currently it covers all known cases:
-  if ('PointerEvent' in window && !L.Browser.safari) {
-    map.on('draw:drawstart', plugin.drawTools.patch789);
-  }
+  map.on('draw:drawstart', plugin.drawTools.drawstart);
 
   window.plugin.drawTools.currentMarker = window.plugin.drawTools.getMarkerIcon(window.plugin.drawTools.currentColor);
 

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -576,19 +576,7 @@ window.plugin.drawTools.snapToPortals = function() {
   window.plugin.drawTools.save();
 }
 
-window.plugin.drawTools.draw_hotfix = function() {
-  // workaround for https://github.com/Leaflet/Leaflet.draw/issues/923
-  map.addHandler('touchExtend', L.Map.TouchExtend);
-
-  // disable tap handler as it conflicts with leaflet.draw
-  // https://github.com/Leaflet/Leaflet/issues/6977
-  // !Note: currently this may brake `contextmenu` handling on iOS
-  map.tap = map.tap ? map.tap.disable() : false;
-}
-
 window.plugin.drawTools.boot = function() {
-
-  window.plugin.drawTools.draw_hotfix();
 
   window.plugin.drawTools.currentMarker = window.plugin.drawTools.getMarkerIcon(window.plugin.drawTools.currentColor);
 
@@ -669,11 +657,30 @@ function loadExternals () {
 
     $('<style>').html('@include_css:external/leaflet.draw-fix.css@').appendTo('head');
 
-    '@include_raw:external/leaflet.draw-fix.js@';
-
     '@include_raw:external/leaflet.draw-snap.js@';
 
     '@include_raw:external/leaflet.draw-geodesic.js@';
+
+    // support Leaflet >= 1
+    // https://github.com/Leaflet/Leaflet.draw/pull/911
+    L.Draw.Polyline.prototype.options.shapeOptions.interactive = true;
+    L.Draw.Polygon.prototype.options.shapeOptions.interactive = true;
+    L.Draw.Rectangle.prototype.options.shapeOptions.interactive = true;
+    L.Draw.CircleMarker.prototype.options.interactive = true;
+    L.Draw.Circle.prototype.options.shapeOptions.interactive = true;
+
+    // https://github.com/Leaflet/Leaflet.draw/issues/789
+    // https://github.com/Leaflet/Leaflet.draw/issues/695
+    L.Draw.Polyline.prototype._onTouch_original = L.Draw.Polyline.prototype._onTouch; // just in case
+    L.Draw.Polyline.prototype._onTouch = L.Util.falseFn;
+
+    // workaround for https://github.com/Leaflet/Leaflet.draw/issues/923
+    map.addHandler('touchExtend', L.Map.TouchExtend);
+
+    // disable tap handler as it conflicts with leaflet.draw
+    // https://github.com/Leaflet/Leaflet/issues/6977
+    // !Note: currently this may brake `contextmenu` handling on iOS
+    map.tap = map.tap ? map.tap.disable() : false;
 
   } catch (e) {
     console.error('leaflet.draw-src.js loading failed');

--- a/plugins/external/leaflet.draw-fix.js
+++ b/plugins/external/leaflet.draw-fix.js
@@ -18,3 +18,10 @@ L.Draw.SimpleShape.include({
   }
 });
 })(L.Draw.SimpleShape.prototype.addHooks,L.Draw.SimpleShape.prototype.removeHooks);
+
+// https://github.com/Leaflet/Leaflet.draw/issues/789
+// https://github.com/Leaflet/Leaflet.draw/issues/695
+L.Draw.Polyline.prototype._onTouch_original = L.Draw.Polyline.prototype._onTouch; // just in case
+L.Draw.Polyline.prototype._onTouch = L.Util.falseFn;
+
+// see more fixes in window.plugin.drawTools.draw_hotfix()

--- a/plugins/external/leaflet.draw-fix.js
+++ b/plugins/external/leaflet.draw-fix.js
@@ -1,6 +1,0 @@
-// https://github.com/Leaflet/Leaflet.draw/issues/789
-// https://github.com/Leaflet/Leaflet.draw/issues/695
-L.Draw.Polyline.prototype._onTouch_original = L.Draw.Polyline.prototype._onTouch; // just in case
-L.Draw.Polyline.prototype._onTouch = L.Util.falseFn;
-
-// see more fixes in window.plugin.drawTools.draw_hotfix()

--- a/plugins/external/leaflet.draw-fix.js
+++ b/plugins/external/leaflet.draw-fix.js
@@ -1,24 +1,3 @@
-// https://github.com/IITC-CE/ingress-intel-total-conversion/pull/175
-// https://github.com/Leaflet/Leaflet.draw/issues/922
-
-(function (addHooks,removeHooks) {
-L.Draw.SimpleShape.include({
-  addHooks: function () {
-    addHooks.call(this);
-    if (this._map) {
-      document.removeEventListener('touchstart', L.DomEvent.preventDefault);
-      this._map.getPanes().mapPane.addEventListener('touchstart', L.DomEvent.preventDefault, {passive: false});
-    }
-  },
-  removeHooks: function () {
-    removeHooks.call(this);
-    if (this._map) {
-      this._map.getPanes().mapPane.removeEventListener('touchstart', L.DomEvent.preventDefault);
-    }
-  }
-});
-})(L.Draw.SimpleShape.prototype.addHooks,L.Draw.SimpleShape.prototype.removeHooks);
-
 // https://github.com/Leaflet/Leaflet.draw/issues/789
 // https://github.com/Leaflet/Leaflet.draw/issues/695
 L.Draw.Polyline.prototype._onTouch_original = L.Draw.Polyline.prototype._onTouch; // just in case

--- a/plugins/external/leaflet.draw-geodesic.js
+++ b/plugins/external/leaflet.draw-geodesic.js
@@ -1,7 +1,5 @@
 // L.Draw extension to support L.Geodesic*
-// support Leaflet >= 1
 
-L.Draw.Polyline.prototype.options.shapeOptions.interactive = true;
 L.Draw.Polyline.include({
 	Poly: L.GeodesicPolyline,
 
@@ -56,12 +54,7 @@ L.Draw.Polyline.include({
 });
 
 L.Draw.Polygon.prototype.Poly = L.GeodesicPolygon;
-L.Draw.Polygon.prototype.options.shapeOptions.interactive = true;
 
-L.Draw.Rectangle.prototype.options.shapeOptions.interactive = true;
-
-L.Draw.CircleMarker.prototype.options.interactive = true;
-L.Draw.Circle.prototype.options.shapeOptions.interactive = true;
 L.Draw.Circle.include({ // ?? extend to L.Draw.GeodesicCircle ??
 	_drawShape: function (latlng) {
 		var distance = this._map.distance(this._startLatLng, latlng);


### PR DESCRIPTION
Revert some previous fixes.
Implement more simple and thus more reliable fixes instead.

Warning: currently this may break `contextmenu` handling on iOS.
https://github.com/Leaflet/Leaflet/issues/6977

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iitc-ce/ingress-intel-total-conversion/316)
<!-- Reviewable:end -->
