### PR TITLE
fix: chat is between sidebar and sidebar toggle

### DIFF
--- a/core/code/boot.js
+++ b/core/code/boot.js
@@ -418,12 +418,12 @@ window.setupSidebarToggle = function() {
     var toggle = $('#sidebartoggle');
     var sidebar = $('#scrollwrapper');
     if(sidebar.is(':visible')) {
-      sidebar.hide().css('z-index', 1);
+      sidebar.hide();
       $('.leaflet-right').css('margin-right','0');
       toggle.html('<span class="toggle open"></span>');
       toggle.css('right', '0');
     } else {
-      sidebar.css('z-index', 1001).show();
+      sidebar.show();
       window.resetScrollOnNewPortal();
       $('.leaflet-right').css('margin-right', SIDEBAR_WIDTH+1+'px');
       toggle.html('<span class="toggle close"></span>');

--- a/core/style.css
+++ b/core/style.css
@@ -64,7 +64,7 @@ i.large { font-size: 6rem; }
   top: 0;
   width: 340px;
   bottom: 45px;
-  z-index: 1001;
+  z-index: 3001;
   pointer-events: none;
 }
 
@@ -78,7 +78,6 @@ i.large { font-size: 6rem; }
   max-height: 100%;
   overflow-y:scroll;
   overflow-x:hidden;
-  z-index: 3000;
   pointer-events: auto;
 }
 
@@ -89,7 +88,7 @@ i.large { font-size: 6rem; }
   line-height: 10px;
   position: absolute;
   top: 108px;
-  z-index: 3001;
+  z-index: 3002;
   background-color: rgba(8, 48, 78, 0.9);
   color: #FFCE00;
   border: 1px solid #20A8B1;


### PR DESCRIPTION
fix #363 

- leave CSS handles z-index (so it can be redefined, no inline)
- order div as chat below sidebar below sidebartoggle

old commit f3bcc3ef0327104ef2d368ec004306f98555a7b1 suggests to test against chrome

> - Bugfix: sidebar not visible in Chrome
> - Bugfix: layer chooser not usable if sidebar collapsed

second lgtm