### PR TITLE
privacy-plugin: fix privacy control in expanded chat

### DIFF
--- a/core/code/chat.js
+++ b/core/code/chat.js
@@ -521,19 +521,17 @@ window.chat.tabToChannel = function(tab) {
 window.chat.toggle = function() {
   var c = $('#chat, #chatcontrols');
   if(c.hasClass('expand')) {
-    $('#chatcontrols a:first').html('<span class="toggle expand"></span>');
     c.removeClass('expand');
     var div = $('#chat > div:visible');
     div.data('ignoreNextScroll', true);
     div.scrollTop(99999999); // scroll to bottom
     $('.leaflet-control').css('margin-left', '13px');
   } else {
-    $('#chatcontrols a:first').html('<span class="toggle shrink"></span>');
     c.addClass('expand');
     $('.leaflet-control').css('margin-left', '720px');
     chat.needMoreMessages();
   }
-}
+};
 
 
 // called by plugins (or other things?) that need to monitor COMM data streams when the user is not viewing them

--- a/core/code/chat.js
+++ b/core/code/chat.js
@@ -525,10 +525,10 @@ window.chat.toggle = function() {
     var div = $('#chat > div:visible');
     div.data('ignoreNextScroll', true);
     div.scrollTop(99999999); // scroll to bottom
-    $('.leaflet-control').css('margin-left', '13px');
+    $('.leaflet-control').removeClass('chat-expand');
   } else {
     c.addClass('expand');
-    $('.leaflet-control').css('margin-left', '720px');
+    $('.leaflet-control').addClass('chat-expand');
     chat.needMoreMessages();
   }
 };

--- a/core/style.css
+++ b/core/style.css
@@ -156,6 +156,10 @@ a:hover {
   margin-bottom: 0 !important;
 }
 
+/* shift controls when chat is expanded */
+.leaflet-left .leaflet-control.chat-expand {
+  margin-left: 720px;
+}
 
 .help {
   cursor: help;
@@ -1248,7 +1252,7 @@ table.artifact .portal {
 
 /* prevent nonfunctional horizontal scrollbar in Chrome (perhaps jQuery issue) */
 .cellscore .historychart > div {
-  overflow: auto; 
+  overflow: auto;
 }
 
 .cellscore .logscale {

--- a/core/style.css
+++ b/core/style.css
@@ -226,15 +226,13 @@ a:hover {
 #chatcontrols .toggle {
   border-left: 10px solid transparent;
   border-right: 10px solid transparent;
+  border-bottom: 10px solid #FFCE00;
   margin: 6px auto auto;
 }
 
-#chatcontrols .expand {
-  border-bottom: 10px solid #FFCE00;
-}
-
-#chatcontrols .shrink {
+#chatcontrols.expand .toggle {
   border-top: 10px solid #FFCE00;
+  border-bottom: none;
 }
 
 #chatcontrols .loading {

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -59,7 +59,7 @@ document.body = document.createElement('body');
 document.body.innerHTML = ''
   + '<div id="map">Loading, please wait</div>'
   + '<div id="chatcontrols" style="display:none">'
-  + '<a accesskey="0" title="[0]"><span class="toggle expand"></span></a>'
+  + '<a accesskey="0" title="[0]"><span class="toggle"></span></a>'
   + '<a accesskey="1" title="[1]">all</a>'
   + '<a accesskey="2" title="[2]" class="active">faction</a>'
   + '<a accesskey="3" title="[3]">alerts</a>'

--- a/plugins/privacy-view.js
+++ b/plugins/privacy-view.js
@@ -17,7 +17,7 @@ function setup () {
       '.privacy_active #chatinput,' +
       '.privacy_active #chatcontrols > a:not(#privacytoggle),' +
       '.privacy_active #chat { display: none; }' +
-      '.privacy_active #chatcontrols { bottom: 0; }')
+      '.privacy_active #chatcontrols { bottom: 0; top: auto }')
     .appendTo('head');
 
   var ctrl = $('<a id="privacytoggle" accesskey="9">')

--- a/plugins/privacy-view.js
+++ b/plugins/privacy-view.js
@@ -17,7 +17,8 @@ function setup () {
       '.privacy_active #chatinput,' +
       '.privacy_active #chatcontrols > a:not(#privacytoggle),' +
       '.privacy_active #chat { display: none; }' +
-      '.privacy_active #chatcontrols { bottom: 0; top: auto }')
+      '.privacy_active #chatcontrols { bottom: 0; top: auto }' +
+      '.privacy_active .leaflet-left .leaflet-control {margin-left: 10px}')
     .appendTo('head');
 
   var ctrl = $('<a id="privacytoggle" accesskey="9">')


### PR DESCRIPTION
fix #426 

also, use #chatcontrol class and css to control the chat toggle shape without changing the toggle class.