### PR TITLE
chat: fix public/faction not cleared on move

### DIFF
--- a/core/code/chat.js
+++ b/core/code/chat.js
@@ -179,8 +179,10 @@ window.chat.handleFaction = function(data, olderMsgs, ascendingTimestampOrder) {
     return log.warn('faction chat error. Waiting for next auto-refresh.');
   }
 
-  var needsClearing = $('#chatfaction').data('needsClearing');
-  if(!needsClearing && data.result.length === 0) return;
+  if (!data.result.length && !$('#chatfaction').data('needsClearing')) {
+    // no new data and current data in chat._faction.data is already rendered
+    return;
+  }
 
   $('#chatfaction').data('needsClearing', null);
 
@@ -230,8 +232,10 @@ window.chat.handlePublic = function(data, olderMsgs, ascendingTimestampOrder) {
     return log.warn('public chat error. Waiting for next auto-refresh.');
   }
 
-  var needsClearing = $('#chatall').data('needsClearing');
-  if(!needsClearing && data.result.length === 0) return;
+  if (!data.result.length && !$('#chatall').data('needsClearing')) {
+    // no new data and current data in chat._public.data is already rendered
+    return;
+  }
 
   $('#chatall').data('needsClearing', null);
 

--- a/core/code/chat.js
+++ b/core/code/chat.js
@@ -179,7 +179,10 @@ window.chat.handleFaction = function(data, olderMsgs, ascendingTimestampOrder) {
     return log.warn('faction chat error. Waiting for next auto-refresh.');
   }
 
-  if(data.result.length === 0) return;
+  var needsClearing = $('#chatfaction').data('needsClearing');
+  if(!needsClearing && data.result.length === 0) return;
+
+  $('#chatfaction').data('needsClearing', null);
 
   var old = chat._faction.oldestGUID;
   chat.writeDataToHash(data, chat._faction, false, olderMsgs, ascendingTimestampOrder);
@@ -227,7 +230,10 @@ window.chat.handlePublic = function(data, olderMsgs, ascendingTimestampOrder) {
     return log.warn('public chat error. Waiting for next auto-refresh.');
   }
 
-  if(data.result.length === 0) return;
+  var needsClearing = $('#chatall').data('needsClearing');
+  if(!needsClearing && data.result.length === 0) return;
+
+  $('#chatall').data('needsClearing', null);
 
   var old = chat._public.oldestGUID;
   chat.writeDataToHash(data, chat._public, undefined, olderMsgs, ascendingTimestampOrder);   //NOTE: isPublic passed as undefined - this is the 'all' channel, so not really public or private


### PR DESCRIPTION
fix #417

Force comm tab render when we need to clear the old log.

Note: I don't clear the alerts tab since alerts do not depend of map view