### PR TITLE
Permanent portal entities

### DIFF
--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -345,6 +345,13 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
   } else {
     marker = createMarker(latlng, data);
 
+    // in case of incomplete data while having fresh details in cache, update the portal with those details
+    if (portalDetail.isFresh(guid)) {
+      var oldDetails = portalDetail.get(guid);
+      if (marker.willUpdate(oldDetails))
+        marker.updateDetails(oldDetails);
+    }
+
     window.runHooks('portalAdded', {portal: marker});
 
     window.portals[data.guid] = marker;

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -286,34 +286,6 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
   var data = decodeArray.portal(ent[2], details);
   var guid = ent[0];
 
-  // check if entity already exists
-  var oldPortal = guid in window.portals;
-
-  if (oldPortal) {
-    // yes. now check to see if the entity data we have is newer than that in place
-    var p = window.portals[guid];
-
-    if (!data.history || p.options.data.history === data.history) {
-      if (p.options.timestamp > ent[1]) {
-        return p; // this data is older - abort processing
-      }
-
-      if (p.options.timestamp == ent[1] && p.hasFullDetails()) // this data is identical - abort processing
-        return p;
-    }
-
-    // the data we have is newer. many data changes require re-rendering of the portal
-    // (e.g. level changed, so size is different, or stats changed so highlighter is different)
-
-    // remember the old details, for the callback
-    previousData = p.getDetails();
-
-    // preserve history
-    if (!data.history) {
-      data.history = previousData.history;
-    }
-  }
-
   // add missing fields
   data.guid = guid;
   if (!data.timestamp)
@@ -321,6 +293,25 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
 
   // LEGACY - TO BE REMOVED AT SOME POINT! use .guid, .timestamp and .data instead
   data.ent = ent;
+
+  // check if entity already exists
+  var oldPortal = guid in window.portals;
+
+  if (oldPortal) {
+    // yes. now check to see if the entity data we have is newer than that in place
+    var p = window.portals[guid];
+
+    if (!p.willUpdate(data)) {
+      // this data doesn't bring new detail - abort processing
+      return p;
+    }
+
+    // the data we have is newer. many data changes require re-rendering of the portal
+    // (e.g. level changed, so size is different, or stats changed so highlighter is different)
+
+    // remember the old details, for the callback
+    previousData = $.extend(true, {}, p.getDetails());
+  }
 
   var latlng = L.latLng(data.latE6/1E6, data.lngE6/1E6);
 

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -39,7 +39,9 @@ window.Render.prototype.clearPortalsOutsideBounds = function(bounds) {
     var p = portals[guid];
     // clear portals outside visible bounds - unless it's the selected portal, or it's relevant to artifacts
     if (!bounds.contains(p.getLatLng()) && guid !== selectedPortal && !artifact.isInterestingPortal(guid)) {
-      this.deletePortalEntity(guid);
+      // remove the marker as a layer first
+      // deletion will be done at endRenderPass
+      p.remove();
       count++;
     }
   }
@@ -294,6 +296,9 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
 
     if (!p.willUpdate(data)) {
       // this data doesn't bring new detail - abort processing
+      // re-add the portal to the relevant layer (does nothing if already in the correct layer)
+      // useful for portals outside the view
+      this.addPortalToMapLayer(p);
       return p;
     }
 
@@ -327,8 +332,6 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
   if (oldPortal) {
     // update marker style/highlight and layer
     marker = window.portals[data.guid];
-    // remove portal from its faction/level specific layer
-    this.removePortalFromMapLayer(marker);
 
     marker.updateDetails(data);
 

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -13,8 +13,6 @@ window.Render.prototype.startRenderPass = function(level,bounds) {
 
   this.deletedGuid = {};  // object - represents the set of all deleted game entity GUIDs seen in a render pass
 
-  this.visibleLinksFieldsAnchors = {};
-
   this.seenPortalsGuid = {};
   this.seenLinksGuid = {};
   this.seenFieldsGuid = {};
@@ -26,11 +24,11 @@ window.Render.prototype.startRenderPass = function(level,bounds) {
   // this will just avoid a few entity removals at start of render when they'll just be added again
   var paddedBounds = bounds.pad(0.1);
 
+  this.clearPortalsOutsideBounds(paddedBounds);
 
   this.clearLinksOutsideBounds(paddedBounds);
   this.clearFieldsOutsideBounds(paddedBounds);
 
-  this.clearPortalsOutsideBounds(paddedBounds);
 
   this.rescalePortalMarkers();
 }
@@ -40,7 +38,7 @@ window.Render.prototype.clearPortalsOutsideBounds = function(bounds) {
   for (var guid in window.portals) {
     var p = portals[guid];
     // clear portals outside visible bounds - unless it's the selected portal, or it's relevant to artifacts
-    if (!bounds.contains(p.getLatLng()) && guid !== selectedPortal && !this.visibleLinksFieldsAnchors[guid] && !artifact.isInterestingPortal(guid)) {
+    if (!bounds.contains(p.getLatLng()) && guid !== selectedPortal && !artifact.isInterestingPortal(guid)) {
       this.deletePortalEntity(guid);
       count++;
     }
@@ -60,9 +58,6 @@ window.Render.prototype.clearLinksOutsideBounds = function(bounds) {
     if (!bounds.intersects(linkBounds)) {
       this.deleteLinkEntity(guid);
       count++;
-    } else {
-      this.visibleLinksFieldsAnchors[l.options.data.oGuid] = true;
-      this.visibleLinksFieldsAnchors[l.options.data.dGuid] = true;
     }
   }
 }
@@ -80,10 +75,6 @@ window.Render.prototype.clearFieldsOutsideBounds = function(bounds) {
     if (!bounds.intersects(fieldBounds)) {
       this.deleteFieldEntity(guid);
       count++;
-    } else {
-      this.visibleLinksFieldsAnchors[f.options.data.points[0].guid] = true;
-      this.visibleLinksFieldsAnchors[f.options.data.points[1].guid] = true;
-      this.visibleLinksFieldsAnchors[f.options.data.points[2].guid] = true;
     }
   }
 }

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -170,11 +170,6 @@ window.Render.prototype.endRenderPass = function() {
   this.bringPortalsToFront();
 
   this.isRendering = false;
-
-  // re-select the selected portal, to re-render the side-bar. ensures that any data calculated from the map data is up to date
-  if (selectedPortal) {
-    renderPortalDetails (selectedPortal);
-  }
 }
 
 window.Render.prototype.bringPortalsToFront = function() {
@@ -362,12 +357,6 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
     window.runHooks('portalAdded', {portal: marker});
 
     window.portals[data.guid] = marker;
-  }
-
-  // (re-)select the portal, to refresh the sidebar on any changes
-  if (data.guid == selectedPortal) {
-    log.log('portal guid '+data.guid+' is the selected portal - re-rendering portal details');
-    renderPortalDetails (selectedPortal);
   }
 
   window.ornaments.addPortal(marker);

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -354,9 +354,7 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
     // remove portal from its faction/level specific layer
     this.removePortalFromMapLayer(marker);
 
-    $.extend(marker.options, dataOptions);
-
-    setMarkerStyle(marker, ent[0] == selectedPortal);
+    marker.updateData(dataOptions, ent[0] == selectedPortal);
 
     window.runHooks('portalAdded', {portal: marker, previousData: previousData});
   } else {

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -268,7 +268,7 @@ window.Render.prototype.createPlaceholderPortalEntity = function(guid,latE6,lngE
 
   this.createPortalEntity(ent, 'core'); // placeholder
 
-}
+};
 
 
 window.Render.prototype.createPortalEntity = function(ent, details) { // details expected in decodeArray.portal
@@ -281,8 +281,9 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
 
   // add missing fields
   data.guid = guid;
-  if (!data.timestamp)
+  if (!data.timestamp) {
     data.timestamp = ent[1];
+  }
 
   // LEGACY - TO BE REMOVED AT SOME POINT! use .guid, .timestamp and .data instead
   data.ent = ent;
@@ -321,7 +322,7 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
     urlPortal = data.guid;
     urlPortalLL = undefined;  // clear the URL parameter so it's not matched again
   }
-  if (urlPortal == data.guid) {
+  if (urlPortal === data.guid) {
     // URL-passed portal found via guid parameter - set it as the selected portal
     log.log('urlPortal GUID '+urlPortal+' found - selecting...');
     selectedPortal = data.guid;
@@ -345,25 +346,27 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
       if (data.timestamp > oldDetails.timestamp) {
         // data is more recent than the cached details so we remove them from the cache
         portalDetail.remove(guid);
-      } else if (marker.willUpdate(oldDetails))
+      } else if (marker.willUpdate(oldDetails)) {
         marker.updateDetails(oldDetails);
+      }
     }
 
     window.runHooks('portalAdded', {portal: marker});
 
     window.portals[data.guid] = marker;
 
-    if (selectedPortal === data.guid)
+    if (selectedPortal === data.guid) {
       marker.renderDetails();
+    }
   }
 
   window.ornaments.addPortal(marker);
 
-  //TODO? postpone adding to the map layer
+  // TODO? postpone adding to the map layer
   this.addPortalToMapLayer(marker);
 
   return marker;
-}
+};
 
 
 window.Render.prototype.createFieldEntity = function(ent) {

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -379,7 +379,7 @@ window.Render.prototype.createFieldEntity = function(ent) {
   //create placeholder portals for field corners. we already do links, but there are the odd case where this is useful
   for (var i=0; i<3; i++) {
     var p=data.points[i];
-    this.createPlaceholderPortalEntity(p.guid, p.latE6, p.lngE6, data.team, data.timestamp);
+    this.createPlaceholderPortalEntity(p.guid, p.latE6, p.lngE6, data.team, 0);
   }
 
   // check if entity already exists

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -359,26 +359,6 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
   } else {
     marker = createMarker(latlng, data);
 
-    function handler_portal_click (e) {
-      window.renderPortalDetails(e.target.options.guid);
-    }
-    function handler_portal_dblclick (e) {
-      window.renderPortalDetails(e.target.options.guid);
-      window.map.setView(e.target.getLatLng(), DEFAULT_ZOOM);
-    }
-    function handler_portal_contextmenu (e) {
-      window.renderPortalDetails(e.target.options.guid);
-      if (window.isSmartphone()) {
-        window.show('info');
-      } else if (!$('#scrollwrapper').is(':visible')) {
-        $('#sidebartoggle').click();
-      }
-    }
-
-    marker.on('click', handler_portal_click);
-    marker.on('dblclick', handler_portal_dblclick);
-    marker.on('contextmenu', handler_portal_contextmenu);
-
     window.runHooks('portalAdded', {portal: marker});
 
     window.portals[data.guid] = marker;

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -297,10 +297,14 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
     // yes. now check to see if the entity data we have is newer than that in place
     var p = window.portals[ent[0]];
 
-    if (!data.history || p.options.data.history === data.history)
-      if (p.options.timestamp >= ent[1]) {
-        return; // this data is identical or older - abort processing
+    if (!data.history || p.options.data.history === data.history) {
+      if (p.options.timestamp > ent[1]) {
+        return p; // this data is older - abort processing
       }
+
+      if (p.options.timestamp == ent[1] && p.hasDetails()) // this data is identical - abort processing
+        return p;
+    }
 
     // the data we have is newer. many data changes require re-rendering of the portal
     // (e.g. level changed, so size is different, or stats changed so highlighter is different)
@@ -395,6 +399,8 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
 
   //TODO? postpone adding to the map layer
   this.addPortalToMapLayer(marker);
+
+  return marker;
 }
 
 

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -348,7 +348,10 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
     // in case of incomplete data while having fresh details in cache, update the portal with those details
     if (portalDetail.isFresh(guid)) {
       var oldDetails = portalDetail.get(guid);
-      if (marker.willUpdate(oldDetails))
+      if (data.timestamp > oldDetails.timestamp) {
+        // data is more recent than the cached details so we remove them from the cache
+        portalDetail.remove(guid);
+      } else if (marker.willUpdate(oldDetails))
         marker.updateDetails(oldDetails);
     }
 

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -349,6 +349,9 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
     window.runHooks('portalAdded', {portal: marker});
 
     window.portals[data.guid] = marker;
+
+    if (selectedPortal === data.guid)
+      marker.renderDetails();
   }
 
   window.ornaments.addPortal(marker);

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -289,20 +289,21 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
   var previousData = undefined;
 
   var data = decodeArray.portal(ent[2], details);
+  var guid = ent[0];
 
   // check if entity already exists
-  var oldPortal = ent[0] in window.portals;
+  var oldPortal = guid in window.portals;
 
   if (oldPortal) {
     // yes. now check to see if the entity data we have is newer than that in place
-    var p = window.portals[ent[0]];
+    var p = window.portals[guid];
 
     if (!data.history || p.options.data.history === data.history) {
       if (p.options.timestamp > ent[1]) {
         return p; // this data is older - abort processing
       }
 
-      if (p.options.timestamp == ent[1] && p.hasDetails()) // this data is identical - abort processing
+      if (p.options.timestamp == ent[1] && p.hasFullDetails()) // this data is identical - abort processing
         return p;
     }
 
@@ -310,7 +311,7 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
     // (e.g. level changed, so size is different, or stats changed so highlighter is different)
 
     // remember the old details, for the callback
-    previousData = p.options.data;
+    previousData = p.getDetails();
 
     // preserve history
     if (!data.history) {
@@ -318,51 +319,45 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
     }
   }
 
-  var portalLevel = parseInt(data.level)||0;
-  var team = teamStringToId(data.team);
-  // the data returns unclaimed portals as level 1 - but IITC wants them treated as level 0
-  if (team == TEAM_NONE) portalLevel = 0;
+  // add missing fields
+  data.guid = guid;
+  if (!data.timestamp)
+    data.timestamp = ent[1];
+
+  // LEGACY - TO BE REMOVED AT SOME POINT! use .guid, .timestamp and .data instead
+  data.ent = ent;
 
   var latlng = L.latLng(data.latE6/1E6, data.lngE6/1E6);
 
-  var dataOptions = {
-    level: portalLevel,
-    team: team,
-    ent: ent,  // LEGACY - TO BE REMOVED AT SOME POINT! use .guid, .timestamp and .data instead
-    guid: ent[0],
-    timestamp: ent[1],
-    data: data,
-  };
-
-  window.pushPortalGuidPositionCache(ent[0], data.latE6, data.lngE6);
+  window.pushPortalGuidPositionCache(data.guid, data.latE6, data.lngE6);
 
   // check for URL links to portal, and select it if this is the one
   if (urlPortalLL && urlPortalLL[0] == latlng.lat && urlPortalLL[1] == latlng.lng) {
     // URL-passed portal found via pll parameter - set the guid-based parameter
-    log.log('urlPortalLL '+urlPortalLL[0]+','+urlPortalLL[1]+' matches portal GUID '+ent[0]);
+    log.log('urlPortalLL '+urlPortalLL[0]+','+urlPortalLL[1]+' matches portal GUID '+data.guid);
 
-    urlPortal = ent[0];
+    urlPortal = data.guid;
     urlPortalLL = undefined;  // clear the URL parameter so it's not matched again
   }
-  if (urlPortal == ent[0]) {
+  if (urlPortal == data.guid) {
     // URL-passed portal found via guid parameter - set it as the selected portal
     log.log('urlPortal GUID '+urlPortal+' found - selecting...');
-    selectedPortal = ent[0];
+    selectedPortal = data.guid;
     urlPortal = undefined;  // clear the URL parameter so it's not matched again
   }
 
   var marker = undefined;
   if (oldPortal) {
     // update marker style/highlight and layer
-    marker = window.portals[ent[0]];
+    marker = window.portals[data.guid];
     // remove portal from its faction/level specific layer
     this.removePortalFromMapLayer(marker);
 
-    marker.updateData(dataOptions, ent[0] == selectedPortal);
+    marker.updateDetails(data);
 
     window.runHooks('portalAdded', {portal: marker, previousData: previousData});
   } else {
-    marker = createMarker(latlng, dataOptions);
+    marker = createMarker(latlng, data);
 
     function handler_portal_click (e) {
       window.renderPortalDetails(e.target.options.guid);
@@ -386,12 +381,12 @@ window.Render.prototype.createPortalEntity = function(ent, details) { // details
 
     window.runHooks('portalAdded', {portal: marker});
 
-    window.portals[ent[0]] = marker;
+    window.portals[data.guid] = marker;
   }
 
   // (re-)select the portal, to refresh the sidebar on any changes
-  if (ent[0] == selectedPortal) {
-    log.log('portal guid '+ent[0]+' is the selected portal - re-rendering portal details');
+  if (data.guid == selectedPortal) {
+    log.log('portal guid '+data.guid+' is the selected portal - re-rendering portal details');
     renderPortalDetails (selectedPortal);
   }
 

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -13,6 +13,8 @@ window.Render.prototype.startRenderPass = function(level,bounds) {
 
   this.deletedGuid = {};  // object - represents the set of all deleted game entity GUIDs seen in a render pass
 
+  this.visibleLinksFieldsAnchors = {};
+
   this.seenPortalsGuid = {};
   this.seenLinksGuid = {};
   this.seenFieldsGuid = {};
@@ -24,11 +26,11 @@ window.Render.prototype.startRenderPass = function(level,bounds) {
   // this will just avoid a few entity removals at start of render when they'll just be added again
   var paddedBounds = bounds.pad(0.1);
 
-  this.clearPortalsOutsideBounds(paddedBounds);
 
   this.clearLinksOutsideBounds(paddedBounds);
   this.clearFieldsOutsideBounds(paddedBounds);
 
+  this.clearPortalsOutsideBounds(paddedBounds);
 
   this.rescalePortalMarkers();
 }
@@ -38,7 +40,7 @@ window.Render.prototype.clearPortalsOutsideBounds = function(bounds) {
   for (var guid in window.portals) {
     var p = portals[guid];
     // clear portals outside visible bounds - unless it's the selected portal, or it's relevant to artifacts
-    if (!bounds.contains(p.getLatLng()) && guid !== selectedPortal && !artifact.isInterestingPortal(guid)) {
+    if (!bounds.contains(p.getLatLng()) && guid !== selectedPortal && !this.visibleLinksFieldsAnchors[guid] && !artifact.isInterestingPortal(guid)) {
       this.deletePortalEntity(guid);
       count++;
     }
@@ -58,6 +60,9 @@ window.Render.prototype.clearLinksOutsideBounds = function(bounds) {
     if (!bounds.intersects(linkBounds)) {
       this.deleteLinkEntity(guid);
       count++;
+    } else {
+      this.visibleLinksFieldsAnchors[l.options.data.oGuid] = true;
+      this.visibleLinksFieldsAnchors[l.options.data.dGuid] = true;
     }
   }
 }
@@ -75,6 +80,10 @@ window.Render.prototype.clearFieldsOutsideBounds = function(bounds) {
     if (!bounds.intersects(fieldBounds)) {
       this.deleteFieldEntity(guid);
       count++;
+    } else {
+      this.visibleLinksFieldsAnchors[f.options.data.points[0].guid] = true;
+      this.visibleLinksFieldsAnchors[f.options.data.points[1].guid] = true;
+      this.visibleLinksFieldsAnchors[f.options.data.points[2].guid] = true;
     }
   }
 }

--- a/core/code/map_data_request.js
+++ b/core/code/map_data_request.js
@@ -69,15 +69,6 @@ window.MapDataRequest = function() {
 
   // ensure we have some initial map status
   this.setStatus ('startup', undefined, -1);
-
-  // add a portalDetailLoaded hook, so we can use the extended details to update portals on the map
-  var _this = this;
-  addHook('portalDetailLoaded', function(data){
-    if(data.success) {
-      _this.render.createPortalEntity(data.ent, 'detailed');
-    }
-  });
-
 }
 
 

--- a/core/code/portal_detail.js
+++ b/core/code/portal_detail.js
@@ -25,6 +25,9 @@ window.portalDetail.isFresh = function(guid) {
   return cache.isFresh(guid);
 }
 
+window.portalDetail.remove = function(guid) {
+  return cache.remove(guid);
+}
 
 var handleResponse = function(deferred, guid, data, success) {
   if (!data || data.error || !data.result) {

--- a/core/code/portal_detail.js
+++ b/core/code/portal_detail.js
@@ -32,13 +32,11 @@ var handleResponse = function(deferred, guid, data, success) {
   }
 
   if (success) {
-
-    var dict = decodeArray.portal(data.result, 'detailed');
-
     // entity format, as used in map data
-    var ent = [guid,dict.timestamp,data.result];
+    var ent = [guid,data.result[13],data.result];
+    var portal = window.mapDataRequest.render.createPortalEntity(ent, 'detailed');
 
-    cache.store(guid,dict);
+    cache.store(guid,portal.options.data);
 
     //FIXME..? better way of handling sidebar refreshing...
 
@@ -46,8 +44,8 @@ var handleResponse = function(deferred, guid, data, success) {
       renderPortalDetails(guid);
     }
 
-    deferred.resolve(dict);
-    window.runHooks ('portalDetailLoaded', {guid:guid, success:success, details:dict, ent:ent});
+    deferred.resolve(portal.options.data);
+    window.runHooks ('portalDetailLoaded', {guid:guid, success:success, details:portal.options.data, ent:ent});
 
   } else {
     if (data && data.error == "RETRY") {

--- a/core/code/portal_detail.js
+++ b/core/code/portal_detail.js
@@ -38,12 +38,6 @@ var handleResponse = function(deferred, guid, data, success) {
 
     cache.store(guid,portal.options.data);
 
-    //FIXME..? better way of handling sidebar refreshing...
-
-    if (guid == selectedPortal) {
-      renderPortalDetails(guid);
-    }
-
     deferred.resolve(portal.options.data);
     window.runHooks ('portalDetailLoaded', {guid:guid, success:success, details:portal.options.data, ent:ent});
 

--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -53,7 +53,7 @@ window.renderPortalDetails = function(guid) {
 
   var portal = window.portals[guid];
   var data = portal.options.data;
-  var details = portalDetail.get(guid);
+  var details = portal.hasFullDetails() ? portal.getDetails() : null;
   var historyDetails = getPortalHistoryDetails(data);
 
   // details and data can get out of sync. if we have details, construct a matching 'data'
@@ -217,7 +217,7 @@ window.getPortalMiscDetails = function(guid,d) {
 
     if (d.artifactBrief && d.artifactBrief.target && Object.keys(d.artifactBrief.target).length > 0) {
       var targets = Object.keys(d.artifactBrief.target);
-//currently (2015-07-10) we no longer know the team each target portal is for - so we'll just show the artifact type(s) 
+//currently (2015-07-10) we no longer know the team each target portal is for - so we'll just show the artifact type(s)
        randDetails += '<div id="artifact_target">Target portal: '+targets.map(function(x) { return x.capitalize(); }).join(', ')+'</div>';
     }
 

--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -27,8 +27,8 @@ window.renderPortalUrl = function (lat, lng, title) {
   linkDetails.append($('<aside>').append(mapHtml));
 };
 
-window.renderPortalDetails = function(guid) {
-  selectPortal(window.portals[guid] ? guid : null);
+window.renderPortalDetails = function(guid, dontSelect) {
+  if (!dontSelect) selectPortal(window.portals[guid] ? guid : null, 'renderPortalDetails');
   if ($('#sidebar').is(':visible')) {
     window.resetScrollOnNewPortal();
     window.renderPortalDetails.lastVisible = guid;
@@ -274,7 +274,7 @@ window.setPortalIndicators = function(p) {
 // on old selection. Returns false if the selected portal changed.
 // Returns true if it's still the same portal that just needs an
 // update.
-window.selectPortal = function(guid) {
+window.selectPortal = function(guid, event) {
   var update = selectedPortal === guid;
   var oldPortalGuid = selectedPortal;
   selectedPortal = guid;
@@ -283,19 +283,13 @@ window.selectPortal = function(guid) {
   var newPortal = portals[guid];
 
   // Restore style of unselected portal
-  if(!update && oldPortal) setMarkerStyle(oldPortal,false);
+  if(!update && oldPortal) oldPortal.setSelected(false);
 
   // Change style of selected portal
-  if(newPortal) {
-    setMarkerStyle(newPortal, true);
-
-    if (map.hasLayer(newPortal)) {
-      newPortal.bringToFront();
-    }
-  }
+  if(newPortal) newPortal.setSelected(true);
 
   setPortalIndicators(newPortal);
 
-  runHooks('portalSelected', {selectedPortalGuid: guid, unselectedPortalGuid: oldPortalGuid});
+  runHooks('portalSelected', {selectedPortalGuid: guid, unselectedPortalGuid: oldPortalGuid, event: event});
   return update;
 }

--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -27,8 +27,9 @@ window.renderPortalUrl = function (lat, lng, title) {
   linkDetails.append($('<aside>').append(mapHtml));
 };
 
-window.renderPortalDetails = function(guid, dontSelect) {
-  if (!dontSelect) selectPortal(window.portals[guid] ? guid : null, 'renderPortalDetails');
+window.renderPortalDetails = function(guid, forceSelect) {
+  if (forceSelect || selectedPortal !== guid)
+    selectPortal(window.portals[guid] ? guid : null, 'renderPortalDetails');
   if ($('#sidebar').is(':visible')) {
     window.resetScrollOnNewPortal();
     window.renderPortalDetails.lastVisible = guid;
@@ -138,7 +139,7 @@ window.renderPortalDetails = function(guid, dontSelect) {
     );
 
   window.renderPortalUrl(lat, lng, title, guid);
-  
+
   // compatibility
   var data = hasFullDetails ? getPortalSummaryData(details) : details;
 

--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -27,9 +27,10 @@ window.renderPortalUrl = function (lat, lng, title) {
   linkDetails.append($('<aside>').append(mapHtml));
 };
 
-window.renderPortalDetails = function(guid, forceSelect) {
-  if (forceSelect || selectedPortal !== guid)
+window.renderPortalDetails = function (guid, forceSelect) {
+  if (forceSelect || selectedPortal !== guid) {
     selectPortal(window.portals[guid] ? guid : null, 'renderPortalDetails');
+  }
   if ($('#sidebar').is(':visible')) {
     window.resetScrollOnNewPortal();
     window.renderPortalDetails.lastVisible = guid;
@@ -57,21 +58,24 @@ window.renderPortalDetails = function(guid, forceSelect) {
   var hasFullDetails = portal.hasFullDetails();
   var historyDetails = getPortalHistoryDetails(details);
 
-  var modDetails = hasFullDetails ? '<div class="mods">'+getModDetails(details)+'</div>' : '';
-  var miscDetails = hasFullDetails ? getPortalMiscDetails(guid,details) : '';
+  var modDetails = hasFullDetails
+    ? '<div class="mods">' + getModDetails(details) + '</div>'
+    : '';
+  var miscDetails = hasFullDetails ? getPortalMiscDetails(guid, details) : '';
   var resoDetails = hasFullDetails ? getResonatorDetails(details) : '';
 
-//TODO? other status details...
-  var statusDetails = hasFullDetails ? '' : '<div id="portalStatus">Loading details...</div>';
+  // TODO? other status details...
+  var statusDetails = hasFullDetails
+    ? ''
+    : '<div id="portalStatus">Loading details...</div>';
 
   var img = fixPortalImageUrl(details.image);
   var title = details.title || 'null';
 
-  var lat = details.latE6/1E6;
-  var lng = details.lngE6/1E6;
+  var lat = details.latE6 / 1e6;
+  var lng = details.lngE6 / 1e6;
 
-  var imgTitle = title+'\n\nClick to show full image.';
-
+  var imgTitle = title + '\n\nClick to show full image.';
 
   // portal level. start with basic data - then extend with fractional info in tooltip if available
   var levelInt = portal.options.level;
@@ -272,7 +276,7 @@ window.setPortalIndicators = function(p) {
 // on old selection. Returns false if the selected portal changed.
 // Returns true if it's still the same portal that just needs an
 // update.
-window.selectPortal = function(guid, event) {
+window.selectPortal = function (guid, event) {
   var update = selectedPortal === guid;
   var oldPortalGuid = selectedPortal;
   selectedPortal = guid;
@@ -281,13 +285,17 @@ window.selectPortal = function(guid, event) {
   var newPortal = portals[guid];
 
   // Restore style of unselected portal
-  if(!update && oldPortal) oldPortal.setSelected(false);
+  if (!update && oldPortal) oldPortal.setSelected(false);
 
   // Change style of selected portal
-  if(newPortal) newPortal.setSelected(true);
+  if (newPortal) newPortal.setSelected(true);
 
   setPortalIndicators(newPortal);
 
-  runHooks('portalSelected', {selectedPortalGuid: guid, unselectedPortalGuid: oldPortalGuid, event: event});
+  runHooks('portalSelected', {
+    selectedPortalGuid: guid,
+    unselectedPortalGuid: oldPortalGuid,
+    event: event,
+  });
   return update;
-}
+};

--- a/core/code/portal_highlighter.js
+++ b/core/code/portal_highlighter.js
@@ -89,9 +89,8 @@ window.changePortalHighlights = function(name) {
 }
 
 window.highlightPortal = function(p) {
-  
   if(_highlighters !== null && _highlighters[_current_highlighter] !== undefined) {
-    _highlighters[_current_highlighter].highlight({portal: p});
+    return _highlighters[_current_highlighter].highlight({portal: p});
   }
 }
 

--- a/core/code/portal_info.js
+++ b/core/code/portal_info.js
@@ -38,6 +38,13 @@ window.getCurrentPortalEnergy = function(d) {
   return nrg;
 }
 
+window.getPortalHealth = function(d) {
+  var max = getTotalPortalEnergy(d);
+  var cur = getCurrentPortalEnergy(d);
+
+  return max>0 ? Math.floor(cur/max*100) : 0;
+}
+
 window.getPortalRange = function(d) {
   // formula by the great gals and guys at
   // http://decodeingress.me/2012/11/18/ingress-portal-levels-and-link-range/

--- a/core/code/portal_info.js
+++ b/core/code/portal_info.js
@@ -38,12 +38,12 @@ window.getCurrentPortalEnergy = function(d) {
   return nrg;
 }
 
-window.getPortalHealth = function(d) {
+window.getPortalHealth = function (d) {
   var max = getTotalPortalEnergy(d);
   var cur = getCurrentPortalEnergy(d);
 
-  return max>0 ? Math.floor(cur/max*100) : 0;
-}
+  return max > 0 ? Math.floor((cur / max) * 100) : 0;
+};
 
 window.getPortalRange = function(d) {
   // formula by the great gals and guys at

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -120,6 +120,22 @@ L.PortalMarker = L.CircleMarker.extend({
   hasFullDetails: function () {
     return !!this._details.mods
   },
+  setStyle: function (style) { // stub for highlighters
+    L.Util.setOptions(this, style);
+    return this;
+  },
+  setMarkerStyle: function (style) {
+    var styleOptions = L.Util.extend(this._style(), style);
+    L.Util.setOptions(this, styleOptions);
+
+    L.Util.setOptions(this, highlightPortal(this));
+
+    var selected = L.extend(
+      { radius: this.options.radius },
+      this._selected && { color: COLOR_SELECTED_PORTAL }
+    );
+    return L.CircleMarker.prototype.setStyle.call(this, selected);
+  },
   select: function (selected) {
     if (selected) {
       this.renderDetails();
@@ -127,18 +143,12 @@ L.PortalMarker = L.CircleMarker.extend({
     return this.reset(selected);
   },
   reset: function (selected) {
-    var styleOptions = this._style();
-    this.setStyle(styleOptions);
-
-    highlightPortal(this);
-
     if (selected === false)
       this._selected = false;
     else
       this._selected = this._selected || selected;
 
-    if (this._selected)
-      this.setStyle ({color: COLOR_SELECTED_PORTAL});
+    return this.setMarkerStyle();
   },
   _style: function () {
     var dashArray = null;

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -11,16 +11,16 @@ var portalBaseStyle = {
 // portal hooks
 function handler_portal_click (e) {
   window.selectPortal(e.target.options.guid, e.type);
-  window.renderPortalDetails(e.target.options.guid, true)
+  window.renderPortalDetails(e.target.options.guid)
 }
 function handler_portal_dblclick (e) {
   window.selectPortal(e.target.options.guid, e.type);
-  window.renderPortalDetails(e.target.options.guid, true)
+  window.renderPortalDetails(e.target.options.guid)
   window.map.setView(e.target.getLatLng(), DEFAULT_ZOOM);
 }
 function handler_portal_contextmenu (e) {
   window.selectPortal(e.target.options.guid, e.type);
-  window.renderPortalDetails(e.target.options.guid, true)
+  window.renderPortalDetails(e.target.options.guid)
   if (window.isSmartphone()) {
     window.show('info');
   } else if (!$('#scrollwrapper').is(':visible')) {
@@ -56,7 +56,7 @@ L.PortalMarker = L.CircleMarker.extend({
     if (this._details.timestamp < details.timestamp)
       return true;
     // current marker is a placeholder, and details is real data
-    if (this.isPlaceholder())
+    if (this.isPlaceholder() && this._details.team === details.team)
       return true;
     // even if we get history that was missing ? is it even possible ?
     if (this._details.timestamp > details.timestamp)
@@ -135,7 +135,7 @@ L.PortalMarker = L.CircleMarker.extend({
   renderDetails() {
     if (!this._rendering) {
       this._rendering = true;
-      renderPortalDetails(this._details.guid, true);
+      renderPortalDetails(this._details.guid);
       this._rendering = false;
     }
   },

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -61,7 +61,11 @@ L.PortalMarker = L.CircleMarker.extend({
       // in any other case
       return false;
     }
-    // new data
+    // more recent timestamp, this occurs when the data has changed because of:
+    //  - resonator deploy/upgrade
+    //  - mod deploy
+    //  - recharge/damage/decay
+    //  - portal edit (title, location, portal main picture)
     if (this._details.timestamp < details.timestamp)
       return true;
     // current marker is a placeholder, and details is real data
@@ -70,6 +74,8 @@ L.PortalMarker = L.CircleMarker.extend({
     // even if we get history that was missing ? is it even possible ?
     if (this._details.timestamp > details.timestamp)
       return false;
+
+    // this._details.timestamp === details.timestamp
 
     // get new history
     if (details.history) {

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -106,12 +106,12 @@ L.PortalMarker = L.CircleMarker.extend({
     L.setOptions(this, dataOptions);
 
     if (this._selected) {
-      this._renderDetails();
+      this.renderDetails();
     }
 
     this.setSelected();
   },
-  _renderDetails() {
+  renderDetails() {
     if (!this._rendering) {
       this._rendering = true;
       renderPortalDetails(this._details.guid, true);

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -10,7 +10,7 @@ L.PortalMarker = L.CircleMarker.extend({
 
     L.CircleMarker.prototype.initialize.call(this, latlng, options);
 
-    highlightPortal(this)
+    highlightPortal(this);
   },
   updateData: function(data) {
     var styleOptions = window.getMarkerStyleOptions(data);
@@ -18,8 +18,9 @@ L.PortalMarker = L.CircleMarker.extend({
     L.setOptions(this, options);
 
     this.setStyle(styleOptions);
+    thighlightPortal(this);
   },
-  select: function (selected) {
+  reset: function (selected) {
     var styleOptions = window.getMarkerStyleOptions(this.options);
     this.setStyle(styleOptions);
 
@@ -46,7 +47,7 @@ window.createMarker = function(latlng, data) {
 
 
 window.setMarkerStyle = function(marker, selected) {
-  marker.select(selected);
+  marker.reset(selected);
 }
 
 

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -37,6 +37,10 @@ L.PortalMarker = L.CircleMarker.extend({
     this.on('contextmenu', handler_portal_contextmenu);
   },
   updateDetails: function(details) {
+    // portal has been moved
+    if (this._details.latE6 !== details.latE6 || this._details.lngE6 !== details.lngE6)
+      this.setLatLng(L.latLng(details.latE6/1E6, details.lngE6/1E6));
+
     // xxx: handle permanent data
     this._details = details;
 

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -10,14 +10,15 @@ var portalBaseStyle = {
 
 // portal hooks
 function handler_portal_click (e) {
-  e.target.select(true);
+  window.selectPortal(e.target.options.guid, e.type);
+  window.renderPortalDetails(e.target.options.guid, true)
 }
 function handler_portal_dblclick (e) {
-  e.target.select(true);
+  handler_portal_click(e);
   window.map.setView(e.target.getLatLng(), DEFAULT_ZOOM);
 }
 function handler_portal_contextmenu (e) {
-  e.target.select(true);
+  handler_portal_click(e);
   if (window.isSmartphone()) {
     window.show('info');
   } else if (!$('#scrollwrapper').is(':visible')) {
@@ -102,15 +103,15 @@ L.PortalMarker = L.CircleMarker.extend({
     L.setOptions(this, dataOptions);
 
     if (this._selected) {
-      this.renderDetails();
+      this._renderDetails();
     }
 
     this.reset();
   },
-  renderDetails() {
+  _renderDetails() {
     if (!this._rendering) {
       this._rendering = true;
-      renderPortalDetails(this._details.guid);
+      renderPortalDetails(this._details.guid, true);
       this._rendering = false;
     }
   },
@@ -136,10 +137,7 @@ L.PortalMarker = L.CircleMarker.extend({
     );
     return L.CircleMarker.prototype.setStyle.call(this, selected);
   },
-  select: function (selected) {
-    if (selected) {
-      this.renderDetails();
-    }
+  setSelected: function (selected) {
     return this.reset(selected);
   },
   reset: function (selected) {
@@ -148,7 +146,10 @@ L.PortalMarker = L.CircleMarker.extend({
     else
       this._selected = this._selected || selected;
 
-    return this.setMarkerStyle();
+    this.setMarkerStyle();
+
+    if (this._selected && window.map.hasLayer(this))
+      this.bringToFront();
   },
   _style: function () {
     var dashArray = null;
@@ -200,7 +201,7 @@ window.createMarker = function(latlng, data) {
 
 
 window.setMarkerStyle = function(marker, selected) {
-  marker.select(selected);
+  marker.setSelected(selected);
 }
 
 

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -94,9 +94,9 @@ L.PortalMarker = L.CircleMarker.extend({
           this._details = details;
         }
       } else if (this._details.timestamp == details.timestamp) {
-        // we got more details
+        // we got more details (core/summary -> summary/detailed/extended)
         var localThis = this;
-        ["mods", "resonators", "owner", "artifactDetail"].forEach(function (prop) {
+        ["level", "health", "resCount", "image", "title", "ornaments", "mission", "mission50plus", "artifactBrief", "mods", "resonators", "owner", "artifactDetail"].forEach(function (prop) {
           if (details[prop]) localThis._details[prop] = details[prop];
         });
         // smarter update for history (cause it's missing sometimes)

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -30,6 +30,9 @@ L.PortalMarker = L.CircleMarker.extend({
 
     this.reset(selected);
   },
+  hasDetails: function () {
+    return !!this.options.data.mods
+  },
   reset: function (selected) {
     var styleOptions = this._style();
     this.setStyle(styleOptions);

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -74,7 +74,6 @@ L.PortalMarker = L.CircleMarker.extend({
     if (!this._details.mods && details.mods)
       return true;
 
-    // does portal picture/name/location modfication update the timestamp ?
     return false;
   },
   updateDetails: function(details) {

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -10,14 +10,14 @@ var portalBaseStyle = {
 
 // portal hooks
 function handler_portal_click (e) {
-  window.renderPortalDetails(e.target.options.guid);
+  e.target.select(true);
 }
 function handler_portal_dblclick (e) {
-  window.renderPortalDetails(e.target.options.guid);
+  e.target.select(true);
   window.map.setView(e.target.getLatLng(), DEFAULT_ZOOM);
 }
 function handler_portal_contextmenu (e) {
-  window.renderPortalDetails(e.target.options.guid);
+  e.target.select(true);
   if (window.isSmartphone()) {
     window.show('info');
   } else if (!$('#scrollwrapper').is(':visible')) {
@@ -38,8 +38,9 @@ L.PortalMarker = L.CircleMarker.extend({
   },
   updateDetails: function(details) {
     // portal has been moved
-    if (this._details.latE6 !== details.latE6 || this._details.lngE6 !== details.lngE6)
-      this.setLatLng(L.latLng(details.latE6/1E6, details.lngE6/1E6));
+    if (this.details)
+      if (this._details.latE6 !== details.latE6 || this._details.lngE6 !== details.lngE6)
+        this.setLatLng(L.latLng(details.latE6/1E6, details.lngE6/1E6));
 
     // xxx: handle permanent data
     this._details = details;
@@ -61,13 +62,30 @@ L.PortalMarker = L.CircleMarker.extend({
     };
     L.setOptions(this, dataOptions);
 
+    if (this._selected) {
+      this.renderDetails();
+    }
+
     this.reset();
+  },
+  renderDetails() {
+    if (!this._rendering) {
+      this._rendering = true;
+      renderPortalDetails(this._details.guid);
+      this._rendering = false;
+    }
   },
   getDetails: function () {
     return this._details;
   },
   hasFullDetails: function () {
     return !!this._details.mods
+  },
+  select: function (selected) {
+    if (selected) {
+      this.renderDetails();
+    }
+    return this.reset(selected);
   },
   reset: function (selected) {
     var styleOptions = this._style();
@@ -133,7 +151,7 @@ window.createMarker = function(latlng, data) {
 
 
 window.setMarkerStyle = function(marker, selected) {
-  marker.reset(selected);
+  marker.select(selected);
 }
 
 

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -88,8 +88,8 @@ L.PortalMarker = L.CircleMarker.extend({
       }
     } else this._details = details;
 
-    this._level = parseInt(details.level)||0;
-    this._team = teamStringToId(details.team);
+    this._level = parseInt(this._details.level)||0;
+    this._team = teamStringToId(this._details.team);
 
     // the data returns unclaimed portals as level 1 - but IITC wants them treated as level 0
     if (this._team == TEAM_NONE) this._level = 0;

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -189,7 +189,7 @@ L.PortalMarker = L.CircleMarker.extend({
   _style: function () {
     var dashArray = null;
     // dashed outline for placeholder portals
-    if (this._team != TEAM_NONE && this._level==0) dashArray = '1,2';
+    if (this.isPlaceholder()) dashArray = '1,2';
 
     return L.extend(this._scale(), portalBaseStyle, {
       color: COLORS[this._team],
@@ -210,7 +210,7 @@ L.PortalMarker = L.CircleMarker.extend({
     var lvlRadius = LEVEL_TO_RADIUS[level] * scale;
 
     // thinner outline for placeholder portals
-    if (this._team != TEAM_NONE && level==0) {
+    if (this.isPlaceholder()) {
       lvlWeight = 1;
     }
 

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -2,18 +2,20 @@
 // code to create and update a portal marker
 
 // portal hooks
-function handler_portal_click (e) {
+function handler_portal_click(e) {
   window.selectPortal(e.target.options.guid, e.type);
-  window.renderPortalDetails(e.target.options.guid)
+  window.renderPortalDetails(e.target.options.guid);
 }
-function handler_portal_dblclick (e) {
+
+function handler_portal_dblclick(e) {
   window.selectPortal(e.target.options.guid, e.type);
-  window.renderPortalDetails(e.target.options.guid)
+  window.renderPortalDetails(e.target.options.guid);
   window.map.setView(e.target.getLatLng(), DEFAULT_ZOOM);
 }
-function handler_portal_contextmenu (e) {
+
+function handler_portal_contextmenu(e) {
   window.selectPortal(e.target.options.guid, e.type);
-  window.renderPortalDetails(e.target.options.guid)
+  window.renderPortalDetails(e.target.options.guid);
   if (window.isSmartphone()) {
     window.show('info');
   } else if (!$('#scrollwrapper').is(':visible')) {
@@ -31,7 +33,7 @@ L.PortalMarker = L.CircleMarker.extend({
       opacity: 1,
       fill: true,
       fillOpacity: 0.5,
-      interactive: true
+      interactive: true,
     },
     // placeholder style
     placeholderStyle: {
@@ -43,7 +45,7 @@ L.PortalMarker = L.CircleMarker.extend({
     LEVEL_TO_RADIUS: [7, 7, 7, 7, 8, 8, 9,10,11],
   },
 
-  initialize: function(latlng, data) {
+  initialize: function (latlng, data) {
     L.CircleMarker.prototype.initialize.call(this, latlng);
     this._selected = data.guid === selectedPortal;
     this.updateDetails(data);
@@ -52,73 +54,107 @@ L.PortalMarker = L.CircleMarker.extend({
     this.on('dblclick', handler_portal_dblclick);
     this.on('contextmenu', handler_portal_contextmenu);
   },
+
   willUpdate: function (details) {
     // details are from a placeholder
     if (details.level === undefined) {
       // if team differs and corresponding link is more recent (ignore field)
-      if (this._details.timestamp < details.timestamp && this._details.team !== details.team)
-        return true;
-      // in any other case
-      return false;
+      return (
+        this._details.timestamp < details.timestamp &&
+        this._details.team !== details.team
+      );
     }
     // more recent timestamp, this occurs when the data has changed because of:
     //  - resonator deploy/upgrade
     //  - mod deploy
     //  - recharge/damage/decay
     //  - portal edit (title, location, portal main picture)
-    if (this._details.timestamp < details.timestamp)
+    if (this._details.timestamp < details.timestamp) {
       return true;
+    }
     // current marker is a placeholder, and details is real data
-    if (this.isPlaceholder() && this._details.team === details.team)
+    if (this.isPlaceholder() && this._details.team === details.team) {
       return true;
+    }
     // even if we get history that was missing ? is it even possible ?
-    if (this._details.timestamp > details.timestamp)
+    if (this._details.timestamp > details.timestamp) {
       return false;
+    }
 
     // this._details.timestamp === details.timestamp
 
     // get new history
     if (details.history) {
-      if (!this._details.history)
+      if (!this._details.history) {
         return true;
-      if (this._details.history._raw !== details.history._raw)
+      }
+      if (this._details.history._raw !== details.history._raw) {
         return true;
+      }
     }
 
     // get details portal data
-    if (!this._details.mods && details.mods)
+    if (!this._details.mods && details.mods) {
       return true;
+    }
 
     return false;
   },
-  updateDetails: function(details) {
+
+  updateDetails: function (details) {
     if (this._details) {
       // portal has been moved
-      if (this._details.latE6 !== details.latE6 || this._details.lngE6 !== details.lngE6)
-        this.setLatLng(L.latLng(details.latE6/1E6, details.lngE6/1E6));
+      if (
+        this._details.latE6 !== details.latE6 ||
+        this._details.lngE6 !== details.lngE6
+      ) {
+        this.setLatLng(L.latLng(details.latE6 / 1e6, details.lngE6 / 1e6));
+      }
 
       // core data from a placeholder
       if (details.level === undefined) {
         // if team has changed
-        if (this._details.timestamp < details.timestamp && this._details.team !== details.team) {
+        if (
+          this._details.timestamp < details.timestamp &&
+          this._details.team !== details.team
+        ) {
           // keep history, title, image
           details.title = this._details.title;
           details.image = this._details.image;
           details.history = this._details.history;
           this._details = details;
         }
-      } else if (this._details.timestamp == details.timestamp) {
+      } else if (this._details.timestamp === details.timestamp) {
         // we got more details (core/summary -> summary/detailed/extended)
         var localThis = this;
-        ["level", "health", "resCount", "image", "title", "ornaments", "mission", "mission50plus", "artifactBrief", "mods", "resonators", "owner", "artifactDetail"].forEach(function (prop) {
+        [
+          'level',
+          'health',
+          'resCount',
+          'image',
+          'title',
+          'ornaments',
+          'mission',
+          'mission50plus',
+          'artifactBrief',
+          'mods',
+          'resonators',
+          'owner',
+          'artifactDetail',
+        ].forEach(function (prop) {
           if (details[prop]) localThis._details[prop] = details[prop];
         });
         // smarter update for history (cause it's missing sometimes)
         if (details.history) {
-          if (!this._details.history) this._details.history = details.history;
-          else {
-            if (this._details.history._raw & details.history._raw != this._details.history._raw)
-              log.warn("new portal data has lost some history");
+          if (!this._details.history) {
+            this._details.history = details.history;
+          } else {
+            if (
+              this._details.history._raw &
+              (details.history._raw != this._details.history._raw)
+            ) {
+              log.warn('new portal data has lost some history');
+            }
             this._details.history._raw |= details.history._raw;
             ['visited', 'captured', 'scoutControlled'].forEach(function (prop) {
               localThis._details.history[prop] ||= details.history[prop];
@@ -129,26 +165,32 @@ L.PortalMarker = L.CircleMarker.extend({
         this._details.ent = details.ent;
       } else {
         // permanent data (history only)
-        if (!details.history) details.history = this._details.history;
+        if (!details.history) {
+          details.history = this._details.history;
+        }
 
         this._details = details;
       }
-    } else this._details = details;
+    } else {
+      this._details = details;
+    }
 
-    this._level = parseInt(this._details.level)||0;
+    this._level = parseInt(this._details.level) || 0;
     this._team = teamStringToId(this._details.team);
 
     // the data returns unclaimed portals as level 1 - but IITC wants them treated as level 0
-    if (this._team == TEAM_NONE) this._level = 0;
+    if (this._team === TEAM_NONE) {
+      this._level = 0;
+    }
 
     // compatibility
     var dataOptions = {
       guid: this._details.guid,
       level: this._level,
       team: this._team,
-      ent: this._details.ent,  // LEGACY - TO BE REMOVED AT SOME POINT! use .guid, .timestamp and .data instead
+      ent: this._details.ent, // LEGACY - TO BE REMOVED AT SOME POINT! use .guid, .timestamp and .data instead
       timestamp: this._details.timestamp,
-      data: this._details
+      data: this._details,
     };
     L.setOptions(this, dataOptions);
 
@@ -158,6 +200,7 @@ L.PortalMarker = L.CircleMarker.extend({
 
     this.setSelected();
   },
+
   renderDetails() {
     if (!this._rendering) {
       this._rendering = true;
@@ -165,19 +208,25 @@ L.PortalMarker = L.CircleMarker.extend({
       this._rendering = false;
     }
   },
+
   getDetails: function () {
     return this._details;
   },
+
   isPlaceholder: function () {
     return this._details.level === undefined;
   },
+
   hasFullDetails: function () {
-    return !!this._details.mods
+    return !!this._details.mods;
   },
-  setStyle: function (style) { // stub for highlighters
+
+  setStyle: function (style) {
+    // stub for highlighters
     L.Util.setOptions(this, style);
     return this;
   },
+
   setMarkerStyle: function (style) {
     var styleOptions = L.Util.extend(this._style(), style);
     L.Util.setOptions(this, styleOptions);
@@ -190,32 +239,39 @@ L.PortalMarker = L.CircleMarker.extend({
     );
     return L.CircleMarker.prototype.setStyle.call(this, selected);
   },
+
   setSelected: function (selected) {
-    if (selected === false)
+    if (selected === false) {
       this._selected = false;
-    else
+    } else {
       this._selected = this._selected || selected;
+    }
 
     this.setMarkerStyle();
 
-    if (this._selected && window.map.hasLayer(this))
+    if (this._selected && window.map.hasLayer(this)) {
       this.bringToFront();
+    }
   },
+
   _style: function () {
     var dashArray = null;
     // dashed outline for placeholder portals
-    if (this.isPlaceholder()) dashArray = L.PortalMarker.placeholderStyle.dashArray;
+    if (this.isPlaceholder()) {
+      dashArray = L.PortalMarker.placeholderStyle.dashArray;
+    }
 
     return L.extend(this._scale(), L.PortalMarker.portalBaseStyle, {
       color: COLORS[this._team],
       fillColor: COLORS[this._team],
-      dashArray: dashArray
+      dashArray: dashArray,
     });
   },
+
   _scale: function () {
     var scale = window.portalMarkerScale();
 
-    var level = Math.floor(this._level||0);
+    var level = Math.floor(this._level || 0);
 
     var lvlWeight = L.PortalMarker.LEVEL_TO_WEIGHT[level] * Math.sqrt(scale);
     var lvlRadius = L.PortalMarker.LEVEL_TO_RADIUS[level] * scale;
@@ -232,36 +288,43 @@ L.PortalMarker = L.CircleMarker.extend({
   },
 });
 
-window.portalMarkerScale = function() {
+window.portalMarkerScale = function () {
   var zoom = map.getZoom();
-  if (L.Browser.mobile)
-    return zoom >= 16 ? 1.5 : zoom >= 14 ? 1.2 : zoom >= 11 ? 1.0 : zoom >= 8 ? 0.65 : 0.5;
-  else
+  if (L.Browser.mobile) {
+    return zoom >= 16
+      ? 1.5
+      : zoom >= 14
+      ? 1.2
+      : zoom >= 11
+      ? 1.0
+      : zoom >= 8
+      ? 0.65
+      : 0.5;
+  } else {
     return zoom >= 14 ? 1 : zoom >= 11 ? 0.8 : zoom >= 8 ? 0.65 : 0.5;
-}
+  }
+};
 
 // create a new marker. 'data' contain the IITC-specific entity data to be stored in the object options
-window.createMarker = function(latlng, data) {
+window.createMarker = function (latlng, data) {
   return new L.PortalMarker(latlng, data);
-}
+};
 
-
-window.setMarkerStyle = function(marker, selected) {
+window.setMarkerStyle = function (marker, selected) {
   marker.setSelected(selected);
-}
+};
 
-
-window.getMarkerStyleOptions = function(details) {
+window.getMarkerStyleOptions = function (details) {
   var scale = window.portalMarkerScale();
 
-  var level = Math.floor(details.level||0);
+  var level = Math.floor(details.level || 0);
 
   var lvlWeight = L.PortalMarker.LEVEL_TO_WEIGHT[level] * Math.sqrt(scale);
   var lvlRadius = L.PortalMarker.LEVEL_TO_RADIUS[level] * scale;
 
   var dashArray = null;
   // thinner and dashed outline for placeholder portals
-  if (details.team != TEAM_NONE && level==0) {
+  if (details.team != TEAM_NONE && level == 0) {
     lvlWeight = L.PortalMarker.placeholderStyle.weight;
     dashArray = L.PortalMarker.placeholderStyle.dashArray;
   }
@@ -280,5 +343,4 @@ window.getMarkerStyleOptions = function(details) {
   );
 
   return options;
-}
-
+};

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -9,32 +9,40 @@ var portalBaseStyle = {
 };
 
 L.PortalMarker = L.CircleMarker.extend({
-  options: {
-    guid: null,
-    level: 0,
-    team: 0,
-    timestamp: 0,
-    data: null,
-    ent: null,  // LEGACY - TO BE REMOVED AT SOME POINT! use .guid, .timestamp and .data instead
-  },
+  options: {},
 
   initialize: function(latlng, data) {
-    L.CircleMarker.prototype.initialize.call(this, latlng, data);
-
-    var styleOptions = this._style();
-    this.setStyle(styleOptions);
-    highlightPortal(this);
+    L.CircleMarker.prototype.initialize.call(this, latlng);
+    this.updateDetails(data);
   },
-  updateData: function(data, selected) {
-    L.setOptions(this, data);
+  updateDetails: function(details) {
+    // xxx: handle permanent data
+    this._details = details;
 
-    this.reset(selected);
+    this._level = parseInt(details.level)||0;
+    this._team = teamStringToId(details.team);
+
+    // the data returns unclaimed portals as level 1 - but IITC wants them treated as level 0
+    if (this._team == TEAM_NONE) this._level = 0;
+
+    // compatibility
+    var dataOptions = {
+      guid: this._details.guid,
+      level: this._level,
+      team: this._team,
+      ent: this._details.ent,  // LEGACY - TO BE REMOVED AT SOME POINT! use .guid, .timestamp and .data instead
+      timestamp: this._details.timestamp,
+      data: this._details
+    };
+    L.setOptions(this, dataOptions);
+
+    this.reset();
   },
   getDetails: function () {
-    return this.options.data;
+    return this._details;
   },
   hasFullDetails: function () {
-    return !!this.options.data.mods
+    return !!this._details.mods
   },
   reset: function (selected) {
     var styleOptions = this._style();
@@ -49,11 +57,11 @@ L.PortalMarker = L.CircleMarker.extend({
   _style: function () {
     var dashArray = null;
     // dashed outline for placeholder portals
-    if (this.options.team != TEAM_NONE && this.options.level==0) dashArray = '1,2';
+    if (this._team != TEAM_NONE && this._level==0) dashArray = '1,2';
 
     return L.extend(this._scale(), portalBaseStyle, {
-      color: COLORS[this.options.team],
-      fillColor: COLORS[this.options.team],
+      color: COLORS[this._team],
+      fillColor: COLORS[this._team],
       dashArray: dashArray
     });
   },
@@ -64,13 +72,13 @@ L.PortalMarker = L.CircleMarker.extend({
     var LEVEL_TO_WEIGHT = [2, 2, 2, 2, 2, 3, 3, 4, 4];
     var LEVEL_TO_RADIUS = [7, 7, 7, 7, 8, 8, 9,10,11];
 
-    var level = Math.floor(this.options.level||0);
+    var level = Math.floor(this._level||0);
 
     var lvlWeight = LEVEL_TO_WEIGHT[level] * Math.sqrt(scale);
     var lvlRadius = LEVEL_TO_RADIUS[level] * scale;
 
     // thinner outline for placeholder portals
-    if (this.options.team != TEAM_NONE && level==0) {
+    if (this._team != TEAM_NONE && level==0) {
       lvlWeight = 1;
     }
 

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -96,9 +96,21 @@ L.PortalMarker = L.CircleMarker.extend({
       } else if (this._details.timestamp == details.timestamp) {
         // we got more details
         var localThis = this;
-        ["mods", "resonators", "owner", "artifactDetail", "history"].forEach(function (prop) {
+        ["mods", "resonators", "owner", "artifactDetail"].forEach(function (prop) {
           if (details[prop]) localThis._details[prop] = details[prop];
         });
+        // smarter update for history (cause it's missing sometimes)
+        if (details.history) {
+          if (!this._details.history) this._details.history = details.history;
+          else {
+            if (this._details.history._raw & details.history._raw != this._details.history._raw)
+              log.warn("new portal data has lost some history");
+            this._details.history._raw |= details.history._raw;
+            ['visited', 'captured', 'scoutControlled'].forEach(function (prop) {
+              localThis._details.history[prop] ||= details.history[prop];
+            });
+          }
+        }
         // LEGACY - TO BE REMOVED AT SOME POINT! use .guid, .timestamp and .data instead
         this._details.ent = details.ent;
       } else {

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -53,10 +53,7 @@ L.PortalMarker = L.CircleMarker.extend({
     this.on('contextmenu', handler_portal_contextmenu);
   },
   willUpdate: function (details) {
-    // portal location edit
-    if (this._details.latE6 !== details.latE6 || this._details.lngE6 !== details.lngE6)
-      return true;
-    // placeholder
+    // details are from a placeholder
     if (details.level === undefined) {
       // if team differs and corresponding link/field is more recent
       if (this._details.timestamp < details.timestamp && this._details.team !== details.team)

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -1,6 +1,35 @@
 // PORTAL MARKER //////////////////////////////////////////////
 // code to create and update a portal marker
 
+L.PortalMarker = L.CircleMarker.extend({
+  options: {},
+
+  initialize: function(latlng, data) {
+    var styleOptions = window.getMarkerStyleOptions(data);
+    var options = L.extend({}, data, styleOptions, { interactive: true });
+
+    L.CircleMarker.prototype.initialize.call(this, latlng, options);
+
+    highlightPortal(this)
+  },
+  updateData: function(data) {
+    var styleOptions = window.getMarkerStyleOptions(data);
+    var options = L.extend({}, data, styleOptions, { interactive: true });
+    L.setOptions(this, options);
+
+    this.setStyle(styleOptions);
+  },
+  select: function (selected) {
+    var styleOptions = window.getMarkerStyleOptions(this.options);
+    this.setStyle(styleOptions);
+
+    highlightPortal(this);
+
+    if (selected) {
+      this.setStyle ({color: COLOR_SELECTED_PORTAL});
+    }
+  },
+});
 
 window.portalMarkerScale = function() {
   var zoom = map.getZoom();
@@ -12,31 +41,12 @@ window.portalMarkerScale = function() {
 
 // create a new marker. 'data' contain the IITC-specific entity data to be stored in the object options
 window.createMarker = function(latlng, data) {
-  var styleOptions = window.getMarkerStyleOptions(data);
-
-  var options = L.extend({}, data, styleOptions, { interactive: true });
-
-  var marker = L.circleMarker(latlng, options);
-
-  highlightPortal(marker);
-
-  return marker;
+  return new L.PortalMarker(latlng, data);
 }
 
 
 window.setMarkerStyle = function(marker, selected) {
-
-  var styleOptions = window.getMarkerStyleOptions(marker.options);
-
-  marker.setStyle(styleOptions);
-
-  // FIXME? it's inefficient to set the marker style (above), then do it again inside the highlighter
-  // the highlighter API would need to be changed for this to be improved though. will it be too slow?
-  highlightPortal(marker);
-
-  if (selected) {
-    marker.setStyle ({color: COLOR_SELECTED_PORTAL});
-  }
+  marker.select(selected);
 }
 
 

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -55,7 +55,7 @@ L.PortalMarker = L.CircleMarker.extend({
   willUpdate: function (details) {
     // details are from a placeholder
     if (details.level === undefined) {
-      // if team differs and corresponding link/field is more recent
+      // if team differs and corresponding link is more recent (ignore field)
       if (this._details.timestamp < details.timestamp && this._details.team !== details.team)
         return true;
       // in any other case

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -106,7 +106,7 @@ L.PortalMarker = L.CircleMarker.extend({
       this._renderDetails();
     }
 
-    this.reset();
+    this.setSelected();
   },
   _renderDetails() {
     if (!this._rendering) {
@@ -138,9 +138,6 @@ L.PortalMarker = L.CircleMarker.extend({
     return L.CircleMarker.prototype.setStyle.call(this, selected);
   },
   setSelected: function (selected) {
-    return this.reset(selected);
-  },
-  reset: function (selected) {
     if (selected === false)
       this._selected = false;
     else

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -14,11 +14,13 @@ function handler_portal_click (e) {
   window.renderPortalDetails(e.target.options.guid, true)
 }
 function handler_portal_dblclick (e) {
-  handler_portal_click(e);
+  window.selectPortal(e.target.options.guid, e.type);
+  window.renderPortalDetails(e.target.options.guid, true)
   window.map.setView(e.target.getLatLng(), DEFAULT_ZOOM);
 }
 function handler_portal_contextmenu (e) {
-  handler_portal_click(e);
+  window.selectPortal(e.target.options.guid, e.type);
+  window.renderPortalDetails(e.target.options.guid, true)
   if (window.isSmartphone()) {
     window.show('info');
   } else if (!$('#scrollwrapper').is(':visible')) {

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -1,12 +1,5 @@
 // PORTAL MARKER //////////////////////////////////////////////
 // code to create and update a portal marker
-var portalBaseStyle = {
-  stroke: true,
-  opacity: 1,
-  fill: true,
-  fillOpacity: 0.5,
-  interactive: true
-};
 
 // portal hooks
 function handler_portal_click (e) {
@@ -30,6 +23,25 @@ function handler_portal_contextmenu (e) {
 
 L.PortalMarker = L.CircleMarker.extend({
   options: {},
+
+  statics: {
+    // base style
+    portalBaseStyle: {
+      stroke: true,
+      opacity: 1,
+      fill: true,
+      fillOpacity: 0.5,
+      interactive: true
+    },
+    // placeholder style
+    placeholderStyle: {
+      dashArray: '1,2',
+      weight: 1,
+    },
+    // portal level   0  1  2  3  4  5  6  7  8
+    LEVEL_TO_WEIGHT: [2, 2, 2, 2, 2, 3, 3, 4, 4],
+    LEVEL_TO_RADIUS: [7, 7, 7, 7, 8, 8, 9,10,11],
+  },
 
   initialize: function(latlng, data) {
     L.CircleMarker.prototype.initialize.call(this, latlng);
@@ -189,9 +201,9 @@ L.PortalMarker = L.CircleMarker.extend({
   _style: function () {
     var dashArray = null;
     // dashed outline for placeholder portals
-    if (this.isPlaceholder()) dashArray = '1,2';
+    if (this.isPlaceholder()) dashArray = L.PortalMarker.placeholderStyle.dashArray;
 
-    return L.extend(this._scale(), portalBaseStyle, {
+    return L.extend(this._scale(), L.PortalMarker.portalBaseStyle, {
       color: COLORS[this._team],
       fillColor: COLORS[this._team],
       dashArray: dashArray
@@ -200,18 +212,14 @@ L.PortalMarker = L.CircleMarker.extend({
   _scale: function () {
     var scale = window.portalMarkerScale();
 
-    //   portal level      0  1  2  3  4  5  6  7  8
-    var LEVEL_TO_WEIGHT = [2, 2, 2, 2, 2, 3, 3, 4, 4];
-    var LEVEL_TO_RADIUS = [7, 7, 7, 7, 8, 8, 9,10,11];
-
     var level = Math.floor(this._level||0);
 
-    var lvlWeight = LEVEL_TO_WEIGHT[level] * Math.sqrt(scale);
-    var lvlRadius = LEVEL_TO_RADIUS[level] * scale;
+    var lvlWeight = L.PortalMarker.LEVEL_TO_WEIGHT[level] * Math.sqrt(scale);
+    var lvlRadius = L.PortalMarker.LEVEL_TO_RADIUS[level] * scale;
 
     // thinner outline for placeholder portals
     if (this.isPlaceholder()) {
-      lvlWeight = 1;
+      lvlWeight = L.PortalMarker.placeholderStyle.weight;
     }
 
     return {
@@ -243,33 +251,30 @@ window.setMarkerStyle = function(marker, selected) {
 window.getMarkerStyleOptions = function(details) {
   var scale = window.portalMarkerScale();
 
-  //   portal level      0  1  2  3  4  5  6  7  8
-  var LEVEL_TO_WEIGHT = [2, 2, 2, 2, 2, 3, 3, 4, 4];
-  var LEVEL_TO_RADIUS = [7, 7, 7, 7, 8, 8, 9,10,11];
-
   var level = Math.floor(details.level||0);
 
-  var lvlWeight = LEVEL_TO_WEIGHT[level] * Math.sqrt(scale);
-  var lvlRadius = LEVEL_TO_RADIUS[level] * scale;
+  var lvlWeight = L.PortalMarker.LEVEL_TO_WEIGHT[level] * Math.sqrt(scale);
+  var lvlRadius = L.PortalMarker.LEVEL_TO_RADIUS[level] * scale;
 
   var dashArray = null;
   // thinner and dashed outline for placeholder portals
   if (details.team != TEAM_NONE && level==0) {
-    lvlWeight = 1;
-    dashArray = '1,2';
+    lvlWeight = L.PortalMarker.placeholderStyle.weight;
+    dashArray = L.PortalMarker.placeholderStyle.dashArray;
   }
 
-  var options = {
-    radius: lvlRadius,
-    stroke: true,
-    color: COLORS[details.team],
-    weight: lvlWeight,
-    opacity: 1,
-    fill: true,
-    fillColor: COLORS[details.team],
-    fillOpacity: 0.5,
-    dashArray: dashArray
-  };
+  var options = L.extend(
+    {
+      radius: lvlRadius,
+      weight: lvlWeight,
+    },
+    L.PortalMarker.portalBaseStyle,
+    {
+      color: COLORS[details.team],
+      fillColor: COLORS[details.team],
+      dashArray: dashArray,
+    }
+  );
 
   return options;
 }

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -33,6 +33,7 @@ L.PortalMarker = L.CircleMarker.extend({
 
   initialize: function(latlng, data) {
     L.CircleMarker.prototype.initialize.call(this, latlng);
+    this._selected = data.guid === selectedPortal;
     this.updateDetails(data);
 
     this.on('click', handler_portal_click);

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -71,9 +71,13 @@ L.PortalMarker = L.CircleMarker.extend({
 
     highlightPortal(this);
 
-    if (selected) {
+    if (selected === false)
+      this._selected = false;
+    else
+      this._selected = this._selected || selected;
+
+    if (this._selected)
       this.setStyle ({color: COLOR_SELECTED_PORTAL});
-    }
   },
   _style: function () {
     var dashArray = null;

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -8,12 +8,33 @@ var portalBaseStyle = {
   interactive: true
 };
 
+// portal hooks
+function handler_portal_click (e) {
+  window.renderPortalDetails(e.target.options.guid);
+}
+function handler_portal_dblclick (e) {
+  window.renderPortalDetails(e.target.options.guid);
+  window.map.setView(e.target.getLatLng(), DEFAULT_ZOOM);
+}
+function handler_portal_contextmenu (e) {
+  window.renderPortalDetails(e.target.options.guid);
+  if (window.isSmartphone()) {
+    window.show('info');
+  } else if (!$('#scrollwrapper').is(':visible')) {
+    $('#sidebartoggle').click();
+  }
+}
+
 L.PortalMarker = L.CircleMarker.extend({
   options: {},
 
   initialize: function(latlng, data) {
     L.CircleMarker.prototype.initialize.call(this, latlng);
     this.updateDetails(data);
+
+    this.on('click', handler_portal_click);
+    this.on('dblclick', handler_portal_dblclick);
+    this.on('contextmenu', handler_portal_contextmenu);
   },
   updateDetails: function(details) {
     // xxx: handle permanent data

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -30,7 +30,10 @@ L.PortalMarker = L.CircleMarker.extend({
 
     this.reset(selected);
   },
-  hasDetails: function () {
+  getDetails: function () {
+    return this.options.data;
+  },
+  hasFullDetails: function () {
     return !!this.options.data.mods
   },
   reset: function (selected) {


### PR DESCRIPTION
Address  #325 

# Changes
 
Extend the CircleMarker class to PortalMarker class following the same idea of #251

Portal entities are only deleted when removed from rendering:
 - portal deleted according to getEtentities data (does this really occurs?)
 - no selected and absent from getEntities data (zoom <15, not in view, not a endpoint)
 
On any other situtation, the portal marker is the same and only receive updates until removed from rendering.

## class `L.PortalMarker`
  Methods:
* `setStyle(style)` (deprecated, for compatibility with old highlighters)
      don't apply a style, but save it for later when calling `setMarkerStyle`
* `setMarkerStyle(style)`
    * compute base portal style according to details and level
    * use the given style on top of it
    * call the highlighter to update further the style
    * if selected, force the color
    * apply the style
* `setSelected(details)`
    * change selected intern state and call setMarkerStyle()
* `willUpdate(details)`
    * given details (from decodeArray.portal), return true if the details are more recent or more detailled than the known details 
* `updateDetails(details)`
    * apply new details
    * maintain permanent data (history)
    * handle partial update with identical timestamp (mods, resonators...)
    * update options (compatibility)
    * update the marker on the map
    * if selected, update the side bar
* `getDetails()`
    * return portal details
* `hasFullDetails()`
    * return true if the marker store mods/resonators/... details 
* `renderDetails()`
    * call `renderPortalDetails` (even if unselected) while avoiding a call to `selectPortal` 

## Hooks `portalSelected`

Add a new field `event` that specified the origin of the event.
This is mainly to distinguish a selection that comes from a call to `renderPortalDetails` and a click/touch event on the marker from the user.

## Portal Details Cache

### Before

on `portalDetail.request`, the data is parsed, store, used for render portal details in the side bar if the portal is selected, then the `portalDetailLoaded` hook trigger the creation of a new portal entity.

portal entity only stores partial data (summary only but full raw)

### Now
on `portalDetail.request`, we create or update a portal entity,  this part renders the portal details if needed, store the portal details in cache, run the `portalDetailLoaded` hook.

portal detail cache is used for incomplete portal entity upon creation

**Gain:** the portal entity always has the most recent data, details are parsed once, the portal entity is sure to exist for the hook.

~**Missing:** if the portal changed before details in cache expires, the code won't fetch new details unless a direct call to `portalDetail.request` (is it true before also?)~ see a587775

## Placeholder entities

Placeholder portal entities are introduced for link/field endpoints.
Fields and links have an unused timestamp.
The PR uses the timestamp from link/field to handle portal updates as any other portal entity.

## Sidenotes

Portal timestamp change on portal edit (title, location, portal main picture).

## deprecated:
  * `window.createMarker`
  * `window.setMarkerStyle`

From #251
## related functions (next candidates for refactoring/deprecation)
  * `window.setPortalIndicators`
  * `window.selectPortal`
  * `window.portalMarkerScale`
  * `window.getMarkerStyleOptions`
  * `window.renderPortalDetails`

