### PR TITLE
plugins: use Date/toLocaleString instead of own functions

### DIFF
--- a/plugins/player-activity-tracker.js
+++ b/plugins/player-activity-tracker.js
@@ -1,7 +1,7 @@
 // @author         breunigs
 // @name           Player activity tracker
 // @category       Layer
-// @version        0.12.0
+// @version        0.12.1
 // @description    Draw trails for the path a user took onto the map based on status messages in COMMs. Uses up to three hours of data. Does not request chat data on its own, even if that would be useful.
 
 
@@ -100,7 +100,7 @@ window.plugin.playerTracker.zoomListener = function() {
 }
 
 window.plugin.playerTracker.getLimit = function() {
- return new Date().getTime() - window.PLAYER_TRACKER_MAX_TIME;
+ return Date.now() - window.PLAYER_TRACKER_MAX_TIME;
 }
 
 window.plugin.playerTracker.discardOldData = function() {
@@ -266,7 +266,7 @@ window.plugin.playerTracker.drawData = function() {
   var polyLineByAgeRes = [[], [], [], []];
 
   var split = PLAYER_TRACKER_MAX_TIME / 4;
-  var now = new Date().getTime();
+  var now = Date.now();
   $.each(plugin.playerTracker.stored, function(plrname, playerData) {
     if(!playerData || playerData.events.length === 0) {
       console.warn('broken player data for plrname=' + plrname);
@@ -528,6 +528,11 @@ window.plugin.playerTracker.onSearchResultSelected = function(result, event) {
   return true;
 };
 
+window.plugin.playerTracker.locale = navigator.languages;
+
+window.plugin.playerTracker.dateTimeFormat = {
+};
+
 window.plugin.playerTracker.onSearch = function(query) {
   var term = query.term.toLowerCase();
 
@@ -541,7 +546,8 @@ window.plugin.playerTracker.onSearch = function(query) {
     query.addResult({
       title: '<mark class="nickname help '+TEAM_TO_CSS[getTeam(data)]+'">' + nick + '</mark>',
       nickname: nick,
-      description: data.team.substr(0,3) + ', last seen ' + unixTimeToDateTimeString(event.time),
+      description: data.team.substr(0,3) + ', last seen ' +
+        new Date(event.time).toLocaleString(window.plugin.playerTracker.locale, window.plugin.playerTracker.dateTimeFormat),
       position: plugin.playerTracker.getLatLngFromEvent(event),
       onSelected: window.plugin.playerTracker.onSearchResultSelected,
     });

--- a/plugins/score-cycle-times.js
+++ b/plugins/score-cycle-times.js
@@ -10,7 +10,7 @@ window.plugin.scoreCycleTimes = function() {};
 
 window.plugin.scoreCycleTimes.CHECKPOINT = 5*60*60; //5 hours per checkpoint
 window.plugin.scoreCycleTimes.CYCLE = 7*25*60*60; //7 25 hour 'days' per cycle
-
+window.plugin.scoreCycleTimes.localeTime = 'default';
 
 window.plugin.scoreCycleTimes.setup  = function() {
 
@@ -40,11 +40,13 @@ window.plugin.scoreCycleTimes.update = function() {
   var checkpointStart = Math.floor(now / (window.plugin.scoreCycleTimes.CHECKPOINT*1000)) * (window.plugin.scoreCycleTimes.CHECKPOINT*1000);
   var checkpointEnd = checkpointStart + window.plugin.scoreCycleTimes.CHECKPOINT*1000;
 
+  var o = new Intl.DateTimeFormat(window.plugin.scoreCycleTimes.localeTime, {
+    year: 'numeric', month: 'numeric', day: 'numeric',
+    hour: 'numeric',
+  });
 
   var formatRow = function(label,time) {
-    var timeStr = unixTimeToString(time,true);
-    timeStr = timeStr.replace(/:00$/,''); //FIXME: doesn't remove seconds from AM/PM formatted dates
-
+    var timeStr = o.format(new Date(time));
     return '<tr><td>'+label+'</td><td>'+timeStr+'</td></tr>';
   };
 

--- a/plugins/score-cycle-times.js
+++ b/plugins/score-cycle-times.js
@@ -42,8 +42,8 @@ window.plugin.scoreCycleTimes.update = function() {
 
 
   var formatRow = function(label,time) {
-    var timeStr = unixTimeToDateTimeString(time,false);
-    timeStr = timeStr.replace(/:00$/,''); 
+    var timeStr = unixTimeToString(time,true);
+    timeStr = timeStr.replace(/:00$/,''); //FIXME: doesn't remove seconds from AM/PM formatted dates
 
     return '<tr><td>'+label+'</td><td>'+timeStr+'</td></tr>';
   };

--- a/plugins/score-cycle-times.js
+++ b/plugins/score-cycle-times.js
@@ -1,66 +1,59 @@
 // @author         jonatkins
 // @name           Scoring cycle / checkpoint times
 // @category       Info
-// @version        0.1.0
+// @version        0.2.0
 // @description    Show the times used for the septicycle and checkpoints for regional scoreboards.
 
 
 // use own namespace for plugin
-window.plugin.scoreCycleTimes = function() {};
+var scoreCycleTimes = {};
+window.plugin.scoreCycleTimes = scoreCycleTimes;
 
-window.plugin.scoreCycleTimes.CHECKPOINT = 5*60*60; //5 hours per checkpoint
-window.plugin.scoreCycleTimes.CYCLE = 7*25*60*60; //7 25 hour 'days' per cycle
-window.plugin.scoreCycleTimes.localeTime = 'default';
-
-window.plugin.scoreCycleTimes.setup  = function() {
-
-  // add a div to the sidebar, and basic style
-  $('#sidebar').append('<div id="score_cycle_times_display"></div>');
-  $('#score_cycle_times_display').css({'color':'#ffce00'});
-
-
-  window.plugin.scoreCycleTimes.update();
+scoreCycleTimes.CHECKPOINT = 5 * 60 * 60 * 1000; // 5 hours per checkpoint
+scoreCycleTimes.CYCLE = 7 * 5 * scoreCycleTimes.CHECKPOINT; // 7 25-hour 'days' per cycle
+scoreCycleTimes.locale = navigator.languages;
+scoreCycleTimes.dateTimeFormat = {
+  year: 'numeric', month: '2-digit', day: '2-digit',
+  hour: '2-digit', minute: '2-digit'
 };
 
+scoreCycleTimes.formatRow = function (label, time) {
+  var dateTime = new Date(time).toLocaleString(scoreCycleTimes.locale, scoreCycleTimes.dateTimeFormat);
+  return '<tr><td>' + label + '</td><td>' + dateTime + '</td></tr>';
+};
 
-
-window.plugin.scoreCycleTimes.update = function() {
-
+scoreCycleTimes.update = function () {
   // checkpoint and cycle start times are based on a simple modulus of the timestamp
   // no special epoch (other than the unix timestamp/javascript's 1970-01-01 00:00 UTC) is required
 
   // when regional scoreboards were introduced, the first cycle would have started at 2014-01-15 10:00 UTC - but it was
   // a few checkpoints in when scores were first added
 
-  var now = new Date().getTime();
+  var now = Date.now();
 
-  var cycleStart = Math.floor(now / (window.plugin.scoreCycleTimes.CYCLE*1000)) * (window.plugin.scoreCycleTimes.CYCLE*1000);
-  var cycleEnd = cycleStart + window.plugin.scoreCycleTimes.CYCLE*1000;
+  var cycleStart = Math.floor(now / scoreCycleTimes.CYCLE) * scoreCycleTimes.CYCLE;
+  var cycleEnd = cycleStart + scoreCycleTimes.CYCLE;
 
-  var checkpointStart = Math.floor(now / (window.plugin.scoreCycleTimes.CHECKPOINT*1000)) * (window.plugin.scoreCycleTimes.CHECKPOINT*1000);
-  var checkpointEnd = checkpointStart + window.plugin.scoreCycleTimes.CHECKPOINT*1000;
-
-  var o = new Intl.DateTimeFormat(window.plugin.scoreCycleTimes.localeTime, {
-    year: 'numeric', month: 'numeric', day: 'numeric',
-    hour: 'numeric',
-  });
-
-  var formatRow = function(label,time) {
-    var timeStr = o.format(new Date(time));
-    return '<tr><td>'+label+'</td><td>'+timeStr+'</td></tr>';
-  };
+  var checkpointStart = Math.floor(now / scoreCycleTimes.CHECKPOINT) * scoreCycleTimes.CHECKPOINT;
+  var checkpointEnd = checkpointStart + scoreCycleTimes.CHECKPOINT;
 
   var html = '<table>'
-           + formatRow('Cycle start', cycleStart)
-           + formatRow('Previous checkpoint', checkpointStart)
-           + formatRow('Next checkpoint', checkpointEnd)
-           + formatRow('Cycle end', cycleEnd)
-           + '</table>';
+    + scoreCycleTimes.formatRow('Cycle start', cycleStart)
+    + scoreCycleTimes.formatRow('Previous checkpoint', checkpointStart)
+    + scoreCycleTimes.formatRow('Next checkpoint', checkpointEnd)
+    + scoreCycleTimes.formatRow('Cycle end', cycleEnd)
+    + '</table>';
 
   $('#score_cycle_times_display').html(html);
 
-  setTimeout ( window.plugin.scoreCycleTimes.update, checkpointEnd-now);
+  setTimeout(scoreCycleTimes.update, checkpointEnd-now);
 };
 
+function setup () {
+  $('#sidebar').append('<div id="score_cycle_times_display"></div>');
+  $('<style>')
+    .html('#score_cycle_times_display { color: #ffce00; }')
+    .appendTo('head');
 
-var setup =  window.plugin.scoreCycleTimes.setup;
+  scoreCycleTimes.update();
+}

--- a/plugins/score-cycle-times.js
+++ b/plugins/score-cycle-times.js
@@ -42,8 +42,8 @@ window.plugin.scoreCycleTimes.update = function() {
 
 
   var formatRow = function(label,time) {
-    var timeStr = unixTimeToString(time,true);
-    timeStr = timeStr.replace(/:00$/,''); //FIXME: doesn't remove seconds from AM/PM formatted dates
+    var timeStr = unixTimeToDateTimeString(time,false);
+    timeStr = timeStr.replace(/:00$/,''); 
 
     return '<tr><td>'+label+'</td><td>'+timeStr+'</td></tr>';
   };


### PR DESCRIPTION
- `score-cycle-times`: for cycle times
  Settings:
  + `window.plugin.scoreCycleTimes.locale`
  + `window.plugin.scoreCycleTimes.dateTimeFormat`
- `player-activity-tracker`: time in search
  Settings:
  + `window.plugin.playerTracker.locale`
  + `window.plugin.playerTracker.dateTimeFormat`

Note: started here: https://github.com/IITC-CE/ingress-intel-total-conversion/commit/e92dd96334bc490a759876ed6b2aed739f8f365a#commitcomment-42962123