### PR TITLE
Drawtools - Fix duplicate declaration

### DIFF
--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -278,7 +278,6 @@ window.plugin.drawTools.manualOpt = function() {
     html: html,
     id: 'plugin-drawtools-options',
     dialogClass: 'ui-dialog-drawtoolsSet',
-    id: 'plugin-drawtools-options',
     title: 'Draw Tools Options'
   });
 


### PR DESCRIPTION
Fix a duplicate `id` declaration in draw tools - not tested :stuck_out_tongue_winking_eye: 