### PR TITLE
Fix Modal Dialogs to be top-most

### DIFF
--- a/core/style.css
+++ b/core/style.css
@@ -861,7 +861,7 @@ h3.title {
  */
 .ui-tooltip, .ui-dialog {
   position: absolute;
-  z-index: 9999;
+  z-index: 9500;
   background-color: rgba(8, 48, 78, 0.9);
   border: 1px solid #20A8B1;
   color: #eee;


### PR DESCRIPTION
When multiple dialog are open a "top most" dialog can be below other dialogs.

Dialogs are created with up counting z-index. They start with 9999 and
quickly reaches 10001.  Modal Dialog are always on z-index 10001 and so
interference with these if more the 2 dialogs are open.