### PR TITLE
portals-list: add portal history columns

### DIFF
--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -22,6 +22,7 @@
   border-bottom: 1px solid #0b314e;
   color: white;
   padding: 3px;
+  white-space: nowrap;
 }
 
 #portalslist table th {

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -98,6 +98,7 @@
   text-align: center;
   font-size: 20px;
   line-height: 13px;
+  vertical-align: middle;
 }
 
 #portalslist .history.unvisited {

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -107,6 +107,6 @@
   width: 22%;
 }
 
-.ui-dialog.ui-dialog-portallist {
+.ui-dialog.ui-dialog-portalslist {
   max-width: calc(100vw - 2px);
 }

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -98,6 +98,27 @@
   font-size: 10px;
 }
 
+#portalslist .portal-list-history {
+  text-align: center;
+  font-size: 20px;
+}
+
+#portalslist .portal-list-history.unvisited {
+  color: white;
+}
+
+#portalslist .portal-list-history.visited {
+  color: yellow;
+}
+
+#portalslist .portal-list-history.captured {
+  color: red;
+}
+
+#portalslist .portal-list-history.scoutControlled {
+  color: purple;
+}
+
 #portalslist.mobile table.filter tr {
   display: block;
   text-align: center;

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -103,3 +103,6 @@
   width: 22%;
 }
 
+.ui-dialog-portalslist {
+  max-width: none !important;
+}

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -22,7 +22,6 @@
   border-bottom: 1px solid #0b314e;
   color: white;
   padding: 3px;
-  white-space: nowrap;
 }
 
 #portalslist table th {
@@ -54,7 +53,7 @@
 }
 
 #portalslist table.filter {
-  table-layout: auto;
+  table-layout: fixed;
   cursor: pointer;
   border-collapse: separate;
   border-spacing: 1px;

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -57,7 +57,7 @@
 }
 
 #portalslist table.filter {
-  table-layout: fixed;
+  table-layout: auto;
   cursor: pointer;
   border-collapse: separate;
   border-spacing: 1px;

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -106,6 +106,6 @@
   width: 22%;
 }
 
-.ui-dialog-portalslist {
-  max-width: none !important;
+.ui-dialog.ui-dialog-portallist {
+  max-width: calc(100vw - 2px);
 }

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -33,9 +33,6 @@
   text-align: right;
 }
 
-#portalslist table .alignC {
-  text-align: center;
-}
 #portalslist table.portals td {
   white-space: nowrap;
 }
@@ -98,24 +95,24 @@
   font-size: 10px;
 }
 
-#portalslist .portal-list-history {
+#portalslist .history {
   text-align: center;
   font-size: 20px;
 }
 
-#portalslist .portal-list-history.unvisited {
+#portalslist .history.unvisited {
   color: white;
 }
 
-#portalslist .portal-list-history.visited {
+#portalslist .history.visited {
   color: yellow;
 }
 
-#portalslist .portal-list-history.captured {
+#portalslist .history.captured {
   color: red;
 }
 
-#portalslist .portal-list-history.scoutControlled {
+#portalslist .history.scoutControlled {
   color: purple;
 }
 

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -96,7 +96,8 @@
 
 #portalslist .history {
   text-align: center;
-  font-size: 20px;
+  font-size: 30px;
+  line-height: 15px;
 }
 
 #portalslist .history.unvisited {

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -32,6 +32,9 @@
   text-align: right;
 }
 
+#portalslist table .alignC {
+  text-align: center;
+}
 #portalslist table.portals td {
   white-space: nowrap;
 }

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -96,8 +96,8 @@
 
 #portalslist .history {
   text-align: center;
-  font-size: 30px;
-  line-height: 15px;
+  font-size: 20px;
+  line-height: 13px;
 }
 
 #portalslist .history.unvisited {

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -165,7 +165,11 @@ window.plugin.portalslist.fields = [
       if(!info) info = { visited: false, captured: false, scoutControlled: false};
 
       $(cell).addClass("portal-list-history");
-      cell.append((info.visited ? "V" : "_")+"/"+(info.captured ? "C" : "_"));
+      if (info.captured){ cell.append ("🔴");
+      } else { if (info.visited) { cell.append ("🟡");
+               } else {cell.append ("⚪️");}
+      }
+//      cell.append((info.visited ? "V" : "_")+"/"+(info.captured ? "C" : "_"));
 
     }
   },

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -332,7 +332,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
   var length = window.plugin.portalslist.listPortals.length;
 
-  ["All", "Neutral", "Resistance", "Enlightened", "Visited", "Captured", "Scout controlled" ].forEach(function(label, i) {
+  ["All", "Neutral", "Resistance", "Enlightened", "Visited", "Captured", "Scout Controlled" ].forEach(function(label, i) {
     cell = row.appendChild(document.createElement('th'));
     cell.className = 'filter' + label.substr(0, 3);
     cell.textContent = label+':';
@@ -406,7 +406,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
   container.append('<div class="disclaimer">Click on portals table headers to sort by that column. '
     + 'Click on <b>All, Neutral, Resistance, Enlightened</b> to only show portals owned '
     + 'by that faction or on the number behind the factions to show all but those portals. '
-    + 'Click on <b>Visited, Captured or Scout controlled</b> to only show portals the user has a history for '
+    + 'Click on <b>Visited, Captured or Scout Controlled</b> to only show portals the user has a history for '
     + 'or on the number to hide those. </div>');
 
   return container;

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -89,11 +89,11 @@ window.plugin.portalslist.fields = [
   {
     title: "Health",
     value: function(portal) { return portal.options.data.health; },
-    sortValue: function(value, portal) { return portal.options.team===TEAM_NONE ? -1 : value; },
+    sortValue: function(value, portal) { return portal.options.team === TEAM_NONE ? -1 : value; },
     format: function(cell, portal, value) {
       $(cell)
         .addClass("alignR")
-        .text(portal.options.team===TEAM_NONE ? '-' : value+'%');
+        .text(portal.options.team === TEAM_NONE ? '-' : value+'%');
     },
     defaultOrder: -1,
   },
@@ -140,7 +140,7 @@ window.plugin.portalslist.fields = [
     sortValue: function(value, portal) { return value.enemyAp; },
     format: function(cell, portal, value) {
       var title = '';
-      if (teamStringToId(PLAYER.team) == portal.options.team) {
+      if (teamStringToId(PLAYER.team) === portal.options.team) {
         title += 'Friendly AP:\t'+value.friendlyAp+'\n'
                + '- deploy '+(8-portal.options.data.resCount)+' resonator(s)\n'
                + '- upgrades/mods unknown\n';
@@ -269,7 +269,7 @@ window.plugin.portalslist.displayPL = function() {
     dialog({
       html: $('<div id="portalslist">').append(list),
       dialogClass: 'ui-dialog-portalslist',
-      title: 'Portal list: ' + window.plugin.portalslist.listPortals.length + ' ' + (window.plugin.portalslist.listPortals.length == 1 ? 'portal' : 'portals'),
+      title: 'Portal list: ' + window.plugin.portalslist.listPortals.length + ' ' + (window.plugin.portalslist.listPortals.length === 1 ? 'portal' : 'portals'),
       id: 'portal-list',
       width: 700
     });
@@ -306,8 +306,8 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
     portals = portals.filter(function(obj) {
       if (Math.abs(filter) <= 3) {
         return filter < 0
-          ? obj.portal.options.team+1 != -filter
-          : obj.portal.options.team+1 == filter;
+          ? obj.portal.options.team+1 !== -filter
+          : obj.portal.options.team+1 === filter;
       }
       switch (filter) {
         case 4: return obj.portal.options.data.history.visited;
@@ -331,7 +331,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
   var length = window.plugin.portalslist.listPortals.length;
 
-  ["All", "Neutral", "Resistance", "Enlightened", "Visited", "Captured", "Scout Controlled" ].forEach(function(label, i) {
+  ['All', 'Neutral', 'Resistance', 'Enlightened', 'Visited', 'Captured', 'Scout Controlled' ].forEach(function(label, i) {
     cell = row.appendChild(document.createElement('th'));
     cell.className = 'filter' + label.substr(0, 3);
     cell.textContent = label+':';
@@ -354,7 +354,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
     var count = window.plugin.portalslist[name];
     cell.textContent = count + ' (' + Math.round(count/length*100) + '%)';
 
-    if (i == 3) {
+    if (i === 3) {
       // create a new row with an empty first cell
        row = table.insertRow(-1);
        cell = row.insertCell(-1); cell.textContent = (" ");
@@ -376,13 +376,13 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
     cell.textContent = field.title;
     if(field.sort !== null) {
       cell.classList.add("sortable");
-      if(i == window.plugin.portalslist.sortBy) {
+      if(i === window.plugin.portalslist.sortBy) {
         cell.classList.add("sorted");
       }
 
       $(cell).click(function() {
         var order;
-        if(i == sortBy) {
+        if(i === sortBy) {
           order = -sortOrder;
         } else {
           order = field.defaultOrder < 0 ? -1 : 1;
@@ -436,7 +436,7 @@ window.plugin.portalslist.getPortalLink = function(portal) {
 }
 
 window.plugin.portalslist.onPaneChanged = function(pane) {
-  if(pane == "plugin-portalslist")
+  if(pane === "plugin-portalslist")
     window.plugin.portalslist.displayPL();
   else
     $("#portalslist").remove()

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -14,6 +14,10 @@ window.plugin.portalslist.sortOrder = -1;
 window.plugin.portalslist.enlP = 0;
 window.plugin.portalslist.resP = 0;
 window.plugin.portalslist.neuP = 0;
+window.plugin.portalslist.visitedP =0;
+window.plugin.portalslist.capturedP =0;
+window.plugin.portalslist.scoutControlledP =0;
+
 window.plugin.portalslist.filter = 0;
 
 /*
@@ -43,7 +47,7 @@ window.plugin.portalslist.visitedValue = function (guid){
   if (info.visited) return 1;
 }
 
-window.plugin.portalslist.scoutControlledValue = fuction(guid) {
+window.plugin.portalslist.scoutControlledValue = function(guid) {
   var info = window.portals[guid].options.data.history
   if (!info) return 0;
   if (info.scoutControlled === undefined ) return 0;
@@ -213,6 +217,9 @@ window.plugin.portalslist.getPortals = function() {
       default:
         window.plugin.portalslist.neuP++;
     }
+    if (portal.options.data.history.visited) window.plugin.portalslist.visitedP++;
+    if (portal.options.data.history.captured) window.plugin.portalslist.capturedP++;
+    if (portal.options.data.history.scoutControlled) window.plugin.portalslist.scoutControlledP++;
 
     // cache values and DOM nodes
     var obj = { portal: portal, values: [], sortValues: [] };
@@ -253,6 +260,9 @@ window.plugin.portalslist.displayPL = function() {
   window.plugin.portalslist.enlP = 0;
   window.plugin.portalslist.resP = 0;
   window.plugin.portalslist.neuP = 0;
+  window.plugin.portalslist.visitedP = 0;
+  window.plugin.portalslist.capturedP = 0;
+  window.plugin.portalslist.scoutControlledP = 0;
   window.plugin.portalslist.filter = 0;
 
   if (window.plugin.portalslist.getPortals()) {
@@ -303,9 +313,19 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
   if(filter !== 0) {
     portals = portals.filter(function(obj) {
+      if (Math.abs(filter) <= 3) {
       return filter < 0
         ? obj.portal.options.team+1 != -filter
         : obj.portal.options.team+1 == filter;
+      }
+      switch (filter) {
+        case 4: {return (obj.portal.options.data.history.visited)};
+        case 5: {return (obj.portal.options.data.history.captured)};
+        case 6: {return (obj.portal.options.data.history.scoutControlled)};
+        case -4: {return (!obj.portal.options.data.history.visited)};
+        case -5: {return (!obj.portal.options.data.history.captured)};
+        case -6: {return (!obj.portal.options.data.history.scoutControlled)};
+      }: 
     });
   }
 
@@ -320,11 +340,11 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
   var length = window.plugin.portalslist.listPortals.length;
 
-  ["All", "Neutral", "Resistance", "Enlightened"].forEach(function(label, i) {
+  ["All", "Neutral", "Resistance", "Enlightened", "visited", "captured", "Sc. contr." ].forEach(function(label, i) {
     cell = row.appendChild(document.createElement('th'));
     cell.className = 'filter' + label.substr(0, 3);
     cell.textContent = label+':';
-    cell.title = 'Show only portals of this color';
+    cell.title = 'Show only '+label+' portals';
     $(cell).click(function() {
       $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i));
     });
@@ -332,7 +352,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
     cell = row.insertCell(-1);
     cell.className = 'filter' + label.substr(0, 3);
-    if(i != 0) cell.title = 'Hide portals of this color';
+    if(i != 0) cell.title = 'Hide '+label+' portals ';
     $(cell).click(function() {
       $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, -i));
     });
@@ -349,6 +369,18 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
         break;
       case 2:
         cell.textContent = window.plugin.portalslist.enlP + ' (' + Math.round(window.plugin.portalslist.enlP/length*100) + '%)';
+        break;
+      case 3:
+        cell.textContent = window.plugin.portalslist.visitedP + ' (' + Math.round(window.plugin.portalslist.visitedP/length*100) + '%)';
+        break;
+      case 4:
+        cell.textContent = window.plugin.portalslist.capturedP + ' (' + Math.round(window.plugin.portalslist.capturedP/length*100) + '%)';
+        break;
+      case 5:
+        cell.textContent = window.plugin.portalslist.scoutControlledP + ' (' + Math.round(window.plugin.portalslist.scoutControlledP/length*100) + '%)';
+    }
+    if (i = 2) {
+      // create a new row with an empty first cell
     }
   });
 

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -332,7 +332,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
   var length = window.plugin.portalslist.listPortals.length;
 
-  ["All", "Neutral", "Resistance", "Enlightened", "visited", "captured", "Sc. contr." ].forEach(function(label, i) {
+  ["All", "Neutral", "Resistance", "Enlightened", "visited", "captured", "Scout Ctrl" ].forEach(function(label, i) {
     cell = row.appendChild(document.createElement('th'));
     cell.className = 'filter' + label.substr(0, 3);
     cell.textContent = label+':';

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -156,39 +156,22 @@ window.plugin.portalslist.fields = [
   },
   { 
     title: "V/C",
-    value: function(portal) { return portal.options.guid; }, // we store the guid, but implement a custom comparator so the list does sort properly without closing and reopening the dialog
-    sort: function(guidA, guidB) {
-      return window.plugin.portalslist.visitedValue(guidA) - window.plugin.portalslist.visitedValue(guidB);
-    },
-    format: function(cell, portal, guid) {
-      var info = window.portals[guid].options.data.history;
-      if(!info) info = { visited: false, captured: false, scoutControlled: false};
-
+    value: function(portal) { return window.plugin.portalslist.visitedValue(portal.options.guid); },
+    format: function(cell, portal, value) {
       $(cell).addClass("portal-list-history alignC");
-      if (info.captured){
-        cell.append (String.fromCodePoint(0x1F534)); // red dot
-      } else {
-        if (info.visited) {
-          cell.append (String.fromCodePoint(0x1F7E1)); //yellow dot
-        } else {
-          cell.append (String.fromCodePoint(0x26AA)); // white dot
-        }
-      }
-
+      var codePoint = [0x26AA, 0x1F7E1, 0, 0x1F534][value];
+      cell.append (String.fromCodePoint(codePoint));
     }
   },
   {
     title: "S",
-    value: function(portal) { return portal.options.guid; }, // we store the guid, but implement a custom comparator so the list does sort properly without closing and reopening the dialog
-    sort:  function(guidA, guidB) {
-      return window.plugin.portalslist.scoutControlledValue(guidA) - window.plugin.portalslist.scoutControlledValue(guidB);
+    value: function(portal) { 
+      return window.plugin.portalslist.scoutControlledValue(portal.options.guid);
     },
-    format: function(cell, portal, guid) {
-      var info = window.portals[guid].options.data.history;
-      if(!info) info = { visited: false, captured: false, scoutControlled: false};
-
+    format: function(cell, portal, value) {
       $(cell).addClass("portal-list-history allingC");
-      cell.append(String.fromCodePoint(info.scoutControlled ? 0x1F7E3 : 0x26AA)); // violet & white dot
+      var codePoint = [0x26AA, 0x1F7E1, 0, 0x1F534, 0x1F7E3][value];
+      cell.append(String.fromCodePoint(codePoint));
     }
   }
 ];

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -341,41 +341,41 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
       $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i));
     });
 
+    if (i != 0) {
+      cell = row.insertCell(-1);
+      cell.className = 'filter' + label.substr(0, 3);
+      cell.title = 'Hide '+label+' portals ';
+      $(cell).click(function() {
+        $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, -i));
+      });
 
-    cell = row.insertCell(-1);
-    cell.className = 'filter' + label.substr(0, 3);
-    if(i != 0) cell.title = 'Hide '+label+' portals ';
-    $(cell).click(function() {
-      $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, -i));
-    });
-
-    switch(i-1) {
-      case -1:
-        cell.textContent = length;
-        break;
-      case 0:
-        cell.textContent = window.plugin.portalslist.neuP + ' (' + Math.round(window.plugin.portalslist.neuP/length*100) + '%)';
-        break;
-      case 1:
-        cell.textContent = window.plugin.portalslist.resP + ' (' + Math.round(window.plugin.portalslist.resP/length*100) + '%)';
-        break;
-      case 2:
-        cell.textContent = window.plugin.portalslist.enlP + ' (' + Math.round(window.plugin.portalslist.enlP/length*100) + '%)';
-        break;
-      case 3:
-        cell.textContent = window.plugin.portalslist.visitedP + ' (' + Math.round(window.plugin.portalslist.visitedP/length*100) + '%)';
-        break;
-      case 4:
-        cell.textContent = window.plugin.portalslist.capturedP + ' (' + Math.round(window.plugin.portalslist.capturedP/length*100) + '%)';
-        break;
-      case 5:
-        cell.textContent = window.plugin.portalslist.scoutControlledP + ' (' + Math.round(window.plugin.portalslist.scoutControlledP/length*100) + '%)';
-    }
-    if (i == 3) {
-      // create a new row with an empty first cell
-       row = table.insertRow(-1);
-       cell = row.insertCell(-1); cell.textContent = (" ");
-       cell = row.insertCell(-1); cell.textContent = (" ");
+      switch(i-1) {
+        case -1:
+          cell.textContent = length;
+          break;
+        case 0:
+          cell.textContent = window.plugin.portalslist.neuP + ' (' + Math.round(window.plugin.portalslist.neuP/length*100) + '%)';
+          break;
+        case 1:
+          cell.textContent = window.plugin.portalslist.resP + ' (' + Math.round(window.plugin.portalslist.resP/length*100) + '%)';
+          break;
+        case 2:
+          cell.textContent = window.plugin.portalslist.enlP + ' (' + Math.round(window.plugin.portalslist.enlP/length*100) + '%)';
+          break;
+        case 3:
+          cell.textContent = window.plugin.portalslist.visitedP + ' (' + Math.round(window.plugin.portalslist.visitedP/length*100) + '%)';
+          break;
+        case 4:
+          cell.textContent = window.plugin.portalslist.capturedP + ' (' + Math.round(window.plugin.portalslist.capturedP/length*100) + '%)';
+          break;
+        case 5:
+          cell.textContent = window.plugin.portalslist.scoutControlledP + ' (' + Math.round(window.plugin.portalslist.scoutControlledP/length*100) + '%)';
+      }
+      if (i == 3) {
+        // create a new row with an empty first cell
+         row = table.insertRow(-1);
+         cell = row.insertCell(-1); cell.textContent = (" ");
+      }
     }
   });
 

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -1,7 +1,7 @@
 // @author         teo96
 // @name           Portals list
 // @category       Info
-// @version        0.2.2
+// @version        0.3.0
 // @description    Display a sortable list of all visible portals with full details about the team, resonators, links, etc.
 
 
@@ -34,6 +34,22 @@ window.plugin.portalslist.filter = 0;
  *     Which order should by default be used for this column. -1 means descending. Default: 1
  */
 
+window.plugin.portalslist.visitedValue = function (guid){
+  var info = window.portals[guid].options.data.history;
+  if(!info) return 0;
+  if(info.visited === undefined) return 0;
+  if(!info.visited) return 0;
+  if(info.visited && info.captured) return 3;
+  if(info.visited) return 1;
+}
+
+window.plugin.portalslist.scoutControlledValue = fuction(guid) {
+  var info = window.portals[guid].options.data.history
+  if (!info) return 0;
+  if (info.scoutControlled === undefined ) return 0;
+  if (!info.scoutControlled ) return 0;
+  if (info.scoutControlled ) return 4;
+}
 
 window.plugin.portalslist.fields = [
   {
@@ -134,6 +150,35 @@ window.plugin.portalslist.fields = [
     },
     defaultOrder: -1,
   },
+  { 
+    title: "V/C",
+    value: function(portal) { return portal.options.guid; }, // we store the guid, but implement a custom comparator so the list does sort properly without closing and reopening the dialog
+    sort: function(guidA, guidB) {
+      return window.plugin.portalslist.visitedValue(guidA) - window.plugin.portalslist.visitedValue(guidB);
+    },
+    format: function(cell, portal, guid) {
+      var info = window.portals[guid].options.data.history;
+      if(!info) info = { visited: false, captured: false, scoutControlled: false};
+
+      $(cell).addClass("portal-list-history");
+      cell.append((info.visited ? "V" : "_")+"/"+(info.captured ? "C" : "_"));
+
+    }
+  },
+  {
+    title: "S",
+    value: function(portal) { return portal.options.guid; }, // we store the guid, but implement a custom comparator so the list does sort properly without closing and reopening the dialog
+    sort:  function(guidA, guidB) {
+      return window.plugin.portalslist.scoutControlledValue(guidA) - window.plugin.portalslist.scoutControlledValue(guidB);
+    },
+    format: function(cell, portal, guid) {
+      var info = window.portals[guid].options.data.history;
+      if(!info) info = { visited: false, captured: false, scoutControlled: false};
+
+      $(cell).addClass("portal-list-history");
+      cell.append(info.scoutControlled ? "S" : "_");
+    }
+  }
 ];
 
 //fill the listPortals array with portals avaliable on the map (level filtered portals will not appear in the table)
@@ -237,6 +282,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
   var portals = window.plugin.portalslist.listPortals;
   var sortField = window.plugin.portalslist.fields[sortBy];
+
 
   portals.sort(function(a, b) {
     var valueA = a.sortValues[sortBy];

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -158,7 +158,7 @@ window.plugin.portalslist.fields = [
     defaultOrder: -1,
   },
   { 
-    title: "V/C",
+    title: 'V/C',
     value: function(portal) { return window.plugin.portalslist.visitedValue(portal.options.guid); },
     format: function(cell, portal, value) {
       $(cell).addClass("portal-list-history alignC");
@@ -166,12 +166,12 @@ window.plugin.portalslist.fields = [
     }
   },
   {
-    title: "S",
+    title: 'S',
     value: function(portal) { 
       return window.plugin.portalslist.scoutControlledValue(portal.options.guid);
     },
     format: function(cell, portal, value) {
-      $(cell).addClass("portal-list-history allingC");
+      $(cell).addClass('portal-list-history allingC');
       cell.append(window.plugin.portalslist.historyCodePoints[value]);
     }
   }
@@ -284,7 +284,6 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
   var portals = window.plugin.portalslist.listPortals;
   var sortField = window.plugin.portalslist.fields[sortBy];
-
 
   portals.sort(function(a, b) {
     var valueA = a.sortValues[sortBy];

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -162,8 +162,6 @@ window.plugin.portalslist.fields = [
     value: function(portal) { return window.plugin.portalslist.visitedValue(portal.options.guid); },
     format: function(cell, portal, value) {
       $(cell).addClass("portal-list-history alignC");
-//      var codePoint = [0x26AA, 0x1F7E1, 0, 0x1F534][value];
-//      cell.append (String.fromCodePoint(codePoint));
       cell.append(window.plugin.portalslist.historyCodePoints[value]);
     }
   },
@@ -174,7 +172,6 @@ window.plugin.portalslist.fields = [
     },
     format: function(cell, portal, value) {
       $(cell).addClass("portal-list-history allingC");
-//      var codePoint = [0x26AA, 0x1F7E1, 0x2BFF, 0x1F534, 0x1F7E3][value];
       cell.append(window.plugin.portalslist.historyCodePoints[value]);
     }
   }

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -153,7 +153,7 @@ window.plugin.portalslist.fields = [
     format: function(cell, portal, value) {
       if (value === -1) { return; }
       $(cell).addClass([
-        'portal-list-history',
+        'history',
         ['unvisited', 'visited', 'captured'][value]
       ]);
       cell.append(window.plugin.portalslist.historySymbol);
@@ -171,7 +171,7 @@ window.plugin.portalslist.fields = [
     format: function(cell, portal, value) {
       if (value === -1) { return; }
       $(cell).addClass([
-        'portal-list-history',
+        'history',
         ['unvisited', 'scoutControlled'][value]
       ]);
       cell.append(window.plugin.portalslist.historySymbol);

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -14,9 +14,6 @@ window.plugin.portalslist.sortOrder = -1;
 window.plugin.portalslist.enlP = 0;
 window.plugin.portalslist.resP = 0;
 window.plugin.portalslist.neuP = 0;
-window.plugin.portalslist.visitedP = 0;
-window.plugin.portalslist.capturedP = 0;
-window.plugin.portalslist.scoutControlledP = 0;
 
 window.plugin.portalslist.filter = 0;
 
@@ -211,9 +208,6 @@ window.plugin.portalslist.getPortals = function() {
       default:
         window.plugin.portalslist.neuP++;
     }
-    if (portal.options.data.history.visited) window.plugin.portalslist.visitedP++;
-    if (portal.options.data.history.captured) window.plugin.portalslist.capturedP++;
-    if (portal.options.data.history.scoutControlled) window.plugin.portalslist.scoutControlledP++;
 
     // cache values and DOM nodes
     var obj = { portal: portal, values: [], sortValues: [] };
@@ -254,9 +248,6 @@ window.plugin.portalslist.displayPL = function() {
   window.plugin.portalslist.enlP = 0;
   window.plugin.portalslist.resP = 0;
   window.plugin.portalslist.neuP = 0;
-  window.plugin.portalslist.visitedP = 0;
-  window.plugin.portalslist.capturedP = 0;
-  window.plugin.portalslist.scoutControlledP = 0;
   window.plugin.portalslist.filter = 0;
 
   if (window.plugin.portalslist.getPortals()) {
@@ -306,19 +297,9 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
   if(filter !== 0) {
     portals = portals.filter(function(obj) {
-      if (Math.abs(filter) <= 3) {
-        return filter < 0
-          ? obj.portal.options.team+1 !== -filter
-          : obj.portal.options.team+1 === filter;
-      }
-      switch (filter) {
-        case 4: return obj.portal.options.data.history.visited;
-        case 5: return obj.portal.options.data.history.captured;
-        case 6: return obj.portal.options.data.history.scoutControlled;
-        case -4: return !obj.portal.options.data.history.visited;
-        case -5: return !obj.portal.options.data.history.captured;
-        case -6: return !obj.portal.options.data.history.scoutControlled;
-      }; 
+      return filter < 0
+        ? obj.portal.options.team+1 != -filter
+        : obj.portal.options.team+1 == filter;
     });
   }
 
@@ -333,33 +314,35 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
   var length = window.plugin.portalslist.listPortals.length;
 
-  ['All', 'Neutral', 'Resistance', 'Enlightened', 'Visited', 'Captured', 'Scout Controlled' ].forEach(function(label, i) {
+  ["All", "Neutral", "Resistance", "Enlightened"].forEach(function(label, i) {
     cell = row.appendChild(document.createElement('th'));
     cell.className = 'filter' + label.substr(0, 3);
     cell.textContent = label+':';
-    cell.title = 'Show only '+label+' portals';
+    cell.title = 'Show only portals of this color';
     $(cell).click(function() {
       $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i));
     });
 
-    // No 'Hide all portals'
-    if (i === 0) return;
 
     cell = row.insertCell(-1);
     cell.className = 'filter' + label.substr(0, 3);
-    cell.title = 'Hide '+label+' portals ';
+    if(i != 0) cell.title = 'Hide portals of this color';
     $(cell).click(function() {
       $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, -i));
     });
 
-    var name = ['neuP', 'resP', 'enlP', 'visitedP', 'capturedP', 'scoutControlledP'][i-1];
-    var count = window.plugin.portalslist[name];
-    cell.textContent = count + ' (' + Math.round(count/length*100) + '%)';
-
-    if (i === 3) {
-      // create a new row with an empty first cell
-       row = table.insertRow(-1);
-       cell = row.insertCell(-1); cell.textContent = (" ");
+    switch(i-1) {
+      case -1:
+        cell.textContent = length;
+        break;
+      case 0:
+        cell.textContent = window.plugin.portalslist.neuP + ' (' + Math.round(window.plugin.portalslist.neuP/length*100) + '%)';
+        break;
+      case 1:
+        cell.textContent = window.plugin.portalslist.resP + ' (' + Math.round(window.plugin.portalslist.resP/length*100) + '%)';
+        break;
+      case 2:
+        cell.textContent = window.plugin.portalslist.enlP + ' (' + Math.round(window.plugin.portalslist.enlP/length*100) + '%)';
     }
   });
 
@@ -405,10 +388,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
   });
 
   container.append('<div class="disclaimer">Click on portals table headers to sort by that column. '
-    + 'Click on <b>All, Neutral, Resistance, Enlightened</b> to only show portals owned '
-    + 'by that faction or on the number behind the factions to show all but those portals. '
-    + 'Click on <b>Visited, Captured or Scout Controlled</b> to only show portals the user has a history for '
-    + 'or on the number to hide those. </div>');
+    + 'Click on <b>All, Neutral, Resistance, Enlightened</b> to only show portals owner by that faction or on the number behind the factions to show all but those portals.</div>');
 
   return container;
 }

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -50,12 +50,12 @@ window.plugin.portalslist.historyCodePoints =[];
 
 window.plugin.portalslist.visitedValue = function (guid){
   var info = window.portals[guid].options.data.history;
-  return ((info) ? (info.visited + info.captured * 2) : 0);
+  return info ? info.visited + info.captured * 2 : 0;
 }
 
 window.plugin.portalslist.scoutControlledValue = function(guid) {
   var info = window.portals[guid].options.data.history
-  return ((info) ? (info.scoutControlled * 4) : 0);
+  return info ? info.scoutControlled * 4 : 0;
 }
 
 window.plugin.portalslist.fields = [

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -20,15 +20,17 @@ window.plugin.portalslist.scoutControlledP = 0;
 
 window.plugin.portalslist.filter = 0;
 
-window.plugin.portalslist.historyCodePoints =[];
-[0x026AA, // white dot
- 0x1F7E1, // yellow dot
- 0x02B55, // red empty dot (should never show)
- 0x1F534, // red dot
- 0x1F7E3  // violet dot
- ].forEach (function (value) {
-   window.plugin.portalslist.historyCodePoints.push(String.fromCodePoint(value))
+var historySymbols = {
+  unvisited:  0x026AA, // Medium White Circle
+  visited:    0x1F7E1, // Large Yellow Circle
+  captured:   0x1F534, // Large Red Circle
+  scoutControlled: 0x1F7E3  // Large Purple Circle
+};
+$.each(historySymbols, function (prop, code) {
+  historySymbols[prop] = String.fromCodePoint(code);
 });
+historySymbols.unknown = '';
+window.plugin.portalslist.historySymbols = historySymbols;
 
 /*
  * plugins may add fields by appending their specifiation to the following list. The following members are supported:
@@ -47,16 +49,6 @@ window.plugin.portalslist.historyCodePoints =[];
  * defaultOrder: -1|1
  *     Which order should by default be used for this column. -1 means descending. Default: 1
  */
-
-window.plugin.portalslist.visitedValue = function (guid){
-  var info = window.portals[guid].options.data.history;
-  return info ? info.visited + info.captured * 2 : 0;
-}
-
-window.plugin.portalslist.scoutControlledValue = function(guid) {
-  var info = window.portals[guid].options.data.history
-  return info ? info.scoutControlled * 4 : 0;
-}
 
 window.plugin.portalslist.fields = [
   {
@@ -159,20 +151,34 @@ window.plugin.portalslist.fields = [
   },
   { 
     title: 'V/C',
-    value: function(portal) { return window.plugin.portalslist.visitedValue(portal.options.guid); },
+    value: function(portal) {
+      var history = portal.options.data.history;
+      if (history) {
+        return history.captured ? 2
+             : history.visited ? 1
+             : 0;
+      }
+      return -1;
+    },
     format: function(cell, portal, value) {
       $(cell).addClass("portal-list-history alignC");
-      cell.append(window.plugin.portalslist.historyCodePoints[value]);
+      var s = window.plugin.portalslist.historySymbols;
+      cell.append([s.unknown, s.unvisited, s.visited, s.captured][value+1]);
     }
   },
   {
     title: 'S',
     value: function(portal) { 
-      return window.plugin.portalslist.scoutControlledValue(portal.options.guid);
+      var history = portal.options.data.history;
+      if (history) {
+        return history.scoutControlled ? 1 : 0;
+      }
+      return -1;
     },
     format: function(cell, portal, value) {
       $(cell).addClass('portal-list-history alignC');
-      cell.append(window.plugin.portalslist.historyCodePoints[value]);
+      var s = window.plugin.portalslist.historySymbols;
+      cell.append([s.unknown, s.unvisited, s.scoutControlled][value+1]);
     }
   }
 ];

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -423,7 +423,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
   container.append('<div class="disclaimer">Click on portals table headers to sort by that column. '
     + 'Click on <b>All, Neutral, Resistance, Enlightened</b> to only show portals owned '
     + 'by that faction or on the number behind the factions to show all but those portals. '
-    + 'Click on <b>visited, captured or Sc. contr.</b> to only show portals the user has a history for '
+    + 'Click on <b>Visited, Captured or Scout controlled</b> to only show portals the user has a history for '
     + 'or on the number to hide those. </div>');
 
   return container;

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -20,6 +20,16 @@ window.plugin.portalslist.scoutControlledP =0;
 
 window.plugin.portalslist.filter = 0;
 
+window.plugin.portalslist.historyCodePoints =[];
+[0x026AA, // white dot
+ 0x1F7E1, // yellow dot
+ 0x02B55, // red empty dot (should never show)
+ 0x1F534, // red dot
+ 0x1F7E3  // violet dot
+ ].forEach (function (value) {
+   window.plugin.portalslist.historyCodePoints.push(String.fromCodePoint(value))
+});
+
 /*
  * plugins may add fields by appending their specifiation to the following list. The following members are supported:
  * title: String
@@ -40,19 +50,12 @@ window.plugin.portalslist.filter = 0;
 
 window.plugin.portalslist.visitedValue = function (guid){
   var info = window.portals[guid].options.data.history;
-  if (!info) return 0;
-  if (info.visited === undefined) return 0;
-  if (!info.visited) return 0;
-  if (info.visited && info.captured) return 3;
-  if (info.visited) return 1;
+  return ((info) ? (info.visited + info.captured * 2) : 0);
 }
 
 window.plugin.portalslist.scoutControlledValue = function(guid) {
   var info = window.portals[guid].options.data.history
-  if (!info) return 0;
-  if (info.scoutControlled === undefined ) return 0;
-  if (!info.scoutControlled ) return 0;
-  if (info.scoutControlled ) return 4;
+  return ((info) ? (info.scoutControlled * 4) : 0);
 }
 
 window.plugin.portalslist.fields = [
@@ -159,8 +162,9 @@ window.plugin.portalslist.fields = [
     value: function(portal) { return window.plugin.portalslist.visitedValue(portal.options.guid); },
     format: function(cell, portal, value) {
       $(cell).addClass("portal-list-history alignC");
-      var codePoint = [0x26AA, 0x1F7E1, 0, 0x1F534][value];
-      cell.append (String.fromCodePoint(codePoint));
+//      var codePoint = [0x26AA, 0x1F7E1, 0, 0x1F534][value];
+//      cell.append (String.fromCodePoint(codePoint));
+      cell.append(window.plugin.portalslist.historyCodePoints[value]);
     }
   },
   {
@@ -170,8 +174,8 @@ window.plugin.portalslist.fields = [
     },
     format: function(cell, portal, value) {
       $(cell).addClass("portal-list-history allingC");
-      var codePoint = [0x26AA, 0x1F7E1, 0, 0x1F534, 0x1F7E3][value];
-      cell.append(String.fromCodePoint(codePoint));
+//      var codePoint = [0x26AA, 0x1F7E1, 0x2BFF, 0x1F534, 0x1F7E3][value];
+      cell.append(window.plugin.portalslist.historyCodePoints[value]);
     }
   }
 ];

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -14,9 +14,9 @@ window.plugin.portalslist.sortOrder = -1;
 window.plugin.portalslist.enlP = 0;
 window.plugin.portalslist.resP = 0;
 window.plugin.portalslist.neuP = 0;
-window.plugin.portalslist.visitedP =0;
-window.plugin.portalslist.capturedP =0;
-window.plugin.portalslist.scoutControlledP =0;
+window.plugin.portalslist.visitedP = 0;
+window.plugin.portalslist.capturedP = 0;
+window.plugin.portalslist.scoutControlledP = 0;
 
 window.plugin.portalslist.filter = 0;
 
@@ -306,9 +306,9 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
   if(filter !== 0) {
     portals = portals.filter(function(obj) {
       if (Math.abs(filter) <= 3) {
-      return filter < 0
-        ? obj.portal.options.team+1 != -filter
-        : obj.portal.options.team+1 == filter;
+        return filter < 0
+          ? obj.portal.options.team+1 != -filter
+          : obj.portal.options.team+1 == filter;
       }
       switch (filter) {
         case 4: {return (obj.portal.options.data.history.visited)};

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -332,7 +332,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
   var length = window.plugin.portalslist.listPortals.length;
 
-  ["All", "Neutral", "Resistance", "Enlightened", "visited", "captured", "Scout Ctrl" ].forEach(function(label, i) {
+  ["All", "Neutral", "Resistance", "Enlightened", "Visited", "Captured", "Scout controlled" ].forEach(function(label, i) {
     cell = row.appendChild(document.createElement('th'));
     cell.className = 'filter' + label.substr(0, 3);
     cell.textContent = label+':';

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -351,25 +351,10 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
       $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, -i));
     });
 
-    switch(i-1) {
-      case 0:
-        cell.textContent = window.plugin.portalslist.neuP + ' (' + Math.round(window.plugin.portalslist.neuP/length*100) + '%)';
-        break;
-      case 1:
-        cell.textContent = window.plugin.portalslist.resP + ' (' + Math.round(window.plugin.portalslist.resP/length*100) + '%)';
-        break;
-      case 2:
-        cell.textContent = window.plugin.portalslist.enlP + ' (' + Math.round(window.plugin.portalslist.enlP/length*100) + '%)';
-        break;
-      case 3:
-        cell.textContent = window.plugin.portalslist.visitedP + ' (' + Math.round(window.plugin.portalslist.visitedP/length*100) + '%)';
-        break;
-      case 4:
-        cell.textContent = window.plugin.portalslist.capturedP + ' (' + Math.round(window.plugin.portalslist.capturedP/length*100) + '%)';
-        break;
-      case 5:
-        cell.textContent = window.plugin.portalslist.scoutControlledP + ' (' + Math.round(window.plugin.portalslist.scoutControlledP/length*100) + '%)';
-    }
+    var name = ['neuP', 'resP', 'enlP', 'visitedP', 'capturedP', 'scoutControlledP'][i-1];
+    var count = window.plugin.portalslist[name];
+    cell.textContent = count + ' (' + Math.round(count/length*100) + '%)';
+
     if (i == 3) {
       // create a new row with an empty first cell
        row = table.insertRow(-1);

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -20,17 +20,7 @@ window.plugin.portalslist.scoutControlledP = 0;
 
 window.plugin.portalslist.filter = 0;
 
-var historySymbols = {
-  unvisited:  0x026AA, // Medium White Circle
-  visited:    0x1F7E1, // Large Yellow Circle
-  captured:   0x1F534, // Large Red Circle
-  scoutControlled: 0x1F7E3  // Large Purple Circle
-};
-$.each(historySymbols, function (prop, code) {
-  historySymbols[prop] = String.fromCodePoint(code);
-});
-historySymbols.unknown = '';
-window.plugin.portalslist.historySymbols = historySymbols;
+window.plugin.portalslist.historySymbol = String.fromCodePoint(0x25CF);
 
 /*
  * plugins may add fields by appending their specifiation to the following list. The following members are supported:
@@ -161,9 +151,12 @@ window.plugin.portalslist.fields = [
       return -1;
     },
     format: function(cell, portal, value) {
-      $(cell).addClass("portal-list-history alignC");
-      var s = window.plugin.portalslist.historySymbols;
-      cell.append([s.unknown, s.unvisited, s.visited, s.captured][value+1]);
+      if (value === -1) { return; }
+      $(cell).addClass([
+        'portal-list-history',
+        ['unvisited', 'visited', 'captured'][value]
+      ]);
+      cell.append(window.plugin.portalslist.historySymbol);
     }
   },
   {
@@ -176,9 +169,12 @@ window.plugin.portalslist.fields = [
       return -1;
     },
     format: function(cell, portal, value) {
-      $(cell).addClass('portal-list-history alignC');
-      var s = window.plugin.portalslist.historySymbols;
-      cell.append([s.unknown, s.unvisited, s.scoutControlled][value+1]);
+      if (value === -1) { return; }
+      $(cell).addClass([
+        'portal-list-history',
+        ['unvisited', 'scoutControlled'][value]
+      ]);
+      cell.append(window.plugin.portalslist.historySymbol);
     }
   }
 ];

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -341,41 +341,39 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
       $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i));
     });
 
-    if (i != 0) {
-      cell = row.insertCell(-1);
-      cell.className = 'filter' + label.substr(0, 3);
-      cell.title = 'Hide '+label+' portals ';
-      $(cell).click(function() {
-        $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, -i));
-      });
+    // No 'Hide all portals'
+    if (i === 0) return;
 
-      switch(i-1) {
-        case -1:
-          cell.textContent = length;
-          break;
-        case 0:
-          cell.textContent = window.plugin.portalslist.neuP + ' (' + Math.round(window.plugin.portalslist.neuP/length*100) + '%)';
-          break;
-        case 1:
-          cell.textContent = window.plugin.portalslist.resP + ' (' + Math.round(window.plugin.portalslist.resP/length*100) + '%)';
-          break;
-        case 2:
-          cell.textContent = window.plugin.portalslist.enlP + ' (' + Math.round(window.plugin.portalslist.enlP/length*100) + '%)';
-          break;
-        case 3:
-          cell.textContent = window.plugin.portalslist.visitedP + ' (' + Math.round(window.plugin.portalslist.visitedP/length*100) + '%)';
-          break;
-        case 4:
-          cell.textContent = window.plugin.portalslist.capturedP + ' (' + Math.round(window.plugin.portalslist.capturedP/length*100) + '%)';
-          break;
-        case 5:
-          cell.textContent = window.plugin.portalslist.scoutControlledP + ' (' + Math.round(window.plugin.portalslist.scoutControlledP/length*100) + '%)';
-      }
-      if (i == 3) {
-        // create a new row with an empty first cell
-         row = table.insertRow(-1);
-         cell = row.insertCell(-1); cell.textContent = (" ");
-      }
+    cell = row.insertCell(-1);
+    cell.className = 'filter' + label.substr(0, 3);
+    cell.title = 'Hide '+label+' portals ';
+    $(cell).click(function() {
+      $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, -i));
+    });
+
+    switch(i-1) {
+      case 0:
+        cell.textContent = window.plugin.portalslist.neuP + ' (' + Math.round(window.plugin.portalslist.neuP/length*100) + '%)';
+        break;
+      case 1:
+        cell.textContent = window.plugin.portalslist.resP + ' (' + Math.round(window.plugin.portalslist.resP/length*100) + '%)';
+        break;
+      case 2:
+        cell.textContent = window.plugin.portalslist.enlP + ' (' + Math.round(window.plugin.portalslist.enlP/length*100) + '%)';
+        break;
+      case 3:
+        cell.textContent = window.plugin.portalslist.visitedP + ' (' + Math.round(window.plugin.portalslist.visitedP/length*100) + '%)';
+        break;
+      case 4:
+        cell.textContent = window.plugin.portalslist.capturedP + ' (' + Math.round(window.plugin.portalslist.capturedP/length*100) + '%)';
+        break;
+      case 5:
+        cell.textContent = window.plugin.portalslist.scoutControlledP + ' (' + Math.round(window.plugin.portalslist.scoutControlledP/length*100) + '%)';
+    }
+    if (i == 3) {
+      // create a new row with an empty first cell
+       row = table.insertRow(-1);
+       cell = row.insertCell(-1); cell.textContent = (" ");
     }
   });
 

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -311,12 +311,12 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
           : obj.portal.options.team+1 == filter;
       }
       switch (filter) {
-        case 4: {return (obj.portal.options.data.history.visited)};
-        case 5: {return (obj.portal.options.data.history.captured)};
-        case 6: {return (obj.portal.options.data.history.scoutControlled)};
-        case -4: {return (!obj.portal.options.data.history.visited)};
-        case -5: {return (!obj.portal.options.data.history.captured)};
-        case -6: {return (!obj.portal.options.data.history.scoutControlled)};
+        case 4: return obj.portal.options.data.history.visited;
+        case 5: return obj.portal.options.data.history.captured;
+        case 6: return obj.portal.options.data.history.scoutControlled;
+        case -4: return !obj.portal.options.data.history.visited;
+        case -5: return !obj.portal.options.data.history.captured;
+        case -6: return !obj.portal.options.data.history.scoutControlled;
       }; 
     });
   }

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -164,12 +164,16 @@ window.plugin.portalslist.fields = [
       var info = window.portals[guid].options.data.history;
       if(!info) info = { visited: false, captured: false, scoutControlled: false};
 
-      $(cell).addClass("portal-list-history");
-      if (info.captured){ cell.append ("🔴");
-      } else { if (info.visited) { cell.append ("🟡");
-               } else {cell.append ("⚪️");}
+      $(cell).addClass("portal-list-history alignC");
+      if (info.captured){
+        cell.append (String.fromCodePoint(0x1F534)); // red dot
+      } else {
+        if (info.visited) {
+          cell.append (String.fromCodePoint(0x1F7E1)); //yellow dot
+        } else {
+          cell.append (String.fromCodePoint(0x26AA)); // white dot
+        }
       }
-//      cell.append((info.visited ? "V" : "_")+"/"+(info.captured ? "C" : "_"));
 
     }
   },
@@ -183,8 +187,8 @@ window.plugin.portalslist.fields = [
       var info = window.portals[guid].options.data.history;
       if(!info) info = { visited: false, captured: false, scoutControlled: false};
 
-      $(cell).addClass("portal-list-history");
-      cell.append(info.scoutControlled ? "S" : "_");
+      $(cell).addClass("portal-list-history allingC");
+      cell.append(String.fromCodePoint(info.scoutControlled ? 0x1F7E3 : 0x26AA)); // violet & white dot
     }
   }
 ];
@@ -329,7 +333,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
         case -4: {return (!obj.portal.options.data.history.visited)};
         case -5: {return (!obj.portal.options.data.history.captured)};
         case -6: {return (!obj.portal.options.data.history.scoutControlled)};
-      }: 
+      }; 
     });
   }
 
@@ -383,8 +387,11 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
       case 5:
         cell.textContent = window.plugin.portalslist.scoutControlledP + ' (' + Math.round(window.plugin.portalslist.scoutControlledP/length*100) + '%)';
     }
-    if (i = 2) {
+    if (i == 3) {
       // create a new row with an empty first cell
+       row = table.insertRow(-1);
+       cell = row.insertCell(-1); cell.textContent = (" ");
+       cell = row.insertCell(-1); cell.textContent = (" ");
     }
   });
 
@@ -430,7 +437,10 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
   });
 
   container.append('<div class="disclaimer">Click on portals table headers to sort by that column. '
-    + 'Click on <b>All, Neutral, Resistance, Enlightened</b> to only show portals owner by that faction or on the number behind the factions to show all but those portals.</div>');
+    + 'Click on <b>All, Neutral, Resistance, Enlightened</b> to only show portals owned '
+    + 'by that faction or on the number behind the factions to show all but those portals. '
+    + 'Click on <b>visited, captured or Sc. contr.</b> to only show portals the user has a history for '
+    + 'or on the number to hide those. </div>');
 
   return container;
 }

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -171,7 +171,7 @@ window.plugin.portalslist.fields = [
       return window.plugin.portalslist.scoutControlledValue(portal.options.guid);
     },
     format: function(cell, portal, value) {
-      $(cell).addClass('portal-list-history allingC');
+      $(cell).addClass('portal-list-history alignC');
       cell.append(window.plugin.portalslist.historyCodePoints[value]);
     }
   }

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -36,11 +36,11 @@ window.plugin.portalslist.filter = 0;
 
 window.plugin.portalslist.visitedValue = function (guid){
   var info = window.portals[guid].options.data.history;
-  if(!info) return 0;
-  if(info.visited === undefined) return 0;
-  if(!info.visited) return 0;
-  if(info.visited && info.captured) return 3;
-  if(info.visited) return 1;
+  if (!info) return 0;
+  if (info.visited === undefined) return 0;
+  if (!info.visited) return 0;
+  if (info.visited && info.captured) return 3;
+  if (info.visited) return 1;
 }
 
 window.plugin.portalslist.scoutControlledValue = fuction(guid) {


### PR DESCRIPTION
Added 2 columns, displaying history statuses as colored circles:
- "V/C", denoting Unvisited/Visited/Captured (white/yellow/red).
- "S", ScoutControlled (white/purple).

Colors can be changed via css.
<details>

@le-jeu 
> This is an example of CSS to handle colors while allowing customization at CSS level (without injecting js). First part remove the current circle (to test on the current portallist in testing), second is how to add the current circle from CSS, third is an example of CSS customization (adding specific glyph for each category)
```css
/* hack to remove current marker */
#portalslist .portal-list-history {
  font-size: 0px;
}
#portalslist .portal-list-history:after {
  font-size: 20px;
}
/* end of the hack */

/* default */
#portalslist .portal-list-history:after {
  content: "●";
  vertical-align: middle
}

/* example of customization, using the initial icons */
#portalslist .portal-list-history.visited:after {
  content: '\1F7E1'
}

#portalslist .portal-list-history.unvisited:after {
  content: '\26AA'
}

#portalslist .portal-list-history.captured:after {
  content: '\1F534'
}

#portalslist .portal-list-history.scoutControlled:after {
  content: '\1F7E3'
}

/* assuming unvisited is set whatever the capture state */
#portalslist .portal-list-history.captured.unvisited:after {
  content: "\2B55"
}
```

</details>

Note: some functionality separated into #456.