### PR TITLE
Draw-Functions

### DIFF
--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -90,7 +90,7 @@ window.plugin.drawTools.fireDraw = function(layer, layerType) {
 /**
  * Create a polyline
  * @param arrCoordArr Array of coordinates
- * @param {string=] color (optional)
+ * @param {string=} color (optional)
  */
 window.plugin.drawTools.drawPolyline = function(arrCoordArr, color) {
   if (color !== undefined) {
@@ -113,7 +113,7 @@ window.plugin.drawTools.drawPolyline = function(arrCoordArr, color) {
 /**
  * Create a polygon
  * @param arrCoordArr Array of coordinates
- * @param {string=] color (optional)
+ * @param {string=} color (optional)
  */
 window.plugin.drawTools.drawPolygon = function(arrCoordArr, color) {
   if (color !== undefined) {
@@ -137,7 +137,7 @@ window.plugin.drawTools.drawPolygon = function(arrCoordArr, color) {
  * Create a marker
  * @param coord coordinates [LatE6, LonE6]
  * @param radius (in meters)
- * @param {string=] color (optional)
+ * @param {string=} color (optional)
  */
 window.plugin.drawTools.drawCircle = function(coord, radius, color) {
   if (color !== undefined) {
@@ -160,7 +160,7 @@ window.plugin.drawTools.drawCircle = function(coord, radius, color) {
 /**
  * Create a marker
  * @param coord coordinates (LatE6, LonE6)
- * @param {string=] color (optional)
+ * @param {string=} color (optional)
  */
 window.plugin.drawTools.drawMarker = function(coord, color) {
   if (color !== undefined) {

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -78,14 +78,8 @@ window.plugin.drawTools.setDrawColor = function(color) {
 }
 
 // Easy create a draw from an IITC-plugin, allow passing an optional color parameter
-  /*
-  // "color" is optional
-  window.plugin.drawTools.drawPolyline(arrCoordArr, color);
-  window.plugin.drawTools.drawPolygon(arrCoordArr, color);
-  window.plugin.drawTools.drawCircle(coord, radius, color);
-  window.plugin.drawTools.drawMarker(coord, color);
-  */
 
+// common function used by folloing functions to trigger display on new drawn item
 window.plugin.drawTools.fireDraw = function(layer, layerType) {
   map.fire('draw:created', {
     layer: layer,
@@ -93,6 +87,11 @@ window.plugin.drawTools.fireDraw = function(layer, layerType) {
   });
 }
 
+/**
+ * Create a polyline
+ * @param arrCoordArr Array of coordinates
+ * @param {string=] color (optional)
+ */
 window.plugin.drawTools.drawPolyline = function(arrCoordArr, color) {
   if (color !== undefined) {
     var oldColor = window.plugin.drawTools.currentColor;
@@ -109,7 +108,13 @@ window.plugin.drawTools.drawPolyline = function(arrCoordArr, color) {
   }
 
   return layer;
-}
+};
+
+/**
+ * Create a polygon
+ * @param arrCoordArr Array of coordinates
+ * @param {string=] color (optional)
+ */
 window.plugin.drawTools.drawPolygon = function(arrCoordArr, color) {
   if (color !== undefined) {
     var oldColor = window.plugin.drawTools.currentColor;
@@ -126,7 +131,14 @@ window.plugin.drawTools.drawPolygon = function(arrCoordArr, color) {
   }
 
   return layer;
-}
+};
+
+/**
+ * Create a marker
+ * @param coord coordinates [LatE6, LonE6]
+ * @param radius (in meters)
+ * @param {string=] color (optional)
+ */
 window.plugin.drawTools.drawCircle = function(coord, radius, color) {
   if (color !== undefined) {
     var oldColor = window.plugin.drawTools.currentColor;
@@ -143,7 +155,13 @@ window.plugin.drawTools.drawCircle = function(coord, radius, color) {
   }
 
   return layer;
-}
+};
+
+/**
+ * Create a marker
+ * @param coord coordinates (LatE6, LonE6)
+ * @param {string=] color (optional)
+ */
 window.plugin.drawTools.drawMarker = function(coord, color) {
   if (color !== undefined) {
     var oldColor = window.plugin.drawTools.currentColor;
@@ -160,7 +178,8 @@ window.plugin.drawTools.drawMarker = function(coord, color) {
   }
 
   return layer;
-}  
+};
+
 // renders the draw control buttons in the top left corner
 window.plugin.drawTools.addDrawControl = function() {
   var drawControl = new L.Control.Draw({

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -77,6 +77,90 @@ window.plugin.drawTools.setDrawColor = function(color) {
   });
 }
 
+// Easy create a draw from an IITC-plugin, allow passing an optional color parameter
+  /*
+  // "color" is optional
+  window.plugin.drawTools.drawPolyline(arrCoordArr, color);
+  window.plugin.drawTools.drawPolygon(arrCoordArr, color);
+  window.plugin.drawTools.drawCircle(coord, radius, color);
+  window.plugin.drawTools.drawMarker(coord, color);
+  */
+
+window.plugin.drawTools.fireDraw = function(layer, layerType) {
+  map.fire('draw:created', {
+    layer: layer,
+    layerType: layerType
+  });
+}
+
+window.plugin.drawTools.drawPolyline = function(arrCoordArr, color) {
+  if (color !== undefined) {
+    var oldColor = window.plugin.drawTools.currentColor;
+    window.plugin.drawTools.setDrawColor(color);
+  }
+  var drawOpt = window.plugin.drawTools.lineOptions;
+
+  var layer = L.geodesicPolyline(arrCoordArr, drawOpt);
+  var layerType = 'polyline';
+  window.plugin.drawTools.fireDraw(layer, layerType);
+
+  if (color !== undefined) {
+    window.plugin.drawTools.setDrawColor(oldColor);
+  }
+
+  return layer;
+}
+window.plugin.drawTools.drawPolygon = function(arrCoordArr, color) {
+  if (color !== undefined) {
+    var oldColor = window.plugin.drawTools.currentColor;
+    window.plugin.drawTools.setDrawColor(color);
+  }
+  var drawOpt = window.plugin.drawTools.polygonOptions;
+
+  var layer = L.geodesicPolygon(arrCoordArr, drawOpt);
+  var layerType = 'polygon';
+  window.plugin.drawTools.fireDraw(layer, layerType);
+
+  if (color !== undefined) {
+    window.plugin.drawTools.setDrawColor(oldColor);
+  }
+
+  return layer;
+}
+window.plugin.drawTools.drawCircle = function(coord, radius, color) {
+  if (color !== undefined) {
+    var oldColor = window.plugin.drawTools.currentColor;
+    window.plugin.drawTools.setDrawColor(color);
+  }
+  var drawOpt = window.plugin.drawTools.polygonOptions;
+
+  var layer = L.geodesicCircle(coord, radius, drawOpt);
+  var layerType = 'circle';
+  window.plugin.drawTools.fireDraw(layer, layerType);
+
+  if (color !== undefined) {
+    window.plugin.drawTools.setDrawColor(oldColor);
+  }
+
+  return layer;
+}
+window.plugin.drawTools.drawMarker = function(coord, color) {
+  if (color !== undefined) {
+    var oldColor = window.plugin.drawTools.currentColor;
+    window.plugin.drawTools.setDrawColor(color);
+  }
+  var drawOpt = window.plugin.drawTools.markerOptions;
+
+  var layer = L.marker(coord, drawOpt);
+  var layerType = 'marker';
+  window.plugin.drawTools.fireDraw(layer, layerType);
+
+  if (color !== undefined) {
+    window.plugin.drawTools.setDrawColor(oldColor);
+  }
+
+  return layer;
+}  
 // renders the draw control buttons in the top left corner
 window.plugin.drawTools.addDrawControl = function() {
   var drawControl = new L.Control.Draw({


### PR DESCRIPTION
Draw-Tools:  

(Migrating additional functions from DrawTools plus.)
These functions add a convenient and easy to use way to directly create a draw, using IITCs standard parameter and settings from a dialog or script. An optional color-parameter can be used, otherwise the currently active color will be used. Passing a color will not change the selected color.

  window.plugin.drawTools.drawPolyline(arrCoordArr[, color]);
  window.plugin.drawTools.drawPolygon(arrCoordArr[, color]);
  window.plugin.drawTools.drawCircle(coord, radius[, color]);
  window.plugin.drawTools.drawMarker(coord[, color]);
  
  coord := [LatE6,LonE6]
  arrCoordArr : [coord, coord]  e.g.  `var arrCoordArr = [[42.447585,13.285419],[41.692902,13.418577]];`

Plugins using these functions: Destroyed Links Simulator, Link Prolongation