### PR TITLE
Intel data (portals/links/fields): from layers to filters 

### DIFF
--- a/core/code/filters.js
+++ b/core/code/filters.js
@@ -1,7 +1,12 @@
 /* Filters API
 
-Filters work by exclusion, following the old layer system.
-A feature that matches a filter is removed from the map.
+Filters API is a mechanism to hide intel entities using their properties (faction,
+health, timestamp...). It provides two level APIs: a set of named filters that
+apply globally (any entity matching one of the filters will be hidden), and low
+level API to test an entity against a filter for generic purpose.
+This comes with a Leaflet layer system following the old layer system, the filter
+is disabled when the layer is added to the map and is enabled when removed.
+
 A filter applies to a combinaison of portal/link/field and is described by
  - data properties that must (all) match
  - or a predicate for complex filter
@@ -14,6 +19,37 @@ A filter applies to a combinaison of portal/link/field and is described by
 
   { field: true, pred: function (f) { return f.options.timestamp < Date.parse('2021-10-31'); } }
       filters any fields made before Halloween 2021
+
+Data properties can be specified as value, or as a complex expression (required
+for array data properties). A complex expression is a 2-array, first element is
+an operator, second is the argument of the operator for the property.
+The operators are:
+ - ['eq', value] : this is equivalent to type directly `value`
+ - ['not', ]
+ - ['or', [exp1, exp2,...]]: the expression matches if one of the exp1.. matches
+ - ['and', [exp1, exp2...]]: matches if all exp1 matches (useful for array
+  properties)
+ - ['some', exp]: when the property is an array, matches if one of the element
+  matches `exp`
+ - ['every', exp]: all elements must match `exp`
+ - ['<', number]: for number comparison (and <= > >=)
+
+Examples:
+  { portal: true, data:  ['not', { history: { scoutControlled: false }, ornaments:
+  ['some', 'sc5_p'] }] }
+      filters all portals but the one never scout controlled that have a scout
+      volatile ornament
+
+  { portal: true, data: ['not', { resonators: ['every', { owner: 'some agent' } ] } ] }
+      filters all portals that have resonators not owned from 'some agent'
+      (note: that would need to load portal details)
+
+  { portal: true, data: { level: ['or', [1,4,5]], health: ['>', 85] } }
+      filters all portals with level 1,4 or 5 and health over 85
+
+  { portal: true, link: true, field: true, options: { timestamp: ['<',
+  Date.now() - 3600000] } }
+      filters all entities with no change since 1 hour.
 */
 
 IITC.filters = {};
@@ -35,6 +71,7 @@ IITC.filters._filters = {};
  * @property {boolean} filterDesc.link           apply to link
  * @property {boolean} filterDesc.field          apply to field
  * @property {object} [filterDesc.data]          entity data properties that must match
+ * @property {object} [filterDesc.options]       entity options that must match
  * @property {FilterPredicate} [filterDesc.pred] predicate on the entity
  */
 
@@ -54,25 +91,120 @@ IITC.filters.remove = function (name) {
   return delete IITC.filters._filters[name];
 };
 
-function simpleFilter(type, entity, filter) {
+function compareValue(constraint, value) {
+  if (constraint instanceof Array) return false;
+  // array must be handled by "some" or "every"
+  if (value instanceof Array) return false;
+  if (constraint instanceof Object) {
+    if (!(value instanceof Object)) return false;
+    // implicit AND on object properties
+    for (const prop in constraint) {
+      if (!genericCompare(constraint[prop], value[prop])) {return false;}
+    }
+    return true;
+  }
+  return constraint === value;
+}
+
+function compareNumber(constraint, value) {
+  if (typeof value !== 'number') return false;
+  if (typeof constraint[1] !== 'number') return false;
+  const v = constraint[1];
+  switch (constraint[0]) {
+  case '==': return value === v;
+  case '<': return value < v;
+  case '<=': return value <= v;
+  case '>': return value > v;
+  case '>=': return value >= v;
+  }
+  return false;
+}
+
+function genericCompare(constraint, object) {
+  if (constraint instanceof Array) {
+    if (constraint.length !== 2) return false;
+    const [op, args] = constraint;
+    switch (op) {
+    case 'eq':
+      return compareValue(args, object);
+    case 'or':
+      if (args instanceof Array) {
+        for (const arg of args) {
+          if (genericCompare(arg, object)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    case 'and':
+      if (args instanceof Array) {
+        for (const arg of args) {
+          if (!genericCompare(arg, object)) {
+            return false;
+          }
+        }
+      }
+      return true;
+    case 'some':
+      if (object instanceof Array) {
+        for (const obj of object) {
+          if (genericCompare(args, obj)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    case 'every':
+      if (object instanceof Array) {
+        for (const obj of object) {
+          if (!genericCompare(args, obj)) {
+            return false;
+          }
+        }
+      }
+      return true;
+    case 'not':
+      return !genericCompare(args, object);
+    case '==':
+    case '<':
+    case '<=':
+    case '>':
+    case '>=':
+      return compareNumber(constraint, object);
+    default:
+        // unknown op
+    }
+    return false;
+  }
+  return compareValue(constraint, object);
+}
+
+/**
+ *
+ * @param {"portal"|"link"|"field"} type Type of the entity
+ * @param {object} entity Portal/link/field to test
+ * @param {FilterDesc} filter Filter
+ * @returns {boolean} `true` if the the `entity` of type `type` matches the `filter`
+ */
+IITC.filters.testFilter = function (type, entity, filter) {
   // type must match
   if (!filter[type]) return false;
   // use predicate if available
-  if (typeof filter.pred === "function") return filter.pred(entity);
-  // if no constraint, match
-  if (!filter.data) return true;
-  // else must match all constraints
-  for (var prop in filter.data)
-    if (entity.options.data[prop] !== filter.data[prop]) return false;
+  if (typeof filter.pred === 'function') return filter.pred(entity);
+  // if doesn't match data constraint
+  if (filter.data && !genericCompare(filter.data, entity.options.data)) return false;
+  // if doesn't match options
+  if (filter.options && !genericCompare(filter.options, entity.options)) {return false;}
+  // else it matches
   return true;
-}
+};
 
 function arrayFilter(type, entity, filters) {
   if (!Array.isArray(filters)) filters = [filters];
   filters = filters.flat();
-  for (let i = 0; i < filters.length; i++)
-    if (simpleFilter(type, entity, filters[i]))
-      return true;
+  for (let i = 0; i < filters.length; i++) {
+    if (IITC.filters.testFilter(type, entity, filters[i])) {return true;}
+  }
   return false;
 }
 
@@ -104,18 +236,18 @@ IITC.filters.filterField = function (field) {
 };
 
 IITC.filters.filterEntities = function () {
-  for (var guid in window.portals) {
-    var p = window.portals[guid];
+  for (const guid in window.portals) {
+    const p = window.portals[guid];
     if (IITC.filters.filterPortal(p)) p.remove();
     else p.addTo(window.map);
   }
-  for (var guid in window.links) {
-    var link = window.links[guid];
+  for (const guid in window.links) {
+    const link = window.links[guid];
     if (IITC.filters.filterLink(link)) link.remove();
     else link.addTo(window.map);
   }
-  for (var guid in window.fields) {
-    var field = window.fields[guid];
+  for (const guid in window.fields) {
+    const field = window.fields[guid];
     if (IITC.filters.filterField(field)) field.remove();
     else field.addTo(window.map);
   }
@@ -139,13 +271,15 @@ IITC.filters.FilterLayer = L.Layer.extend({
     IITC.filters.set(this.options.name, this.options.filter);
   },
 
-  onAdd: function (map) {
+  onAdd: function () {
     IITC.filters.remove(this.options.name);
     IITC.filters.filterEntities();
   },
 
-  onRemove: function (map) {
+  onRemove: function () {
     IITC.filters.set(this.options.name, this.options.filter);
     IITC.filters.filterEntities();
   },
 });
+
+/* global IITC, L */

--- a/core/code/filters.js
+++ b/core/code/filters.js
@@ -49,7 +49,8 @@ Examples:
 
   { portal: true, link: true, field: true, options: { timestamp: ['<',
   Date.now() - 3600000] } }
-      filters all entities with no change since 1 hour.
+      filters all entities with no change since 1 hour (from the creation of
+      the filter)
 */
 
 IITC.filters = {};
@@ -99,7 +100,9 @@ function compareValue(constraint, value) {
     if (!(value instanceof Object)) return false;
     // implicit AND on object properties
     for (const prop in constraint) {
-      if (!genericCompare(constraint[prop], value[prop])) {return false;}
+      if (!genericCompare(constraint[prop], value[prop])) {
+        return false;
+      }
     }
     return true;
   }
@@ -111,11 +114,16 @@ function compareNumber(constraint, value) {
   if (typeof constraint[1] !== 'number') return false;
   const v = constraint[1];
   switch (constraint[0]) {
-  case '==': return value === v;
-  case '<': return value < v;
-  case '<=': return value <= v;
-  case '>': return value > v;
-  case '>=': return value >= v;
+    case '==':
+      return value === v;
+    case '<':
+      return value < v;
+    case '<=':
+      return value <= v;
+    case '>':
+      return value > v;
+    case '>=':
+      return value >= v;
   }
   return false;
 }
@@ -125,54 +133,54 @@ function genericCompare(constraint, object) {
     if (constraint.length !== 2) return false;
     const [op, args] = constraint;
     switch (op) {
-    case 'eq':
-      return compareValue(args, object);
-    case 'or':
-      if (args instanceof Array) {
-        for (const arg of args) {
-          if (genericCompare(arg, object)) {
-            return true;
+      case 'eq':
+        return compareValue(args, object);
+      case 'or':
+        if (args instanceof Array) {
+          for (const arg of args) {
+            if (genericCompare(arg, object)) {
+              return true;
+            }
           }
         }
-      }
-      return false;
-    case 'and':
-      if (args instanceof Array) {
-        for (const arg of args) {
-          if (!genericCompare(arg, object)) {
-            return false;
+        return false;
+      case 'and':
+        if (args instanceof Array) {
+          for (const arg of args) {
+            if (!genericCompare(arg, object)) {
+              return false;
+            }
           }
         }
-      }
-      return true;
-    case 'some':
-      if (object instanceof Array) {
-        for (const obj of object) {
-          if (genericCompare(args, obj)) {
-            return true;
+        return true;
+      case 'some':
+        if (object instanceof Array) {
+          for (const obj of object) {
+            if (genericCompare(args, obj)) {
+              return true;
+            }
           }
         }
-      }
-      return false;
-    case 'every':
-      if (object instanceof Array) {
-        for (const obj of object) {
-          if (!genericCompare(args, obj)) {
-            return false;
+        return false;
+      case 'every':
+        if (object instanceof Array) {
+          for (const obj of object) {
+            if (!genericCompare(args, obj)) {
+              return false;
+            }
           }
         }
-      }
-      return true;
-    case 'not':
-      return !genericCompare(args, object);
-    case '==':
-    case '<':
-    case '<=':
-    case '>':
-    case '>=':
-      return compareNumber(constraint, object);
-    default:
-        // unknown op
+        return true;
+      case 'not':
+        return !genericCompare(args, object);
+      case '==':
+      case '<':
+      case '<=':
+      case '>':
+      case '>=':
+        return compareNumber(constraint, object);
+      default:
+      // unknown op
     }
     return false;
   }
@@ -194,7 +202,9 @@ IITC.filters.testFilter = function (type, entity, filter) {
   // if doesn't match data constraint
   if (filter.data && !genericCompare(filter.data, entity.options.data)) return false;
   // if doesn't match options
-  if (filter.options && !genericCompare(filter.options, entity.options)) {return false;}
+  if (filter.options && !genericCompare(filter.options, entity.options)) {
+    return false;
+  }
   // else it matches
   return true;
 };
@@ -203,7 +213,9 @@ function arrayFilter(type, entity, filters) {
   if (!Array.isArray(filters)) filters = [filters];
   filters = filters.flat();
   for (let i = 0; i < filters.length; i++) {
-    if (IITC.filters.testFilter(type, entity, filters[i])) {return true;}
+    if (IITC.filters.testFilter(type, entity, filters[i])) {
+      return true;
+    }
   }
   return false;
 }

--- a/core/code/filters.js
+++ b/core/code/filters.js
@@ -1,0 +1,151 @@
+/* Filters API
+
+Filters work by exclusion, following the old layer system.
+A feature that matches a filter is removed from the map.
+A filter applies to a combinaison of portal/link/field and is described by
+ - data properties that must (all) match
+ - or a predicate for complex filter
+
+  { portal: true, link: true, data: { team: 'E' }}
+      filters any ENL portal/link
+
+  [{ link: true, data: { oGuid: "some guid" }}, { link: true, data: { dGuid: "some guid" }}]
+      filters any links on portal with guid "some guid"
+
+  { field: true, pred: function (f) { return f.options.timestamp < Date.parse('2021-10-31'); } }
+      filters any fields made before Halloween 2021
+*/
+
+IITC.filters = {};
+/**
+ * @type {Object.<string, FilterDesc>}
+ */
+IITC.filters._filters = {};
+
+/**
+ * @callback FilterPredicate
+ * @param {Object} ent - IITC entity
+ * @returns {boolean}
+ */
+
+/**
+ * @typedef FilterDesc
+ * @type {object}
+ * @property {boolean} filterDesc.portal         apply to portal
+ * @property {boolean} filterDesc.link           apply to link
+ * @property {boolean} filterDesc.field          apply to field
+ * @property {object} [filterDesc.data]          entity data properties that must match
+ * @property {FilterPredicate} [filterDesc.pred] predicate on the entity
+ */
+
+/**
+ * @param {string} name                              filter name
+ * @param {FilterDesc | FilterDesc[]} filterDesc     filter description (OR)
+ */
+IITC.filters.set = function (name, filterDesc) {
+  IITC.filters._filters[name] = filterDesc;
+};
+
+IITC.filters.has = function (name) {
+  return name in IITC.filters._filters;
+};
+
+IITC.filters.remove = function (name) {
+  return delete IITC.filters._filters[name];
+};
+
+function simpleFilter(type, entity, filter) {
+  // type must match
+  if (!filter[type]) return false;
+  // use predicate if available
+  if (typeof filter.pred === "function") return filter.pred(entity);
+  // if no constraint, match
+  if (!filter.data) return true;
+  // else must match all constraints
+  for (var prop in filter.data)
+    if (entity.options.data[prop] !== filter.data[prop]) return false;
+  return true;
+}
+
+function arrayFilter(type, entity, filters) {
+  if (!Array.isArray(filters)) filters = [filters];
+  filters = filters.flat();
+  for (let i = 0; i < filters.length; i++)
+    if (simpleFilter(type, entity, filters[i]))
+      return true;
+  return false;
+}
+
+/**
+ *
+ * @param {object} portal Portal to test
+ * @returns {boolean} `true` if the the portal matches one of the filters
+ */
+IITC.filters.filterPortal = function (portal) {
+  return arrayFilter('portal', portal, Object.values(IITC.filters._filters));
+};
+
+/**
+ *
+ * @param {object} link Link to test
+ * @returns {boolean} `true` if the the link matches one of the filters
+ */
+IITC.filters.filterLink = function (link) {
+  return arrayFilter('link', link, Object.values(IITC.filters._filters));
+};
+
+/**
+ *
+ * @param {object} field Field to test
+ * @returns {boolean} `true` if the the field matches one of the filters
+ */
+IITC.filters.filterField = function (field) {
+  return arrayFilter('field', field, Object.values(IITC.filters._filters));
+};
+
+IITC.filters.filterEntities = function () {
+  for (var guid in window.portals) {
+    var p = window.portals[guid];
+    if (IITC.filters.filterPortal(p)) p.remove();
+    else p.addTo(window.map);
+  }
+  for (var guid in window.links) {
+    var link = window.links[guid];
+    if (IITC.filters.filterLink(link)) link.remove();
+    else link.addTo(window.map);
+  }
+  for (var guid in window.fields) {
+    var field = window.fields[guid];
+    if (IITC.filters.filterField(field)) field.remove();
+    else field.addTo(window.map);
+  }
+};
+
+/**
+ * @class FilterLayer
+ * @description Layer abstraction to control with the layer chooser a filter.
+ *              The filter is disabled on layer add, and enabled on layer remove.
+ * @extends L.Layer
+ * @param {{name: string, filter: FilterDesc}} options
+ */
+IITC.filters.FilterLayer = L.Layer.extend({
+  options: {
+    name: null,
+    filter: {},
+  },
+
+  initialize: function (options) {
+    L.setOptions(this, options);
+    IITC.filters.set(this.options.name, this.options.filter);
+  },
+
+  onAdd: function (map) {
+    IITC.filters.remove(this.options.name);
+    IITC.filters.filterEntities();
+  },
+
+  onRemove: function (map) {
+    IITC.filters.set(this.options.name, this.options.filter);
+    IITC.filters.filterEntities();
+  },
+});

--- a/core/code/map.js
+++ b/core/code/map.js
@@ -155,10 +155,6 @@ function createDefaultOverlays() {
   addLayers[linksLayer.options.name] = linksLayer;
 
   // faction-specific layers
-  var neutralLayer = new IITC.filters.FilterLayer({
-    name: window.TEAM_NAME_NONE,
-    filter: { portal: true, data: { team: 'N' } },
-  });
   var resistanceLayer = new IITC.filters.FilterLayer({
     name: window.TEAM_NAME_RES,
     filter: { portal: true, link: true, field: true, data: { team: 'R' } },
@@ -172,7 +168,6 @@ function createDefaultOverlays() {
     filter: { portal: true, link: true, field: true, data: { team: 'M' } },
   });
 
-  addLayers[neutralLayer.options.name] = neutralLayer;
   // to avoid any favouritism, we'll put the player's own faction layer first
   if (PLAYER.team === 'RESISTANCE') {
     addLayers[resistanceLayer.options.name] = resistanceLayer;
@@ -233,8 +228,6 @@ window.setupMap = function () {
   }
   var baseLayers = createDefaultBaseMapLayers();
   var overlays = createDefaultOverlays();
-  map.addLayer(overlays.Neutral);
-  delete overlays.Neutral;
 
   var layerChooser = window.layerChooser = new window.LayerChooser(baseLayers, overlays, {map: map})
     .addTo(map);

--- a/core/code/map.js
+++ b/core/code/map.js
@@ -345,3 +345,5 @@ window.setupMap = function () {
   };
   */
 };
+
+/* global IITC, PLAYER */

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -164,26 +164,8 @@ window.Render.prototype.endRenderPass = function() {
 }
 
 window.Render.prototype.bringPortalsToFront = function() {
-  for (var lvl in portalsFactionLayers) {
-    // portals are stored in separate layers per faction
-    // to avoid giving weight to one faction or another, we'll push portals to front based on GUID order
-    var lvlPortals = {};
-    for (var fac in portalsFactionLayers[lvl]) {
-      var layer = portalsFactionLayers[lvl][fac];
-      if (layer._map) {
-        layer.eachLayer (function(p) {
-          lvlPortals[p.options.guid] = p;
-        });
-      }
-    }
-
-    var guids = Object.keys(lvlPortals);
-    guids.sort();
-
-    for (var j in guids) {
-      var guid = guids[j];
-      lvlPortals[guid].bringToFront();
-    }
+  for (var guid in window.portals) {
+    window.portals[guid].bringToFront();
   }
 
   // artifact portals are always brought to the front, above all others
@@ -192,7 +174,6 @@ window.Render.prototype.bringPortalsToFront = function() {
       portals[guid].bringToFront();
     }
   });
-
 }
 
 
@@ -215,7 +196,7 @@ window.Render.prototype.deletePortalEntity = function(guid) {
 window.Render.prototype.deleteLinkEntity = function(guid) {
   if (guid in window.links) {
     var l = window.links[guid];
-    linksFactionLayers[l.options.team].removeLayer(l);
+    l.remove();
     delete window.links[guid];
     window.runHooks('linkRemoved', {link: l, data: l.options.data });
   }
@@ -225,8 +206,7 @@ window.Render.prototype.deleteLinkEntity = function(guid) {
 window.Render.prototype.deleteFieldEntity = function(guid) {
   if (guid in window.fields) {
     var f = window.fields[guid];
-
-    fieldsFactionLayers[f.options.team].removeLayer(f);
+    f.remove();
     delete window.fields[guid];
     window.runHooks('fieldRemoved', {field: f, data: f.options.data });
   }
@@ -436,7 +416,7 @@ window.Render.prototype.createFieldEntity = function(ent) {
   window.fields[ent[0]] = poly;
 
   // TODO? postpone adding to the layer??
-  fieldsFactionLayers[poly.options.team].addLayer(poly);
+  if (!IITC.filters.filterField(poly)) poly.addTo(window.map);
 }
 
 window.Render.prototype.createLinkEntity = function (ent) {
@@ -498,7 +478,7 @@ window.Render.prototype.createLinkEntity = function (ent) {
 
   window.links[ent[0]] = poly;
 
-  linksFactionLayers[poly.options.team].addLayer(poly);
+  if (!IITC.filters.filterLink(poly)) poly.addTo(window.map);
 }
 
 
@@ -519,10 +499,10 @@ window.Render.prototype.rescalePortalMarkers = function() {
 
 // add the portal to the visible map layer
 window.Render.prototype.addPortalToMapLayer = function(portal) {
-  portalsFactionLayers[parseInt(portal.options.level)||0][portal.options.team].addLayer(portal);
+  if (!IITC.filters.filterPortal(portal)) portal.addTo(window.map);
 }
 
 window.Render.prototype.removePortalFromMapLayer = function(portal) {
   //remove it from the portalsLevels layer
-  portalsFactionLayers[parseInt(portal.options.level)||0][portal.options.team].removeLayer(portal);
+  portal.remove();
 }

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -506,3 +506,5 @@ window.Render.prototype.removePortalFromMapLayer = function(portal) {
   //remove it from the portalsLevels layer
   portal.remove();
 }
+
+/* global IITC */

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -5,7 +5,7 @@
 // @run-at         document-end
 
 // create IITC scope
-var IITC = {}
+var IITC = {};
 window.IITC = IITC;
 
 window.script_info = plugin_info;

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -4,6 +4,9 @@
 // @description    Total conversion for the ingress intel map.
 // @run-at         document-end
 
+// create IITC scope
+var IITC = {}
+window.IITC = IITC;
 
 window.script_info = plugin_info;
 window.script_info.changelog = [


### PR DESCRIPTION
Atm, intel data layers (portals/links/fields) are structured as follow:
 - unclaimed/placeholder portals 
 - portals L1 .... L8
 - Links
 - Fields
 
Each layer have internally 3 sub layers for neutral, resistance, enlightenment (NB: neutral is only for the layer 'unclaimed/placeholder...').
This decomposition allows to have two additional layers, Resistance/Enlightenment that doesn't contain any content but are still shown in the layer list.
For instance, hiding the Resistance layer triggers some code (`setFactionsLayersState`) that removes all resistance sub layers from their respective layers.

Also, this decomposition prevents to remove entities one by one by considering all entities with common properties as a whole layer (faction+level).

But, this system doesn't offer simple API to hide a set of portals/links/fields. See:
 - hiding uniques (recently and since years https://github.com/iitc-project/ingress-intel-total-conversion/issues/962) is implemented with highlighters (also with an API to be improved).
 - simulate portal destroyed with https://github.com/MysticJay/ZasoItems.CE/blob/master/destroyed-links-simulator.user.js

Rather than a fixed layer system, we can aim to a more flexible system such as filters.

A filter is a rule an entity as to match in order to be displayed (or it could be the opposite).
The system could work like advanced filter in excel-like spreadsheet, given a set of filters, all entities matching at least one of the filters is displayed. 

Since we start displaying everything on intel, then hiding stuff, filtering in IITC could work in a opposite way (wrt to spreadsheet).

The following draft introduces a way to add filter (simulating the layer chooser feature).

A filter is either a function or described by an object
```js
{
  portal: true,  // hide portals
  data: {        // with data matching
    level: 2     // level is 2
  }
}
``` 
or (for resistance filter) 
```js
{
  portal: true,
  link: true,
  field: true,
  data: {
    team: 'R'
  }
}
```

Update 2022-07-31:
In order to filter on timestamp, I also add the `{ ..., options: { timestamp: 42 } }`, but testing equality on timestamp isn't really useful so I extend filters to expression that looks like [MapBox expression](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/). For instance, to show only fields created between date1 and date2:
```js
{
  field: true,
  options: {
    timestamp: ['or', [['<', date1], ['>', date2]]],
  },
}
```

Related: #142 #197 #326 https://github.com/iitc-project/ingress-intel-total-conversion/issues/962