### PR TITLE
zoom-slider: fix error starting plugin when no standard zoomControl is available

### DIFF
--- a/plugins/zoom-slider.js
+++ b/plugins/zoom-slider.js
@@ -23,7 +23,7 @@ function setup () {
   loadLeafletZoomslider();
 
   var map = window.map;
-  if (map.zoomControl._map) {
+  if (map.zoomControl && map.zoomControl._map) {
     map.zoomControl.remove();
   }
   zoomSlider.control = L.control.zoomslider(zoomSlider.options).addTo(map);


### PR DESCRIPTION
E.g. in mobile app

Fix #453
