### PR TITLE
fix Facebook login

### DIFF
--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_WebViewClient.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_WebViewClient.java
@@ -283,7 +283,8 @@ public class IITC_WebViewClient extends WebViewClient {
             Log.d("redirect to: " + uriQuery);
             return shouldOverrideUrlLoading(view, uriQuery);
         }
-        if (uriHost.equals("facebook.com") && uriPath.contains("oauth")) {
+        if (uriHost.endsWith("facebook.com")
+                && (uriPath.contains("oauth") || uriPath.equals("/login.php") || uriPath.equals("/checkpoint/"))) {
             Log.d("Facebook login");
             return false;
         }


### PR DESCRIPTION
Support urls with redirections like this:
https://www.facebook.com/v3.2/dialog/oauth?client_id=449856365443419&redirect_uri=https://intel.ingress.com/
--> https://m.facebook.com/login.php?...
--> https://m.facebook.com/checkpoint/...