### PR TITLE
log source code instead of function pointers on error

### DIFF
--- a/core/code/boot.js
+++ b/core/code/boot.js
@@ -685,14 +685,14 @@ function prepPluginsToLoad() {
 
   // executes setup function of plugin
   // and collects info for About IITC
-  function safeSetup (setup) {
-    if (!setup) {
+  function safeSetup(setup) {
+    if (typeof setup !== 'function') {
       log.warn('plugin must provide setup function');
       return;
     }
     var info = setup.info;
     if (typeof info !== 'object') {
-      log.warn('plugin does not have proper wrapper:',setup);
+      log.warn('plugin does not have proper wrapper:', { function: setup, info: setup.info, source: setup.toString() });
       info = {};
     }
     try {

--- a/core/code/hooks.js
+++ b/core/code/hooks.js
@@ -74,7 +74,7 @@ window.runHooks = function(event, data) {
         return false;  //break from $.each
       }
     } catch (e) {
-      log.error('error running hook '+event+', error: '+e);
+      log.error('error running hook', { event: event, error: e, source: callback.toString(), data: data });
     }
   });
   return !interrupted;

--- a/core/code/hooks.js
+++ b/core/code/hooks.js
@@ -64,10 +64,10 @@
 window._hooks = {}
 window.VALID_HOOKS = []; // stub for compatibility
 
-window.runHooks = function(event, data) {
-  if(!_hooks[event]) return true;
+window.runHooks = function (event, data) {
+  if (!_hooks[event]) return true;
   var interrupted = false;
-  $.each(_hooks[event], function(ind, callback) {
+  $.each(_hooks[event], function (ind, callback) {
     try {
       if (callback(data) === false) {
         interrupted = true;
@@ -80,28 +80,28 @@ window.runHooks = function(event, data) {
   return !interrupted;
 }
 
-window.pluginCreateHook = function() {}; // stub for compatibility
+window.pluginCreateHook = function () { }; // stub for compatibility
 
-window.addHook = function(event, callback) {
+window.addHook = function (event, callback) {
   if (typeof callback !== 'function') {
     throw new Error('Callback must be a function.');
   }
 
-  if(!_hooks[event])
+  if (!_hooks[event])
     _hooks[event] = [callback];
   else
     _hooks[event].push(callback);
 }
 
 // callback must the SAME function to be unregistered.
-window.removeHook = function(event, callback) {
+window.removeHook = function (event, callback) {
   if (typeof callback !== 'function') {
     throw new Error('Callback must be a function.');
   }
 
   if (_hooks[event]) {
     var index = _hooks[event].indexOf(callback);
-    if(index == -1)
+    if (index == -1)
       log.warn('Callback wasn\'t registered for this event.');
     else
       _hooks[event].splice(index, 1);

--- a/core/code/hooks.js
+++ b/core/code/hooks.js
@@ -74,7 +74,7 @@ window.runHooks = function (event, data) {
         return false;  //break from $.each
       }
     } catch (e) {
-      log.error('error running hook', { event: event, error: e, source: callback.toString(), data: data });
+      log.error('error running hook', { event: event, error: e, source: callback && callback.toString(), data: data });
     }
   });
   return !interrupted;


### PR DESCRIPTION
Function pointers doesn't give much hints where they came from.
Use 'toString' to see the source code of the bad function.