### PR TITLE
Close a tag after FAQ link

### DIFF
--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -81,7 +81,7 @@
           tap the screen to beam the map to the other device).<br>
         • You can add official plugins in the settings.<br>
         • For external plugins please have a look at the
-          <a href="https://iitc.modos189.ru/faq.html">FAQ.<br>
+          <a href="https://iitc.modos189.ru/faq.html">FAQ</a>.<br>
         ]]>
     </string>
     <string name="notice_info">


### PR DESCRIPTION
Came across this when translating, e.g. German translation is wrong, as it has to place some word behind "FAQ", which would currently still work as a link.