### PR TITLE
fix gps orientation side effect

### DIFF
--- a/mobile/plugins/user-location.js
+++ b/mobile/plugins/user-location.js
@@ -132,6 +132,8 @@ window.plugin.userLocation.onOrientationChange = function(direction) {
 
   window.plugin.userLocation.user.direction = direction;
 
+  if (!window.plugin.userLocation.marker._icon) return;
+  
   var container = $(".container", window.plugin.userLocation.marker._icon);
 
   if(direction === null) {


### PR DESCRIPTION
when gps orientation is enabled in iitc android configuration but user location layer is disabled (from layer menu), iitc rotates all html elements with classname `container`.