### PR TITLE
entiti_decode: log inconsistent portal history occurrences

### DIFF
--- a/core/code/entity_decode.js
+++ b/core/code/entity_decode.js
@@ -160,6 +160,9 @@ window.decodeArray.portal = function(a, details) {
 
   if (a.length >= EXTENDED_PORTAL_DATA_LENGTH || details === 'extended' || details === 'detailed') {
     $.extend(data, extendedPortalData(a));
+    if (data.history && data.history.captured && !data.history.visited) {
+      log.warn('Inconsistent history data found in portal "' + data.title + '"');
+    }
   }
 
   return data;


### PR DESCRIPTION
Earlier unusual cases were reported: 'captured' portals sometimes have not set 'visited' bit.
Now logging this case to find whether it is common (or just rare intel bug).
