### PR TITLE
API: getCurrentZoomTileParameters -> getDataZoomTileParameters

### DIFF
--- a/core/code/map_data_calc_tools.js
+++ b/core/code/map_data_calc_tools.js
@@ -98,6 +98,12 @@ window.getMapZoomTileParameters = function(zoom) {
   };
 }
 
+window.getDataZoomTileParameters = function(zoom) {
+  zoom = arguments.length ? zoom : map.getZoom();
+  var dataZoom = getDataZoomForMapZoom(zoom);
+  return tileParams = getMapZoomTileParameters(dataZoom);
+}
+
 
 window.getDataZoomForMapZoom = function(zoom) {
   // we can fetch data at a zoom level different to the map zoom.

--- a/core/code/map_data_calc_tools.js
+++ b/core/code/map_data_calc_tools.js
@@ -54,7 +54,7 @@ window.setupDataTileParams = function() {
   // 2015-07-01: niantic added code to the stock site that overrides the min zoom level for unclaimed portals to 15 and above
   // instead of updating the zoom-to-level array. makes no sense really....
   // we'll just chop off the array at that point, so the code defaults to level 0 (unclaimed) everywhere...
-  window.TILE_PARAMS.ZOOM_TO_LEVEL = window.TILE_PARAMS.ZOOM_TO_LEVEL.slice(0,15);
+  window.TILE_PARAMS.ZOOM_TO_LEVEL = window.TILE_PARAMS.ZOOM_TO_LEVEL.slice(0,15); // deprecated
 
 }
 
@@ -90,7 +90,7 @@ window.getMapZoomTileParameters = function(zoom) {
   var maxTilesPerEdge = window.TILE_PARAMS.TILES_PER_EDGE[window.TILE_PARAMS.TILES_PER_EDGE.length-1];
 
   return {
-    level: window.TILE_PARAMS.ZOOM_TO_LEVEL[zoom] || 0,
+    level: window.TILE_PARAMS.ZOOM_TO_LEVEL[zoom] || 0, // deprecated
     tilesPerEdge: window.TILE_PARAMS.TILES_PER_EDGE[zoom] || maxTilesPerEdge,
     minLinkLength: window.TILE_PARAMS.ZOOM_TO_LINK_LENGTH[zoom] || 0,
     hasPortals: zoom >= window.TILE_PARAMS.ZOOM_TO_LINK_LENGTH.length,  // no portals returned at all when link length limits things

--- a/core/code/status_bar.js
+++ b/core/code/status_bar.js
@@ -13,12 +13,7 @@ window.renderUpdateStatus = function() {
 
   if (tileParams.hasPortals) {
     // zoom level includes portals (and also all links/fields)
-    if(!window.isSmartphone()) // space is valuable
-      t += '<b>portals</b>: ';
-    if(tileParams.level === 0)
-      t += '<span id="loadlevel">all</span>';
-    else
-      t += '<span id="loadlevel" style="background:'+COLORS_LVL[tileParams.level]+'">L'+tileParams.level+(tileParams.level<8?'+':'') + '</span>';
+    t += '<span id="loadlevel">portals</span>';
   } else {
     if(!window.isSmartphone()) // space is valuable
       t += '<b>links</b>: ';

--- a/core/code/status_bar.js
+++ b/core/code/status_bar.js
@@ -7,7 +7,7 @@ window.renderUpdateStatusTimer_ = undefined;
 window.renderUpdateStatus = function() {
   var progress = 1;
 
-  var tileParams = window.getCurrentZoomTileParameters();
+  var tileParams = window.getDataZoomTileParameters();
 
   var t = '<span class="help portallevel" title="Indicates portal levels/link lengths displayed.  Zoom in to display more.">';
 

--- a/core/code/utils_misc.js
+++ b/core/code/utils_misc.js
@@ -275,12 +275,6 @@ window.androidCopy = function(text) {
   return false;
 }
 
-window.getCurrentZoomTileParameters = function() {
-  var zoom = getDataZoomForMapZoom( map.getZoom() );
-  var tileParams = getMapZoomTileParameters(zoom);
-  return tileParams;
-}
-
 // returns number of pixels left to scroll down before reaching the
 // bottom. Works similar to the native scrollTop function.
 window.scrollBottom = function(elm) {

--- a/plugins/ap-stats.js
+++ b/plugins/ap-stats.js
@@ -47,7 +47,7 @@ window.plugin.compAPStats.updateNoPortals = function (hasFinished) {
 }
 
 window.plugin.compAPStats.update = function (hasFinished) {
-  if (!window.getCurrentZoomTileParameters().hasPortals) {
+  if (!window.getDataZoomTileParameters().hasPortals) {
     window.plugin.compAPStats.updateNoPortals(hasFinished);
     return;
   }

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -527,7 +527,7 @@ window.plugin.drawTools.optReset = function() {
 }
 
 window.plugin.drawTools.snapToPortals = function() {
-  var dataParams = window.getCurrentZoomTileParameters();
+  var dataParams = window.getDataZoomTileParameters();
   if (dataParams.level > 0) {
     if (!confirm('Not all portals are visible on the map. Snap to portals may move valid points to the wrong place. Continue?')) {
       return;

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -527,8 +527,7 @@ window.plugin.drawTools.optReset = function() {
 }
 
 window.plugin.drawTools.snapToPortals = function() {
-  var dataParams = window.getDataZoomTileParameters();
-  if (dataParams.level > 0) {
+  if (!window.getDataZoomTileParameters().hasPortals) {
     if (!confirm('Not all portals are visible on the map. Snap to portals may move valid points to the wrong place. Continue?')) {
       return;
     }

--- a/plugins/portal-counts.js
+++ b/plugins/portal-counts.js
@@ -152,7 +152,7 @@ window.plugin.portalcounts.getPortals = function (){
     counts += '<p>No Portals in range!</p>';
   }
 
-  if (!window.getCurrentZoomTileParameters().hasPortals) {
+  if (!window.getDataZoomTileParameters().hasPortals) {
     counts += '<p class="help"><b>Warning</b>: Portal counts is inaccurate when zoomed to link-level</p>';
   }
 


### PR DESCRIPTION
Motivation: make API more consistent
- transfer the function from utils_misc.js to map_data_calc_tools.js (where all related routines reside)
- rename it to `getDataZoomTileParameters`, and let it to take map zoom as argument, to make it more general
- put in near  `getMapZoomTileParameters`, to make it clear what is common between them.

Also: deprecate `TILE_PARAMS.ZOOM_TO_LEVEL` and `getMapZoomTileParameters().level`.