### PR TITLE
Update portal counts plugin to integrate with draw tools and uniques

### DIFF
--- a/plugins/portal-counts.js
+++ b/plugins/portal-counts.js
@@ -1,27 +1,8 @@
-// ==UserScript==
 // @author         yenky
-// @name           IITC plugin: Portal count
+// @name           Portal count
 // @category       Info
 // @version        0.1.2
 // @description    Display a list of all localized portals by level and faction.
-// @id             portal-counts
-// @namespace      https://github.com/IITC-CE/ingress-intel-total-conversion
-// @updateURL      https://iitc.modos189.ru/build/release/plugins/portal-counts.meta.js
-// @downloadURL    https://iitc.modos189.ru/build/release/plugins/portal-counts.user.js
-// @match          https://intel.ingress.com/*
-// @grant          none
-// ==/UserScript==
-
-function wrapper(plugin_info) {
-// ensure plugin framework is there, even if iitc is not yet loaded
-if(typeof window.plugin !== 'function') window.plugin = function() {};
-
-//PLUGIN AUTHORS: writing a plugin outside of the IITC build environment? if so, delete these lines!!
-//(leaving them in place might break the 'About IITC' page or break update checks)
-plugin_info.buildName = 'release';
-plugin_info.dateTimeVersion = '2020-01-18-170317';
-plugin_info.pluginId = 'portal-counts';
-//END PLUGIN AUTHORS NOTE
 
 
 /* whatsnew

--- a/plugins/portal-counts.js
+++ b/plugins/portal-counts.js
@@ -78,7 +78,7 @@ window.plugin.portalcounts.getPortals = function (){
       var latlng = portal._latlng.lat + ',' + portal._latlng.lng;
       for(var dl in drawLayer){
         if(drawLayer[dl].type === 'polygon') {
-          if(window.plugin.portalcounts.portalinpolygon(latlng,drawLayer[dl].latLngs)) {
+          if(window.plugin.portalcounts.portalinpolygon(portal, drawLayer[dl].latLngs)) {
             portalInPolygon = true;
             break;
           }

--- a/plugins/portal-counts.js
+++ b/plugins/portal-counts.js
@@ -34,7 +34,7 @@ window.plugin.portalcounts = {
 window.plugin.portalcounts.portalinpolygon = function(portal,LatLngsObjectsArray) {
   var portalCoords = portal.split(',');
 
-  var x = portalCoords[0], y = portalCoords[1];
+  var x = portalCoords.lat, y = portalCoords.lng;
 
   var inside = false;
   for (var i = 0, j = LatLngsObjectsArray.length - 1; i < LatLngsObjectsArray.length; j = i++) {

--- a/plugins/portal-counts.js
+++ b/plugins/portal-counts.js
@@ -30,7 +30,9 @@ window.plugin.portalcounts = {
   CENTER_Y: 100,
 };
 
-/*********** HELPER FUNCTION ****************************************************/
+// Determine if a point is inside of a polygon.
+// ray-casting algorithm based on
+// https://observablehq.com/@tmcw/understanding-point-in-polygon
 window.plugin.portalcounts.portalinpolygon = function(portal,LatLngsObjectsArray) {
   var portalCoords = portal.getLatLng();
 

--- a/plugins/portal-counts.js
+++ b/plugins/portal-counts.js
@@ -75,7 +75,6 @@ window.plugin.portalcounts.getPortals = function (){
   $.each(window.portals, function(i, portal) {
     if (drawLayer && drawLayer.length) {
       var portalInPolygon = false;
-      var latlng = portal._latlng.lat + ',' + portal._latlng.lng;
       for(var dl in drawLayer){
         if(drawLayer[dl].type === 'polygon') {
           if(window.plugin.portalcounts.portalinpolygon(portal, drawLayer[dl].latLngs)) {

--- a/plugins/portal-counts.js
+++ b/plugins/portal-counts.js
@@ -73,7 +73,6 @@ window.plugin.portalcounts.getPortals = function (){
     var drawLayer = JSON.parse(localStorage['plugin-draw-tools-layer']);
   }
   $.each(window.portals, function(i, portal) {
-    console.log(drawLayer);
     if (drawLayer.length) {
       var portalInPolygon = false;
       var latlng = portal._latlng.lat + ',' + portal._latlng.lng;

--- a/plugins/portal-counts.js
+++ b/plugins/portal-counts.js
@@ -32,7 +32,7 @@ window.plugin.portalcounts = {
 
 /*********** HELPER FUNCTION ****************************************************/
 window.plugin.portalcounts.portalinpolygon = function(portal,LatLngsObjectsArray) {
-  var portalCoords = portal.split(',');
+  var portalCoords = portal.getLatLng();
 
   var x = portalCoords.lat, y = portalCoords.lng;
 

--- a/plugins/portal-counts.js
+++ b/plugins/portal-counts.js
@@ -73,7 +73,7 @@ window.plugin.portalcounts.getPortals = function (){
     var drawLayer = JSON.parse(localStorage['plugin-draw-tools-layer']);
   }
   $.each(window.portals, function(i, portal) {
-    if (drawLayer.length) {
+    if (drawLayer && drawLayer.length) {
       var portalInPolygon = false;
       var latlng = portal._latlng.lat + ',' + portal._latlng.lng;
       for(var dl in drawLayer){
@@ -238,7 +238,7 @@ window.plugin.portalcounts.getPortals = function (){
 
   var total = self.enlP + self.resP + self.neuP;
   var title = total + ' ' + (total == 1 ? 'portal' : 'portals');
-  if (drawLayer.length) {
+  if (drawLayer && drawLayer.length) {
       title = title + ' in polygons';
   }
 

--- a/plugins/portal-counts.js
+++ b/plugins/portal-counts.js
@@ -46,6 +46,9 @@ window.plugin.portalcounts.getPortals = function (){
     self.PortalsRes[level] = 0;
   }
 
+  self.upcP = 0;
+  self.upvP = 0;
+
   $.each(window.portals, function(i, portal) {
     var level = portal.options.level;
     var team = portal.options.team;
@@ -63,6 +66,23 @@ window.plugin.portalcounts.getPortals = function (){
       default:
         self.neuP++;
         break;
+    }
+
+    if (window.plugin.uniques) {
+      var guid = portal.options.ent[0];
+      var uniqueInfo = window.plugin.uniques.uniques[guid];
+
+      if (uniqueInfo) {
+        if (!uniqueInfo.captured) {
+          self.upcP++;
+        }
+        if (!uniqueInfo.visited) {
+          self.upvP++;
+        }
+      } else {
+        self.upvP++;
+        self.upcP++;
+      }
     }
   });
 
@@ -82,7 +102,19 @@ window.plugin.portalcounts.getPortals = function (){
 
     counts += '<tr><td>Neutral:</td><td colspan="2">';
     counts += self.neuP;
-    counts += '</td></tr></table>';
+    counts += '</td></tr>';
+
+    if (window.plugin.uniques) {
+      counts += '<tr><td>Unvisited:</td><td colspan="2">';
+      counts += self.upvP;
+      counts += '</td></tr>';
+
+      counts += '<tr><td>Uncaptured:</td><td colspan="2">';
+      counts += self.upcP;
+      counts += '</td></tr>';
+    }
+
+    counts += '</table>';
 
     var svg = $('<svg width="300" height="200">').css('margin-top', 10);
 

--- a/plugins/portal-counts.js
+++ b/plugins/portal-counts.js
@@ -415,17 +415,3 @@ var setup =  function() {
     '#portalcounts table th:nth-child(1) { text-align: left;}' +
     '</style>');
 }
-
-setup.info = plugin_info; //add the script info data to the function as a property
-if(!window.bootPlugins) window.bootPlugins = [];
-window.bootPlugins.push(setup);
-// if IITC has already booted, immediately run the 'setup' function
-if(window.iitcLoaded && typeof setup === 'function') setup();
-} // wrapper end
-// inject code into site context
-var script = document.createElement('script');
-var info = {};
-if (typeof GM_info !== 'undefined' && GM_info && GM_info.script) info.script = { version: GM_info.script.version, name: GM_info.script.name, description: GM_info.script.description };
-script.appendChild(document.createTextNode('('+ wrapper +')('+JSON.stringify(info)+');'));
-(document.body || document.head || document.documentElement).appendChild(script);
-


### PR DESCRIPTION
Display count of unvisited and uncaptured portals if the uniques plugin is installed.

If any polygons are draw, only count portals in the polygons.