### PR TITLE
portal-history: separate styles

### DIFF
--- a/plugins/highlight-portal-history.js
+++ b/plugins/highlight-portal-history.js
@@ -10,13 +10,14 @@ var portalsHistory = {};
 window.plugin.portalHighlighterPortalsHistory = portalsHistory;
 
 portalsHistory.styles = {
-  marked: {
-    fillColor: 'red',
+  common: {
     fillOpacity: 1
   },
+  marked: {
+    fillColor: 'red'
+  },
   semiMarked: {
-    fillColor: 'yellow',
-    fillOpacity: 1
+    fillColor: 'yellow'
   }
 };
 
@@ -63,11 +64,15 @@ portalsHistory.notScoutControlled = function (data) {
 };
 
 var setup = function () {
+  var styles = portalsHistory.styles;
+  ['marked', 'semiMarked'].forEach(function (name) {
+    styles[name] = L.extend(L.Util.create(styles.common), styles[name]);
+  });
   ['visited', 'captureTarget'].forEach(function (name) {
-    portalsHistory.styles[name] = portalsHistory.styles.semiMarked;
+    styles[name] = L.extend(L.Util.create(styles.semiMarked), styles[name]);
   });
   ['captured', 'visitTarget', 'scoutControlled', 'scoutControllTarget'].forEach(function (name) {
-    portalsHistory.styles[name] = portalsHistory.styles.marked;
+    styles[name] = L.extend(L.Util.create(styles.marked), styles[name]);
   });
 
   window.addPortalHighlighter('History: visited/captured', portalsHistory.visited);

--- a/plugins/highlight-portal-history.js
+++ b/plugins/highlight-portal-history.js
@@ -1,7 +1,7 @@
 // @author         Johtaja
 // @name           Highlight portals based on history
 // @category       Highlighter
-// @version        0.1.0
+// @version        0.1.1
 // @description    Use the portal fill color to denote the portal has been visited, captured, scout controlled
 
 
@@ -14,14 +14,12 @@ function setStyle (data, color, opacity) {
 
 function visited (data) {
   var history = data.portal.options.data.history;
-  if (!history || !(history.visited || !history.captured)) {
+  if (!history) {
     return;
   }
   if (history.captured) {
     setStyle(data, 'red', 1);
-    return;
-  }
-  if (history.visited) {
+  } else if (history.visited) {
     setStyle(data, 'yellow', 1);
   }
 }
@@ -31,43 +29,41 @@ function notVisited (data) {
   if (!history) {
     return;
   }
-  if (history.captured) {
-    return;
-  }
-  if (history.visited) {
+  if (!history.visited) {
+    setStyle(data, 'red', 1);
+  } else if (!history.captured) {
     setStyle(data, 'yellow', 1);
-    return;
   }
-  setStyle(data, 'red', 1);
 }
 
 function scoutControlled (data) {
   var history = data.portal.options.data.history;
-  if (!history || !history.scoutControlled) {
-    return;
+  if (history && history.scoutControlled) {
+    setStyle(data, 'red', 1);
   }
-  setStyle(data, 'red', 1);
 }
 
 function notScoutControlled (data) {
   var history = data.portal.options.data.history;
-  if (!history || history.scoutControlled) {
-    return;
+  if (history && !history.scoutControlled) {
+    setStyle(data, 'red', 1);
   }
-  setStyle(data, 'red', 1);
 }
 
 // use own namespace for plugin
-window.plugin.portalHighlighterPortalsHistory = {
+var portalHighlighterPortalsHistory = {
   visited: visited,
   notVisited: notVisited,
   scoutControlled: scoutControlled,
   notScoutControlled: notScoutControlled,
 };
 
+// use own namespace for plugin
+window.plugin.portalHighlighterPortalsHistory = portalHighlighterPortalsHistory;
+
 var setup = function () {
-  window.addPortalHighlighter('History: visited/captured', window.plugin.portalHighlighterPortalsHistory.visited);
-  window.addPortalHighlighter('History: not visited/captured', window.plugin.portalHighlighterPortalsHistory.notVisited);
-  window.addPortalHighlighter('History: scout controlled', window.plugin.portalHighlighterPortalsHistory.scoutControlled);
-  window.addPortalHighlighter('History: not scout controlled', window.plugin.portalHighlighterPortalsHistory.notScoutControlled);
-}
+  window.addPortalHighlighter('History: visited/captured', portalHighlighterPortalsHistory.visited);
+  window.addPortalHighlighter('History: not visited/captured', portalHighlighterPortalsHistory.notVisited);
+  window.addPortalHighlighter('History: scout controlled', portalHighlighterPortalsHistory.scoutControlled);
+  window.addPortalHighlighter('History: not scout controlled', portalHighlighterPortalsHistory.notScoutControlled);
+};

--- a/plugins/highlight-portal-history.js
+++ b/plugins/highlight-portal-history.js
@@ -18,6 +18,9 @@ portalsHistory.styles = {
   },
   semiMarked: {
     fillColor: 'yellow'
+  },
+  commonOther: {
+    // no action by default
   }
 };
 
@@ -30,10 +33,13 @@ portalsHistory.visited = function (data) {
   if (!history) {
     return;
   }
+  var s = portalsHistory.styles;
   if (history.captured) {
-    data.portal.setStyle(portalsHistory.styles.captured);
+    data.portal.setStyle(s.captured);
   } else if (history.visited) {
-    data.portal.setStyle(portalsHistory.styles.visited);
+    data.portal.setStyle(s.visited);
+  } else if (!$.isEmptyObject(s.otherVC)) {
+    data.portal.setStyle(s.otherVC);
   }
 };
 
@@ -42,24 +48,39 @@ portalsHistory.notVisited = function (data) {
   if (!history) {
     return;
   }
+  var s = portalsHistory.styles;
   if (!history.visited) {
-    data.portal.setStyle(portalsHistory.styles.visitTarget);
+    data.portal.setStyle(s.visitTarget);
   } else if (!history.captured) {
-    data.portal.setStyle(portalsHistory.styles.captureTarget);
+    data.portal.setStyle(s.captureTarget);
+  } else if (!$.isEmptyObject(s.otherNotVC)) {
+    data.portal.setStyle(s.otherNotVC);
   }
 };
 
 portalsHistory.scoutControlled = function (data) {
   var history = data.portal.options.data.history;
-  if (history && history.scoutControlled) {
-    data.portal.setStyle(portalsHistory.styles.scoutControlled);
+  if (!history) {
+    return;
+  }
+  var s = portalsHistory.styles;
+  if (history.scoutControlled) {
+    data.portal.setStyle(s.scoutControlled);
+  } else if (!$.isEmptyObject(s.otherScout)) {
+    data.portal.setStyle(s.otherScout);
   }
 };
 
 portalsHistory.notScoutControlled = function (data) {
   var history = data.portal.options.data.history;
-  if (history && !history.scoutControlled) {
-    data.portal.setStyle(portalsHistory.styles.scoutControllTarget);
+  if (!history) {
+    return;
+  }
+  var s = portalsHistory.styles;
+  if (!history.scoutControlled) {
+    data.portal.setStyle(s.scoutControllTarget);
+  } else if (!$.isEmptyObject(s.otherNotScout)) {
+    data.portal.setStyle(s.otherNotScout);
   }
 };
 
@@ -76,6 +97,7 @@ var setup = function () {
   inherit('common', ['marked', 'semiMarked']);
   inherit('semiMarked', ['visited', 'captureTarget']);
   inherit('marked', ['captured', 'visitTarget', 'scoutControlled', 'scoutControllTarget']);
+  inherit('commonOther', ['otherVC', 'otherNotVC', 'otherScout', 'otherNotScout']);
 
   window.addPortalHighlighter('History: visited/captured', portalsHistory.visited);
   window.addPortalHighlighter('History: not visited/captured', portalsHistory.notVisited);

--- a/plugins/highlight-portal-history.js
+++ b/plugins/highlight-portal-history.js
@@ -63,17 +63,19 @@ portalsHistory.notScoutControlled = function (data) {
   }
 };
 
-var setup = function () {
+// Creating styles based on a given template
+function inherit (parentName, childNames) {
   var styles = portalsHistory.styles;
-  ['marked', 'semiMarked'].forEach(function (name) {
-    styles[name] = L.extend(L.Util.create(styles.common), styles[name]);
+  childNames.forEach(function (name) {
+    // Extension of _styles_ with a new _name_ object, created based on _parentName_ object.
+    styles[name] = L.extend(L.Util.create(styles[parentName]), styles[name]);
   });
-  ['visited', 'captureTarget'].forEach(function (name) {
-    styles[name] = L.extend(L.Util.create(styles.semiMarked), styles[name]);
-  });
-  ['captured', 'visitTarget', 'scoutControlled', 'scoutControllTarget'].forEach(function (name) {
-    styles[name] = L.extend(L.Util.create(styles.marked), styles[name]);
-  });
+}
+
+var setup = function () {
+  inherit('common', ['marked', 'semiMarked']);
+  inherit('semiMarked', ['visited', 'captureTarget']);
+  inherit('marked', ['captured', 'visitTarget', 'scoutControlled', 'scoutControllTarget']);
 
   window.addPortalHighlighter('History: visited/captured', portalsHistory.visited);
   window.addPortalHighlighter('History: not visited/captured', portalsHistory.notVisited);

--- a/plugins/highlight-portal-history.js
+++ b/plugins/highlight-portal-history.js
@@ -1,69 +1,77 @@
 // @author         Johtaja
 // @name           Highlight portals based on history
 // @category       Highlighter
-// @version        0.1.1
+// @version        0.2.0
 // @description    Use the portal fill color to denote the portal has been visited, captured, scout controlled
 
 
-function setStyle (data, color, opacity) {
-  data.portal.setStyle({
-    fillColor: color,
-    fillOpacity: opacity
-  });
-}
+// use own namespace for plugin
+var portalsHistory = {};
+window.plugin.portalHighlighterPortalsHistory = portalsHistory;
 
-function visited (data) {
+portalsHistory.styles = {
+  marked: {
+    fillColor: 'red',
+    fillOpacity: 1
+  },
+  semiMarked: {
+    fillColor: 'yellow',
+    fillOpacity: 1
+  }
+};
+
+portalsHistory.setStyle = function (data, name) {
+  data.portal.setStyle(portalsHistory.styles[name]);
+};
+
+portalsHistory.visited = function (data) {
   var history = data.portal.options.data.history;
   if (!history) {
     return;
   }
   if (history.captured) {
-    setStyle(data, 'red', 1);
+    data.portal.setStyle(portalsHistory.styles.captured);
   } else if (history.visited) {
-    setStyle(data, 'yellow', 1);
+    data.portal.setStyle(portalsHistory.styles.visited);
   }
-}
+};
 
-function notVisited (data) {
+portalsHistory.notVisited = function (data) {
   var history = data.portal.options.data.history;
   if (!history) {
     return;
   }
   if (!history.visited) {
-    setStyle(data, 'red', 1);
+    data.portal.setStyle(portalsHistory.styles.visitTarget);
   } else if (!history.captured) {
-    setStyle(data, 'yellow', 1);
+    data.portal.setStyle(portalsHistory.styles.captureTarget);
   }
-}
-
-function scoutControlled (data) {
-  var history = data.portal.options.data.history;
-  if (history && history.scoutControlled) {
-    setStyle(data, 'red', 1);
-  }
-}
-
-function notScoutControlled (data) {
-  var history = data.portal.options.data.history;
-  if (history && !history.scoutControlled) {
-    setStyle(data, 'red', 1);
-  }
-}
-
-// use own namespace for plugin
-var portalHighlighterPortalsHistory = {
-  visited: visited,
-  notVisited: notVisited,
-  scoutControlled: scoutControlled,
-  notScoutControlled: notScoutControlled,
 };
 
-// use own namespace for plugin
-window.plugin.portalHighlighterPortalsHistory = portalHighlighterPortalsHistory;
+portalsHistory.scoutControlled = function (data) {
+  var history = data.portal.options.data.history;
+  if (history && history.scoutControlled) {
+    data.portal.setStyle(portalsHistory.styles.scoutControlled);
+  }
+};
+
+portalsHistory.notScoutControlled = function (data) {
+  var history = data.portal.options.data.history;
+  if (history && !history.scoutControlled) {
+    data.portal.setStyle(portalsHistory.styles.scoutControllTarget);
+  }
+};
 
 var setup = function () {
-  window.addPortalHighlighter('History: visited/captured', portalHighlighterPortalsHistory.visited);
-  window.addPortalHighlighter('History: not visited/captured', portalHighlighterPortalsHistory.notVisited);
-  window.addPortalHighlighter('History: scout controlled', portalHighlighterPortalsHistory.scoutControlled);
-  window.addPortalHighlighter('History: not scout controlled', portalHighlighterPortalsHistory.notScoutControlled);
+  ['visited', 'captureTarget'].forEach(function (name) {
+    portalsHistory.styles[name] = portalsHistory.styles.semiMarked;
+  });
+  ['captured', 'visitTarget', 'scoutControlled', 'scoutControllTarget'].forEach(function (name) {
+    portalsHistory.styles[name] = portalsHistory.styles.marked;
+  });
+
+  window.addPortalHighlighter('History: visited/captured', portalsHistory.visited);
+  window.addPortalHighlighter('History: not visited/captured', portalsHistory.notVisited);
+  window.addPortalHighlighter('History: scout controlled', portalsHistory.scoutControlled);
+  window.addPortalHighlighter('History: not scout controlled', portalsHistory.notScoutControlled);
 };


### PR DESCRIPTION
Separate style for every included here highlighter.
Any style may be overridden without touching main logic:
- inline (`portalsHistory.styles` object)
- or in separate plugin, with code like this:
  ```js
  var setup = function () {
    var portalsHistory = window.plugin.portalHighlighterPortalsHistory;
    if (!portalsHistory || !portalsHistory.styles) {
      console.warn('highlight-portal-history plugin is required!');
      return;
    }
    portalsHistory.styles.common.radius = 10;
    portalsHistory.styles.commonOther.fillOpacity = 0.1;
  };
  ```

Known styles:
```
  captured <------------ |
  visitTarget <--------- |
  scoutControlled <----- |
  scoutControllTarget <- | <== marked ===== |
                                            | <= common
  visited <------------- | <== semiMarked = |
  captureTarget <------- |
```
```
  otherVC <------- | <= commonOther (empty by default)
  otherScout <---- |
  otherNotVC <---- |
  otherNotScout <- |
```