### PR TITLE
Redirect to https if user still uses old http

### DIFF
--- a/buildsettings.py
+++ b/buildsettings.py
@@ -22,7 +22,7 @@ defaults = {  # common for all build targets
 
     # these settings should not be touched unless intel url(s) changed
     'url_intel_base': 'https://intel.ingress.com/',
-    'match': 'https://intel.ingress.com/*',
+    'match': '*://intel.ingress.com/*',
 
     'plugin_wrapper': 'pluginwrapper', # use wrapper from pluginwrapper.py
 

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -13,6 +13,11 @@ if (document.documentElement.getAttribute('itemscope') !== null) {
 }
 window.iitcBuildDate = '@build_date@';
 
+// force https
+if (location.protocol !== 'https:') {
+  location.replace('https:' + location.href.substring(location.protocol.length));
+}
+
 // disable vanilla JS
 window.onload = function() {};
 document.body.onload = function() {};


### PR DESCRIPTION
Force HTTPS protocol.

There are still users out there using the outdated http page (or maybe scripts generating old links?)
Additional Nia removed the redirect from http to https awhile ago.