### PR TITLE
map_data_render.js: placeholders get -1 timestamp value

### DIFF
--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -258,7 +258,7 @@ window.Render.prototype.createPlaceholderPortalEntity = function(guid,latE6,lngE
 
   var ent = [
     guid,       //ent[0] = guid
-    0,          //ent[1] = timestamp - zero will mean any other source of portal data will have a higher timestamp
+    -1,         //ent[1] = timestamp - zero will mean any other source of portal data will have a higher timestamp
                 //ent[2] = an array with the entity data
     [ 'p',      //0 - a portal
       team,     //1 - team
@@ -274,6 +274,7 @@ window.Render.prototype.createPlaceholderPortalEntity = function(guid,latE6,lngE
     var p = window.portals[guid];
     if (team != p.options.data.team || latE6 != p.options.data.latE6 || lngE6 != p.options.data.lngE6) {
       // team or location have changed - delete existing portal
+      log.log('removing outdated portal data and creating placeholder instead');
       this.deletePortalEntity(guid);
     }
   }


### PR DESCRIPTION
This can fix issue with recent intel bug, when normal portals (not placeholders) had 0 timestamp value,
which lead to wrong data processing, because detailed data was rejected as it considered not fresher than
placeholders (that originated from links/fields that currently are processing earlier).
https://t.me/iitc_group/8046

Note: this is rather temporary fix, as we need to revise our data procesing approaches in whole.
Perhaps, instead of relying on timestamps, we should compare new data details with cached,
every single property.

There is another issue: ghosted fields, which may be considered as intel (or Ingress) bug,
but we still should try to investigate it further, as it may be possible to propose some workaround.
Of cause if it will not turn out that Ingress itself is affected in same way (shows same ghosted fields,
and prevents linking in that area).

For now, just add more logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iitc-ce/ingress-intel-total-conversion/324)
<!-- Reviewable:end -->
