### PR TITLE
build.py: fix to support Python 3.8.2

### DIFF
--- a/build.py
+++ b/build.py
@@ -17,7 +17,7 @@ def run_python(cmd):
         cmd = Path(__file__).with_name(cmd)
         if not cmd.is_file():
             raise UserWarning(f'no such file: {original}')
-    return run_path(cmd)
+    return run_path(str(cmd))
 
 
 def run_system(cmd):


### PR DESCRIPTION
* It seems that python3.8 doesn't allow path like objects in runpy.run_path any more. (see https://github.com/spacemanspiff2007/HABApp/issues/111)
* ~In version 3.8 --bind argument enhanced to support IPv6. (https://docs.python.org/3/library/http.server.html#http.server.SimpleHTTPRequestHandler) this causes the server to start at http://[::1]:8000/.~