### PR TITLE
Update targetSdkVersion to 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ android:
   components:
   - platform-tools
   - tools
-  - build-tools-28.0.3
-  - android-28
+  - build-tools-29.0.3
+  - android-29
   - extra-android-m2repository
 
 addons:

--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -17,13 +17,13 @@ def getVersionCodeTimeStamps = { ->
 }
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion = '28.0.3'
+    compileSdkVersion 29
+    buildToolsVersion = '29.0.3'
 
     defaultConfig {
         applicationId "org.exarhteam.iitc_mobile"
         minSdkVersion 17
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode = getVersionCodeTimeStamps()
         versionName "0.30.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_iitcm"
         android:label="@string/app_name"
+        android:requestLegacyExternalStorage="true"
         android:theme="@style/AppBaseTheme">
         <activity android:name="org.exarhteam.iitc_mobile.IntroActivity"
             android:label="app_intro" />


### PR DESCRIPTION
The new requirements for applications on Google Play require an API level of at least 29. This does not affect support of older devices (`minSdkVersion` is used to specify the minimum supported API).

The `requestLegacyExternalStorage` parameter is used to support legacy file system access. To drop this parameter and upgrade to API level 30 requires reworking file system access (more details https://developer.android.com/about/versions/11/privacy/storage)