### PR TITLE
portalslist: add scout/capture/visit filters

### DIFF
--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -192,7 +192,6 @@
 
 #portalslist .disclaimer {
   margin-top: 10px;
-  font-size: 10px;
 }
 
 #portalslist .history .icon {

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -23,6 +23,7 @@
   color: white;
   padding: 3px;
   white-space: nowrap;
+  vertical-align: middle;
 }
 
 #portalslist table th {
@@ -194,27 +195,27 @@
   font-size: 10px;
 }
 
-#portalslist .history {
-  text-align: center;
-  font-size: 20px;
-  line-height: 13px;
-  vertical-align: middle;
+#portalslist .history .icon {
+  width: 11px;
+  height: 11px;
+  border-radius: 6px;
+  margin: auto;
 }
 
-#portalslist .history.unvisited {
-  color: white;
+#portalslist .history.unvisited .icon{
+  background-color: white;
 }
 
-#portalslist .history.visited {
-  color: yellow;
+#portalslist .history.visited .icon {
+  background-color: yellow;
 }
 
-#portalslist .history.captured {
-  color: red;
+#portalslist .history.captured .icon {
+  background-color: red;
 }
 
-#portalslist .history.scoutControlled {
-  color: purple;
+#portalslist .history.scoutControlled .icon {
+  background-color: purple;
 }
 
 .ui-dialog.ui-dialog-portalslist {

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -53,44 +53,77 @@
   color: #FFCE00;
 }
 
-#portalslist .filter {
+#portalslist .filters {
   display: grid;
   grid-template-columns: 1fr auto 1fr auto 1fr auto;
   grid-gap: 1px
 }
 
-#portalslist.mobile .filter {
+#portalslist.mobile .filters {
   grid-template-columns: 1fr auto 1fr auto;
 }
 
-#portalslist .filter > div {
-  text-align: left;
+#portalslist .filters div {
   padding: 0.2em 0.3em;
   overflow: hidden;
   text-overflow: ellipsis;
+  background-color: #0005;
+  white-space: nowrap;
 }
 
-#portalslist .filter .active {
-  font-weight: bolder
+#portalslist .filters .count {
+  text-align: right;
 }
 
-#portalslist .filter .filterAll {
+#portalslist .filters .active {
+  font-weight: bolder;
+  color: #FFCE00;
+}
+
+#portalslist .filters .filterAll {
   display: none;
 }
 
-#portalslist.mobile .filter .filterAll {
+#portalslist.mobile .filters .filterAll {
   display: block;
 }
 
-#portalslist .filterNeu {
+#portalslist .filters .filterNeu {
   background-color: #666;
 }
 
-#portalslist table tr.res td, #portalslist .filterRes {
+#portalslist .filterVis.name:before,
+#portalslist .filterCap.name:before,
+#portalslist .filterSco.name:before {
+  content: '';
+  display: inline-block;
+  width: 11px;
+  height: 11px;
+  border-radius: 6px;
+  margin: auto;
+  margin-right: 0.2em;
+  vertical-align: -8%;
+}
+
+#portalslist .filterVis:before {
+  background-color: yellow;
+}
+
+#portalslist .filterCap:before {
+  background-color: red;
+}
+
+#portalslist .filterSco:before {
+  background-color: purple;
+}
+
+#portalslist table tr.res td,
+#portalslist .filters .filterRes {
   background-color: #005684;
 }
 
-#portalslist table tr.enl td, #portalslist .filterEnl {
+#portalslist table tr.enl td,
+#portalslist .filters .filterEnl {
   background-color: #017f01;
 }
 

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -22,6 +22,7 @@
   border-bottom: 1px solid #0b314e;
   color: white;
   padding: 3px;
+  white-space: nowrap;
 }
 
 #portalslist table th {
@@ -53,7 +54,7 @@
 }
 
 #portalslist table.filter {
-  table-layout: fixed;
+  table-layout: auto;
   cursor: pointer;
   border-collapse: separate;
   border-spacing: 1px;

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -53,25 +53,21 @@
   color: #FFCE00;
 }
 
-#portalslist table.filter {
-  table-layout: auto;
-  cursor: pointer;
-  border-collapse: separate;
-  border-spacing: 1px;
+#portalslist .filter {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr auto 1fr auto;
+    grid-gap: 1px
 }
 
-#portalslist table.filter th {
+#portalslist .filter > div {
   text-align: left;
-  padding-left: 0.3em;
+  padding: 0.2em 0.3em;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-#portalslist table.filter td {
-  text-align: right;
-  padding-right: 0.3em;
-  overflow: hidden;
-  text-overflow: ellipsis;
+#portalslist .filter .active {
+    font-weight: bolder
 }
 
 #portalslist .filterNeu {
@@ -116,15 +112,6 @@
 
 #portalslist .history.scoutControlled {
   color: purple;
-}
-
-#portalslist.mobile table.filter tr {
-  display: block;
-  text-align: center;
-}
-#portalslist.mobile table.filter th, #portalslist.mobile table.filter td {
-  display: inline-block;
-  width: 22%;
 }
 
 .ui-dialog.ui-dialog-portalslist {

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -117,6 +117,10 @@
   background-color: purple;
 }
 
+#portalslist .table-container {
+  overflow-y: hidden;
+}
+
 #portalslist table tr.res td,
 #portalslist .filters .filterRes {
   background-color: #005684;

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -1,10 +1,10 @@
 #portalslist.mobile {
   background: transparent;
-  border: 0 none !important;
-  height: 100% !important;
-  width: 100% !important;
-  left: 0 !important;
-  top: 0 !important;
+  border: 0 none;
+  height: 100%;
+  width: 100%;
+  left: 0;
+  top: 0;
   position: absolute;
   overflow: auto;
 }
@@ -43,8 +43,8 @@
 }
 
 #portalslist table .portalTitle {
-  min-width: 120px !important;
-  max-width: 240px !important;
+  min-width: 120px;
+  max-width: 240px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -85,6 +85,11 @@
   display: block;
 }
 
+/* kitkat fallback */
+#portalslist.mobile .filters .name {
+  float: left;
+}
+
 #portalslist .filters .filterNeu,
 #portalslist .filters .filterRes,
 #portalslist .filters .filterEnl {

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -54,9 +54,13 @@
 }
 
 #portalslist .filter {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr auto 1fr auto;
-    grid-gap: 1px
+  display: grid;
+  grid-template-columns: 1fr auto 1fr auto 1fr auto;
+  grid-gap: 1px
+}
+
+#portalslist.mobile .filter {
+  grid-template-columns: 1fr auto 1fr auto;
 }
 
 #portalslist .filter > div {
@@ -67,7 +71,15 @@
 }
 
 #portalslist .filter .active {
-    font-weight: bolder
+  font-weight: bolder
+}
+
+#portalslist .filter .filterAll {
+  display: none;
+}
+
+#portalslist.mobile .filter .filterAll {
+  display: block;
 }
 
 #portalslist .filterNeu {

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -59,10 +59,6 @@
   grid-gap: 1px
 }
 
-#portalslist.mobile .filters {
-  grid-template-columns: 1fr auto 1fr auto;
-}
-
 #portalslist .filters div {
   padding: 0.2em 0.3em;
   overflow: hidden;
@@ -86,6 +82,64 @@
 
 #portalslist.mobile .filters .filterAll {
   display: block;
+}
+
+#portalslist .filters .filterNeu,
+#portalslist .filters .filterRes,
+#portalslist .filters .filterEnl {
+  grid-row: 2;
+}
+
+#portalslist .filters .filterVis,
+#portalslist .filters .filterCap,
+#portalslist .filters .filterSco {
+  grid-row: 3;
+}
+
+/* 2 columns */
+@media (orientation: portrait) {
+  #portalslist.mobile .filters {
+    grid-template-columns: 1fr auto 1fr auto;
+  }
+
+  #portalslist.mobile .filters .filterNeu.name,
+  #portalslist.mobile .filters .filterRes.name,
+  #portalslist.mobile .filters .filterEnl.name {
+    grid-column: 1;
+  }
+
+  #portalslist.mobile .filters .filterNeu.count,
+  #portalslist.mobile .filters .filterRes.count,
+  #portalslist.mobile .filters .filterEnl.count {
+    grid-column: 2;
+  }
+
+  #portalslist.mobile .filters .filterVis.name,
+  #portalslist.mobile .filters .filterCap.name,
+  #portalslist.mobile .filters .filterSco.name {
+    grid-column: 3;
+  }
+
+  #portalslist.mobile .filters .filterVis.count,
+  #portalslist.mobile .filters .filterCap.count,
+  #portalslist.mobile .filters .filterSco.count {
+    grid-column: 4;
+  }
+
+  #portalslist.mobile .filters .filterNeu,
+  #portalslist.mobile .filters .filterVis {
+    grid-row: 2
+  }
+
+  #portalslist.mobile .filters .filterRes,
+  #portalslist.mobile .filters .filterCap {
+    grid-row: 3
+  }
+
+  #portalslist.mobile .filters .filterEnl,
+  #portalslist.mobile .filters .filterSco {
+    grid-row: 4
+  }
 }
 
 #portalslist .filters .filterNeu {

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -317,7 +317,6 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter, reve
     });
   }
 
-  var table, row, cell;
   var container = $('<div>');
 
   filters = document.createElement('div');
@@ -327,7 +326,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter, reve
   var length = window.plugin.portalslist.listPortals.length;
 
   ['All', 'Neutral', 'Resistance', 'Enlightened', 'Visited', 'Captured', 'Scout Controlled' ].forEach(function(label, i) {
-    cell = filters.appendChild(document.createElement('div'));
+    var cell = filters.appendChild(document.createElement('div'));
     cell.className = 'name filter' + label.substr(0, 3);
     cell.textContent = label+':';
     cell.title = 'Show only '+label+' portals';
@@ -368,14 +367,18 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter, reve
     }
   });
 
-  table = document.createElement('table');
+  var tableDiv = document.createElement('div');
+  tableDiv.className = 'table-container';
+  container.append(tableDiv);
+
+  var table = document.createElement('table');
   table.className = 'portals';
-  container.append(table);
+  tableDiv.appendChild(table);
 
   var thead = table.appendChild(document.createElement('thead'));
-  row = thead.insertRow(-1);
+  var row = thead.insertRow(-1);
 
-  cell = row.appendChild(document.createElement('th'));
+  var cell = row.appendChild(document.createElement('th'));
   cell.textContent = '#';
 
   window.plugin.portalslist.fields.forEach(function(field, i) {

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -322,42 +322,31 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
   var table, row, cell;
   var container = $('<div>');
 
-  table = document.createElement('table');
-  table.className = 'filter';
-  container.append(table);
-
-  row = table.insertRow(-1);
+  filters = document.createElement('div');
+  filters.className = 'filter';
+  container.append(filters);
 
   var length = window.plugin.portalslist.listPortals.length;
 
-  ['All', 'Neutral', 'Resistance', 'Enlightened', 'Visited', 'Captured', 'Scout Controlled' ].forEach(function(label, i) {
-    cell = row.appendChild(document.createElement('th'));
+  ['Neutral', 'Resistance', 'Enlightened', 'Visited', 'Captured', 'Scout Controlled' ].forEach(function(label, i) {
+    cell = filters.appendChild(document.createElement('div'));
     cell.className = 'filter' + label.substr(0, 3);
     cell.textContent = label+':';
     cell.title = 'Show only '+label+' portals';
     $(cell).click(function() {
-      $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i));
+      $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i+1));
     });
 
-    // No 'Hide all portals'
-    if (i === 0) return;
-
-    cell = row.insertCell(-1);
+    cell = filters.appendChild(document.createElement('div'));
     cell.className = 'filter' + label.substr(0, 3);
     cell.title = 'Hide '+label+' portals ';
     $(cell).click(function() {
-      $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, -i));
+      $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, -i-1));
     });
 
-    var name = ['neuP', 'resP', 'enlP', 'visitedP', 'capturedP', 'scoutControlledP'][i-1];
+    var name = ['neuP', 'resP', 'enlP', 'visitedP', 'capturedP', 'scoutControlledP'][i];
     var count = window.plugin.portalslist[name];
     cell.textContent = count + ' (' + Math.round(count/length*100) + '%)';
-
-    if (i === 3) {
-      // create a new row with an empty first cell
-       row = table.insertRow(-1);
-       cell = row.insertCell(-1); cell.textContent = (" ");
-    }
   });
 
   table = document.createElement('table');

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -335,12 +335,20 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter, reve
       $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i+1, false));
     });
 
+    if (filter === i+1 && !reversed) {
+      cell.classList.add('active');
+    }
+
     cell = filters.appendChild(document.createElement('div'));
     cell.className = 'filter' + label.substr(0, 3);
     cell.title = 'Hide '+label+' portals ';
     $(cell).click(function() {
       $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i+1, true));
     });
+
+    if (filter === i+1 && reversed) {
+      cell.classList.add('active');
+    }
 
     var name = ['neuP', 'resP', 'enlP', 'visitedP', 'capturedP', 'scoutControlledP'][i];
     var count = window.plugin.portalslist[name];

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -139,7 +139,7 @@ window.plugin.portalslist.fields = [
     },
     defaultOrder: -1,
   },
-  { 
+  {
     title: 'V/C',
     value: function(portal) {
       var history = portal.options.data.history;
@@ -161,7 +161,7 @@ window.plugin.portalslist.fields = [
   },
   {
     title: 'S',
-    value: function(portal) { 
+    value: function(portal) {
       var history = portal.options.data.history;
       if (history) {
         return history.scoutControlled ? 1 : 0;
@@ -321,14 +321,14 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter, reve
   var container = $('<div>');
 
   filters = document.createElement('div');
-  filters.className = 'filter';
+  filters.className = 'filters';
   container.append(filters);
 
   var length = window.plugin.portalslist.listPortals.length;
 
   ['All', 'Neutral', 'Resistance', 'Enlightened', 'Visited', 'Captured', 'Scout Controlled' ].forEach(function(label, i) {
     cell = filters.appendChild(document.createElement('div'));
-    cell.className = 'filter' + label.substr(0, 3);
+    cell.className = 'name filter' + label.substr(0, 3);
     cell.textContent = label+':';
     cell.title = 'Show only '+label+' portals';
     $(cell).click(function() {
@@ -344,7 +344,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter, reve
     }
 
     cell = filters.appendChild(document.createElement('div'));
-    cell.className = 'filter' + label.substr(0, 3);
+    cell.className = 'count filter' + label.substr(0, 3);
 
     if (i == 0) {
       cell.textContent = length;

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -20,8 +20,6 @@ window.plugin.portalslist.scoutControlledP = 0;
 
 window.plugin.portalslist.filter = 0;
 
-window.plugin.portalslist.historySymbol = String.fromCharCode(0x25CF);
-
 /*
  * plugins may add fields by appending their specifiation to the following list. The following members are supported:
  * title: String
@@ -156,7 +154,7 @@ window.plugin.portalslist.fields = [
         'history',
         ['unvisited', 'visited', 'captured'][value]
       ]);
-      cell.append(window.plugin.portalslist.historySymbol);
+      $(cell).append('<div class="icon"></div>');
     }
   },
   {
@@ -174,7 +172,7 @@ window.plugin.portalslist.fields = [
         'history',
         ['unvisited', 'scoutControlled'][value]
       ]);
-      cell.append(window.plugin.portalslist.historySymbol);
+      $(cell).append('<div class="icon"></div>');
     }
   }
 ];

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -14,6 +14,9 @@ window.plugin.portalslist.sortOrder = -1;
 window.plugin.portalslist.enlP = 0;
 window.plugin.portalslist.resP = 0;
 window.plugin.portalslist.neuP = 0;
+window.plugin.portalslist.visitedP = 0;
+window.plugin.portalslist.capturedP = 0;
+window.plugin.portalslist.scoutControlledP = 0;
 
 window.plugin.portalslist.filter = 0;
 
@@ -204,6 +207,9 @@ window.plugin.portalslist.getPortals = function() {
       default:
         window.plugin.portalslist.neuP++;
     }
+    if (portal.options.data.history.visited) window.plugin.portalslist.visitedP++;
+    if (portal.options.data.history.captured) window.plugin.portalslist.capturedP++;
+    if (portal.options.data.history.scoutControlled) window.plugin.portalslist.scoutControlledP++;
 
     // cache values and DOM nodes
     var obj = { portal: portal, values: [], sortValues: [] };
@@ -244,6 +250,9 @@ window.plugin.portalslist.displayPL = function() {
   window.plugin.portalslist.enlP = 0;
   window.plugin.portalslist.resP = 0;
   window.plugin.portalslist.neuP = 0;
+  window.plugin.portalslist.visitedP = 0;
+  window.plugin.portalslist.capturedP = 0;
+  window.plugin.portalslist.scoutControlledP = 0;
   window.plugin.portalslist.filter = 0;
 
   if (window.plugin.portalslist.getPortals()) {
@@ -293,9 +302,19 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
   if(filter !== 0) {
     portals = portals.filter(function(obj) {
-      return filter < 0
-        ? obj.portal.options.team+1 != -filter
-        : obj.portal.options.team+1 == filter;
+      if (Math.abs(filter) <= 3) {
+        return filter < 0
+          ? obj.portal.options.team+1 !== -filter
+          : obj.portal.options.team+1 === filter;
+      }
+      switch (filter) {
+        case 4: return obj.portal.options.data.history.visited;
+        case 5: return obj.portal.options.data.history.captured;
+        case 6: return obj.portal.options.data.history.scoutControlled;
+        case -4: return !obj.portal.options.data.history.visited;
+        case -5: return !obj.portal.options.data.history.captured;
+        case -6: return !obj.portal.options.data.history.scoutControlled;
+      }; 
     });
   }
 
@@ -310,35 +329,33 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
   var length = window.plugin.portalslist.listPortals.length;
 
-  ["All", "Neutral", "Resistance", "Enlightened"].forEach(function(label, i) {
+  ['All', 'Neutral', 'Resistance', 'Enlightened', 'Visited', 'Captured', 'Scout Controlled' ].forEach(function(label, i) {
     cell = row.appendChild(document.createElement('th'));
     cell.className = 'filter' + label.substr(0, 3);
     cell.textContent = label+':';
-    cell.title = 'Show only portals of this color';
+    cell.title = 'Show only '+label+' portals';
     $(cell).click(function() {
       $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i));
     });
 
+    // No 'Hide all portals'
+    if (i === 0) return;
 
     cell = row.insertCell(-1);
     cell.className = 'filter' + label.substr(0, 3);
-    if(i != 0) cell.title = 'Hide portals of this color';
+    cell.title = 'Hide '+label+' portals ';
     $(cell).click(function() {
       $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, -i));
     });
 
-    switch(i-1) {
-      case -1:
-        cell.textContent = length;
-        break;
-      case 0:
-        cell.textContent = window.plugin.portalslist.neuP + ' (' + Math.round(window.plugin.portalslist.neuP/length*100) + '%)';
-        break;
-      case 1:
-        cell.textContent = window.plugin.portalslist.resP + ' (' + Math.round(window.plugin.portalslist.resP/length*100) + '%)';
-        break;
-      case 2:
-        cell.textContent = window.plugin.portalslist.enlP + ' (' + Math.round(window.plugin.portalslist.enlP/length*100) + '%)';
+    var name = ['neuP', 'resP', 'enlP', 'visitedP', 'capturedP', 'scoutControlledP'][i-1];
+    var count = window.plugin.portalslist[name];
+    cell.textContent = count + ' (' + Math.round(count/length*100) + '%)';
+
+    if (i === 3) {
+      // create a new row with an empty first cell
+       row = table.insertRow(-1);
+       cell = row.insertCell(-1); cell.textContent = (" ");
     }
   });
 
@@ -384,7 +401,10 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
   });
 
   container.append('<div class="disclaimer">Click on portals table headers to sort by that column. '
-    + 'Click on <b>All, Neutral, Resistance, Enlightened</b> to only show portals owner by that faction or on the number behind the factions to show all but those portals.</div>');
+    + 'Click on <b>All, Neutral, Resistance, Enlightened</b> to only show portals owned '
+    + 'by that faction or on the number behind the factions to show all but those portals. '
+    + 'Click on <b>Visited, Captured or Scout Controlled</b> to only show portals the user has a history for '
+    + 'or on the number to hide those. </div>');
 
   return container;
 }

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -332,7 +332,11 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter, reve
     cell.textContent = label+':';
     cell.title = 'Show only '+label+' portals';
     $(cell).click(function() {
-      $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i+1, false));
+      if (this.classList.contains('active')) {
+        $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, 0, false));
+      } else {
+        $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i+1, false));
+      }
     });
 
     if (filter === i+1 && !reversed) {
@@ -343,7 +347,11 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter, reve
     cell.className = 'filter' + label.substr(0, 3);
     cell.title = 'Hide '+label+' portals ';
     $(cell).click(function() {
-      $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i+1, true));
+      if (this.classList.contains('active')) {
+        $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, 0, false));
+      } else {
+        $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i+1, true));
+      }
     });
 
     if (filter === i+1 && reversed) {

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -302,19 +302,20 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
   if(filter !== 0) {
     portals = portals.filter(function(obj) {
-      if (Math.abs(filter) <= 3) {
-        return filter < 0
-          ? obj.portal.options.team+1 !== -filter
-          : obj.portal.options.team+1 === filter;
-      }
-      switch (filter) {
-        case 4: return obj.portal.options.data.history.visited;
-        case 5: return obj.portal.options.data.history.captured;
-        case 6: return obj.portal.options.data.history.scoutControlled;
-        case -4: return !obj.portal.options.data.history.visited;
-        case -5: return !obj.portal.options.data.history.captured;
-        case -6: return !obj.portal.options.data.history.scoutControlled;
-      }; 
+      var type = Math.abs(filter)
+      var reversed = filter < 0;
+      switch (type) {
+        case 1:
+        case 2:
+        case 3:
+          return reversed ^ (1+obj.portal.options.team === filter);
+        case 4:
+          return reversed ^ obj.portal.options.data.history.visited;
+        case 5:
+          return reversed ^ obj.portal.options.data.history.captured;
+        case 6:
+          return reversed ^ obj.portal.options.data.history.scoutControlled;
+      };
     });
   }
 

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -256,7 +256,7 @@ window.plugin.portalslist.displayPL = function() {
   window.plugin.portalslist.filter = 0;
 
   if (window.plugin.portalslist.getPortals()) {
-    list = window.plugin.portalslist.portalTable(window.plugin.portalslist.sortBy, window.plugin.portalslist.sortOrder,window.plugin.portalslist.filter);
+    list = window.plugin.portalslist.portalTable(window.plugin.portalslist.sortBy, window.plugin.portalslist.sortOrder,window.plugin.portalslist.filter, false);
   } else {
     list = $('<table class="noPortals"><tr><td>Nothing to show!</td></tr></table>');
   };
@@ -274,7 +274,7 @@ window.plugin.portalslist.displayPL = function() {
   }
 }
 
-window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
+window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter, reversed) {
   // save the sortBy/sortOrder/filter
   window.plugin.portalslist.sortBy = sortBy;
   window.plugin.portalslist.sortOrder = sortOrder;
@@ -302,9 +302,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
 
   if(filter !== 0) {
     portals = portals.filter(function(obj) {
-      var type = Math.abs(filter)
-      var reversed = filter < 0;
-      switch (type) {
+      switch (filter) {
         case 1:
         case 2:
         case 3:
@@ -334,14 +332,14 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
     cell.textContent = label+':';
     cell.title = 'Show only '+label+' portals';
     $(cell).click(function() {
-      $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i+1));
+      $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i+1, false));
     });
 
     cell = filters.appendChild(document.createElement('div'));
     cell.className = 'filter' + label.substr(0, 3);
     cell.title = 'Hide '+label+' portals ';
     $(cell).click(function() {
-      $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, -i-1));
+      $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i+1, true));
     });
 
     var name = ['neuP', 'resP', 'enlP', 'visitedP', 'capturedP', 'scoutControlledP'][i];
@@ -376,7 +374,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter) {
           order = field.defaultOrder < 0 ? -1 : 1;
         }
 
-        $('#portalslist').empty().append(window.plugin.portalslist.portalTable(i, order, filter));
+        $('#portalslist').empty().append(window.plugin.portalslist.portalTable(i, order, filter, reversed));
       });
     }
   });

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -326,7 +326,7 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter, reve
 
   var length = window.plugin.portalslist.listPortals.length;
 
-  ['Neutral', 'Resistance', 'Enlightened', 'Visited', 'Captured', 'Scout Controlled' ].forEach(function(label, i) {
+  ['All', 'Neutral', 'Resistance', 'Enlightened', 'Visited', 'Captured', 'Scout Controlled' ].forEach(function(label, i) {
     cell = filters.appendChild(document.createElement('div'));
     cell.className = 'filter' + label.substr(0, 3);
     cell.textContent = label+':';
@@ -335,32 +335,37 @@ window.plugin.portalslist.portalTable = function(sortBy, sortOrder, filter, reve
       if (this.classList.contains('active')) {
         $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, 0, false));
       } else {
-        $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i+1, false));
+        $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i, false));
       }
     });
 
-    if (filter === i+1 && !reversed) {
+    if (filter === i && !reversed) {
       cell.classList.add('active');
     }
 
     cell = filters.appendChild(document.createElement('div'));
     cell.className = 'filter' + label.substr(0, 3);
-    cell.title = 'Hide '+label+' portals ';
-    $(cell).click(function() {
-      if (this.classList.contains('active')) {
-        $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, 0, false));
-      } else {
-        $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i+1, true));
+
+    if (i == 0) {
+      cell.textContent = length;
+    } else {
+      cell.title = 'Hide '+label+' portals ';
+      $(cell).click(function() {
+        if (this.classList.contains('active')) {
+          $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, 0, false));
+        } else {
+          $('#portalslist').empty().append(window.plugin.portalslist.portalTable(sortBy, sortOrder, i, true));
+        }
+      });
+
+      if (filter === i && reversed) {
+        cell.classList.add('active');
       }
-    });
 
-    if (filter === i+1 && reversed) {
-      cell.classList.add('active');
+      var name = ['neuP', 'resP', 'enlP', 'visitedP', 'capturedP', 'scoutControlledP'][i-1];
+      var count = window.plugin.portalslist[name];
+      cell.textContent = count + ' (' + Math.round(count/length*100) + '%)';
     }
-
-    var name = ['neuP', 'resP', 'enlP', 'visitedP', 'capturedP', 'scoutControlledP'][i];
-    var count = window.plugin.portalslist[name];
-    cell.textContent = count + ' (' + Math.round(count/length*100) + '%)';
   });
 
   table = document.createElement('table');


### PR DESCRIPTION
- `All` filter is hidden on desktop, reselect the active filter to disable it 
- includes scout/capture/visit filters
- rework some portalslist functions 
- UI filters: 3 columns on desktop/landscape(mobile) and 2 columns on portrait (mobile) 
- increase description font size 
- fix V/C&S UI size 

![image](https://user-images.githubusercontent.com/64744459/111025688-1603da00-83e6-11eb-979a-c4ff1418b5d4.png)

![image](https://user-images.githubusercontent.com/64744459/111025668-eead0d00-83e5-11eb-96f7-f7298bf53c28.png)

![image](https://user-images.githubusercontent.com/64744459/111025661-df2dc400-83e5-11eb-839a-f704b8208867.png)



~This need to be rebased before merging~