### PR TITLE
Use CSS vars to homogenize UI style

### DIFF
--- a/core/style.css
+++ b/core/style.css
@@ -8,6 +8,9 @@
   --ui-background-color-no-alpha: rgb(8, 48, 78);
   --ui-title-background-color: rgba(8, 60, 78, 0.9);
   --ui-title-button-background-color: #20a8b1;
+  --ui-title-color: #ffce00;
+  --ui-title-inactive-color: #ffffff;
+
   --highlight-text-color: #ffce00;
   --highlight-border-color: #ffce00;
   --arrow-toggle-color: #ffce00;
@@ -975,11 +978,11 @@ h3.title {
 }
 
 .ui-dialog-title-active {
-  color: var(--highlight-text-color);
+  color: var(--ui-title-color);
 }
 
 .ui-dialog-title-inactive {
-  color: #ffffff;
+  color: var(--ui-title-inactive-color);
 }
 
 .ui-dialog-titlebar-button {

--- a/core/style.css
+++ b/core/style.css
@@ -5,6 +5,8 @@
   --html-background-color: #0e3d4e;
   --ui-border-color: #20a8b1;
   --ui-background-color: rgba(8, 48, 78, 0.9);
+  --ui-title-background-color: rgba(8, 60, 78, 0.9);
+  --ui-title-button-background-color: #20a8b1;
   --highlight-text-color: #ffce00;
   --highlight-border-color: #ffce00;
   --arrow-toggle-color: #ffce00;
@@ -948,7 +950,7 @@ h3.title {
   line-height: 15px;
   text-align: center;
   padding: 4px;
-  background-color: rgba(8, 60, 78, 0.9);
+  background-color: var(--ui-title-background-color);
 }
 
 .ui-dialog-title {
@@ -981,7 +983,7 @@ h3.title {
 }
 
 .ui-dialog-titlebar-button:active {
-  background-color: rgb(32, 168, 177);
+  background-color: var(--ui-title-button-background-color);
 }
 
 .ui-dialog-titlebar-button-close {
@@ -997,7 +999,7 @@ h3.title {
 }
 
 .ui-dialog-titlebar-button-collapse-collapsed {
-  background-color: rgb(32, 168, 177);
+  background-color: var(--ui-title-button-background-color);
 }
 
 .ui-dialog-titlebar-button-collapse::after,
@@ -1026,7 +1028,7 @@ h3.title {
 .ui-dialog-titlebar-button.ui-dialog-titlebar-button-collapse-collapsed::before,
 .ui-dialog-titlebar-button:active::after,
 .ui-dialog-titlebar-button:active::before {
-  border-top-color: rgba(8, 60, 78, 0.9);
+  border-top-color: var(--ui-title-background-color);
 }
 
 .ui-dialog-content {

--- a/core/style.css
+++ b/core/style.css
@@ -117,9 +117,7 @@ i.large { font-size: 6rem; }
 }
 
 #sidebar {
-  background-color: var(--ui-background-color);
-  border-left: 1px solid var(--ui-border-color);
-  color: var(--ui-content-color);
+  border-left: 1px solid;
   position: relative;
   left: 0;
   top: 0;
@@ -137,9 +135,7 @@ i.large { font-size: 6rem; }
   position: absolute;
   top: 108px;
   z-index: 3002;
-  background-color: var(--ui-background-color);
-  color: var(--highlight-text-color);
-  border: 1px solid var(--ui-border-color);
+  border: 1px solid;
   border-right: none;
   border-radius: 5px 0 0 5px;
   text-decoration: none;
@@ -163,7 +159,6 @@ i.large { font-size: 6rem; }
 }
 
 a {
-  color: var(--highlight-text-color);
   cursor: pointer;
   text-decoration: none;
 }
@@ -219,8 +214,6 @@ a:hover {
 /* chat ***************************************************************/
 
 #chatcontrols {
-  color: var(--highlight-text-color);
-  background: var(--ui-background-color);
   position: absolute;
   left: 0;
   z-index: 3000;
@@ -240,7 +233,7 @@ a:hover {
   text-align: center;
   height: 24px;
   line-height: 24px;
-  border: 1px solid var(--ui-border-color);
+  border: 1px solid;
   vertical-align: top;
 }
 
@@ -306,10 +299,8 @@ a:hover {
   bottom: 23px;
   left: 0;
   z-index: 3000;
-  background: var(--ui-background-color);
   line-height: 15px;
-  color: var(--ui-content-color);
-  border: 1px solid var(--ui-border-color);
+  border: 1px solid;
   border-bottom: 0;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -408,10 +399,9 @@ summary {
   bottom: 0;
   left: 0;
   padding: 0 2px;
-  background: var(--ui-background-color);
   width: 708px;
   height: 23px;
-  border: 1px solid var(--ui-border-color);
+  border: 1px solid;
   z-index: 3001;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -426,7 +416,6 @@ summary {
 
 #chatinput input {
   background: transparent;
-  color: var(--ui-content-color);
   width: 100%;
   height: 100%;
   padding:3px 4px 1px 4px;
@@ -437,13 +426,11 @@ summary {
 /* sidebar ************************************************************/
 
 #sidebar > * {
-  border-bottom: 1px solid var(--ui-border-color);
+  border-bottom: 1px solid;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
-
-
 
 #sidebartoggle .toggle {
   border-bottom: 10px solid transparent;
@@ -464,7 +451,6 @@ summary {
 }
 
 h2 {
-  color: var(--highlight-text-color);
   font-size: 21px;
   padding: 0 4px;
   margin: 0;
@@ -543,7 +529,6 @@ input[type="text"], input[type="password"],
 input[type="number"], input[type="email"],
 input[type="search"], input[type="url"] {
   background-color: var(--input-background-color);
-  color: var(--highlight-text-color);
   height: 24px;
   padding:0px 4px 0px 4px;
   font-size: 12px;
@@ -867,14 +852,12 @@ h3.title {
   top: -2px;
   right: 2px;
   cursor: pointer;
-  color: var(--highlight-text-color);
   font-size: 16px;
 }
 
 /* history details */
 #historydetails {
   text-align: center;
-  color: var(--highlight-text-color);
 }
 
 #historydetails .missing {
@@ -890,12 +873,10 @@ h3.title {
 
 /* update status */
 #updatestatus {
-  background-color: var(--ui-background-color);
   border-bottom: 0;
-  border-top: 1px solid var(--ui-border-color);
-  border-left: 1px solid var(--ui-border-color);
+  border-top: 1px solid;
+  border-left: 1px solid;
   bottom: 0;
-  color: var(--highlight-text-color);
   font-size:13px;
   padding: 4px;
   position: fixed;
@@ -915,7 +896,7 @@ h3.title {
   color: #000000;
   display: inline-block;
   min-width: 1.8em;
-  border: 1px solid var(--ui-border-color);
+  border: 1px solid;
   border-width: 0 1px;
   margin: -4px 0;
   padding: 4px 0.2em;
@@ -926,9 +907,7 @@ h3.title {
 .ui-tooltip, .ui-dialog {
   position: absolute;
   z-index: 9500;
-  background-color: var(--ui-background-color);
-  border: 1px solid var(--ui-border-color);
-  color: var(--ui-content-color);
+  border: 1px solid;
   font-size: 13px;
   line-height: 15px;
   padding: 2px 4px;
@@ -955,10 +934,6 @@ h3.title {
 
 .ui-tooltip {
   z-index: 10002 !important;
-}
-
-.ui-tooltip, .ui-dialog a {
-  color: var(--highlight-text-color);
 }
 
 .ui-dialog {
@@ -1002,7 +977,7 @@ h3.title {
   height: 17px;
   top: 3px;
   cursor: pointer;
-  border: 1px solid var(--ui-border-color);
+  border: 1px solid;
   background-color: rgba(0, 0, 0, 0);
   padding: 0;
 }
@@ -1037,7 +1012,7 @@ h3.title {
   width: 11px;
   margin-left: -6px;
   height: 0;
-  border-top: 2px solid var(--ui-border-color);
+  border-top: 2px;
 }
 .ui-dialog-titlebar-button-close::after {
   transform: translateY(3.5px) rotate(45deg);
@@ -1084,7 +1059,7 @@ h3.title {
 
 .ui-dialog-buttonpane {
   padding: 6px;
-  border-top: 1px solid var(--ui-border-color);
+  border-top: 1px solid;
 }
 
 .ui-dialog-buttonset {
@@ -1095,9 +1070,7 @@ h3.title {
 .ui-dialog-content button {
   padding: 2px;
   min-width: 40px;
-  color: var(--highlight-text-color);
   border: 1px solid var(--highlight-border-color);
-  background-color: var(--ui-background-color);
 }
 
 .ui-dialog-buttonset button:hover {
@@ -1188,7 +1161,6 @@ td + td {
   z-index: 2500;
   font-size:11px;
   background-color: inherit;
-  color: var(--highlight-text-color);
 }
 
 
@@ -1213,10 +1185,6 @@ td + td {
 
 
 /** artifact dialog *****************/
-table.artifact tr > * {
-  background: var(--ui-background-color);
-}
-
 table.artifact td.info {
   min-width: 110px; /* min-width for info column, to ensure really long portal names don't crowd things out */
 }
@@ -1234,13 +1202,12 @@ table.artifact .portal {
 #map .leaflet-popup-content-wrapper {
   border-radius: 0px;
   -webkit-border-radius: 0px;
-  border: 1px solid var(--ui-border-color);
+  border: 1px solid;
   background: var(--html-background-color);
   pointer-events: auto;
 }
 
 #map .leaflet-popup-content {
-  color: var(--highlight-text-color);
   margin: 5px 8px;
 }
 
@@ -1271,19 +1238,17 @@ table.artifact .portal {
 
 /* misc */
 .layer_off_warning {
-  color: var(--highlight-text-color);
   margin: 8px;
   text-align: center;
 }
 
 /* region scores */
 .cellscore .ui-accordion-header, .cellscore .ui-accordion-content {
-	border: 1px solid var(--ui-border-color);
+	border: 1px solid;
 	margin-top: -1px;
 	display: block;
 }
 .cellscore .ui-accordion-header {
-	color: var(--highlight-text-color);
 	outline: none
 }
 .cellscore .ui-accordion-header:before {
@@ -1365,7 +1330,7 @@ g.checkpoint:hover circle {
 /* tabs */
 .ui-tabs-nav {
 	display: block;
-	border-bottom: 1px solid var(--ui-border-color);
+	border-bottom: 1px solid;
 	border-top: 1px solid transparent;
 	margin: 3px 0 0;
 	padding: 0;
@@ -1382,7 +1347,7 @@ g.checkpoint:hover circle {
 	display: block;
 	float:left;
 	margin: 0 0 -1px;
-	border: 1px solid var(--ui-border-color);
+	border: 1px solid;
 }
 .ui-tabs-nav li.ui-tabs-active {
 	border-bottom-color: #0F2C3F;
@@ -1423,4 +1388,66 @@ svg.icon-button {
 .leaflet-marker-icon > svg {
 	height: inherit;
 	width: inherit;
+}
+
+/* border ui */
+.ui-tooltip, .ui-dialog,
+.ui-dialog-titlebar-button,
+.ui-dialog-titlebar-button-collapse::after,
+.ui-dialog-titlebar-button-close::after,
+.ui-dialog-titlebar-button-close::before,
+.ui-dialog-buttonpane,
+.ui-tabs-nav, .ui-tabs-nav li,
+#map .leaflet-popup-content-wrapper,
+.cellscore .ui-accordion-header, .cellscore .ui-accordion-content,
+#sidebar, #sidebar > *,
+#sidebartoggle,
+#updatestatus,
+#loadlevel,
+#chat,
+#chatinput,
+#chatcontrols a {
+  border-color: var(--ui-border-color);
+}
+
+/* highilight */
+a, h2, input:not([type]), .input,
+input[type="text"], input[type="password"],
+input[type="number"], input[type="email"],
+input[type="search"], input[type="url"],
+#chatcontrols,
+#sidebartoggle,
+#portaldetails .close,
+#historydetails,
+#updatestatus,
+#portal_highlight_select,
+.ui-tooltip, .ui-dialog a,
+.ui-dialog-buttonset button,
+.ui-dialog-content button,
+#map .leaflet-popup-content,
+.layer_off_warning,
+.cellscore .ui-accordion-header {
+  color: var(--highlight-text-color);
+}
+
+/* ui background */
+#sidebar,
+#sidebartoggle,
+#chatcontrols,
+#chat,
+#chatinput,
+#updatestatus,
+.ui-tooltip, .ui-dialog,
+.ui-dialog-buttonset button,
+.ui-dialog-content button,
+table.artifact tr > * {
+  background-color: var(--ui-background-color);
+}
+
+/* ui content color */
+#sidebar,
+#chat,
+#chatinput input,
+.ui-tooltip, .ui-dialog {
+  color: var(--ui-content-color);
 }

--- a/core/style.css
+++ b/core/style.css
@@ -15,6 +15,10 @@
   --highlight-border-color: #ffce00;
   --arrow-toggle-color: #ffce00;
 
+  --faction-none-light-color: #ffffff;
+  --faction-res-light-color: #00c5ff;
+  --faction-enl-light-color: #03fe03;
+
   --faction-none-color: #ff6600;
   --faction-res-color: #0088ff;
   --faction-enl-color: #03dc03;
@@ -138,11 +142,11 @@ i.large { font-size: 6rem; }
 }
 
 .enl {
-  color: var(--faction-enl-color) !important;
+  color: var(--faction-enl-light-color) !important;
 }
 
 .res {
-  color: var(--faction-res-color) !important;
+  color: var(--faction-res-light-color) !important;
 }
 
 .none {
@@ -706,10 +710,10 @@ h3.title {
 }
 
 .res .mods span, .res .meter {
-  border: 1px solid #0076b6;
+  border: 1px solid var(--faction-res-color);
 }
 .enl .mods span, .enl .meter {
-  border: 1px solid #017f01;
+  border: 1px solid var(--faction-enl-color);
 }
 
 /* random details, resonator details */
@@ -1175,11 +1179,11 @@ td + td {
 }
 
 .RESISTANCE {
-  color: var(--faction-res-color);
+  color: var(--faction-res-light-color);
 }
 
 .ALIENS, .ENLIGHTENED {
-  color: var(--faction-enl-color);
+  color: var(--faction-enl-light-color);
 }
 
 #portal_highlight_select {

--- a/core/style.css
+++ b/core/style.css
@@ -4,6 +4,7 @@
 :root {
   --html-background-color: #0e3d4e;
   --ui-border-color: #20a8b1;
+  --ui-background-color: rgba(8, 48, 78, 0.9);
   --highlight-text-color: #ffce00;
   --highlight-border-color: #ffce00;
   --arrow-toggle-color: #ffce00;
@@ -78,7 +79,7 @@ i.large { font-size: 6rem; }
 }
 
 #sidebar {
-  background-color: rgba(8, 48, 78, 0.9);
+  background-color: var(--ui-background-color);
   border-left: 1px solid var(--ui-border-color);
   color: #888;
   position: relative;
@@ -98,7 +99,7 @@ i.large { font-size: 6rem; }
   position: absolute;
   top: 108px;
   z-index: 3002;
-  background-color: rgba(8, 48, 78, 0.9);
+  background-color: var(--ui-background-color);
   color: var(--highlight-text-color);
   border: 1px solid var(--ui-border-color);
   border-right: none;
@@ -191,7 +192,7 @@ a:hover {
 
 #chatcontrols {
   color: var(--highlight-text-color);
-  background: rgba(8, 48, 78, 0.9);
+  background: var(--ui-background-color);
   position: absolute;
   left: 0;
   z-index: 3000;
@@ -277,7 +278,7 @@ a:hover {
   bottom: 23px;
   left: 0;
   z-index: 3000;
-  background: rgba(8, 48, 78, 0.9);
+  background: var(--ui-background-color);
   line-height: 15px;
   color: #eee;
   border: 1px solid var(--ui-border-color);
@@ -379,7 +380,7 @@ summary {
   bottom: 0;
   left: 0;
   padding: 0 2px;
-  background: rgba(8, 48, 78, 0.9);
+  background: var(--ui-background-color);
   width: 708px;
   height: 23px;
   border: 1px solid var(--ui-border-color);
@@ -862,7 +863,7 @@ h3.title {
 
 /* update status */
 #updatestatus {
-  background-color: rgba(8, 48, 78, 0.9);
+  background-color: var(--ui-background-color);
   border-bottom: 0;
   border-top: 1px solid var(--ui-border-color);
   border-left: 1px solid var(--ui-border-color);
@@ -898,7 +899,7 @@ h3.title {
 .ui-tooltip, .ui-dialog {
   position: absolute;
   z-index: 9500;
-  background-color: rgba(8, 48, 78, 0.9);
+  background-color: var(--ui-background-color);
   border: 1px solid var(--ui-border-color);
   color: #eee;
   font-size: 13px;
@@ -1069,7 +1070,7 @@ h3.title {
   min-width: 40px;
   color: var(--highlight-text-color);
   border: 1px solid var(--highlight-border-color);
-  background-color: rgba(8, 48, 78, 0.9);
+  background-color: var(--ui-background-color);
 }
 
 .ui-dialog-buttonset button:hover {
@@ -1187,7 +1188,7 @@ td + td {
 
 /** artifact dialog *****************/
 table.artifact tr > * {
-  background: rgba(8, 48, 78, 0.9);
+  background: var(--ui-background-color);
 }
 
 table.artifact td.info {

--- a/core/style.css
+++ b/core/style.css
@@ -11,6 +11,20 @@
   --highlight-text-color: #ffce00;
   --highlight-border-color: #ffce00;
   --arrow-toggle-color: #ffce00;
+
+  --faction-none-color: #ff6600;
+  --faction-res-color: #0088ff;
+  --faction-enl-color: #03dc03;
+
+  --level-0-color: #000;
+  --level-1-color: #fece5a;
+  --level-2-color: #ffa630;
+  --level-3-color: #ff7315;
+  --level-4-color: #e40000;
+  --level-5-color: #fd2992;
+  --level-6-color: #eb26cd;
+  --level-7-color: #c124e0;
+  --level-8-color: #9627f4;
 }
 
 /* for printing directly from the browser, hide all UI components

--- a/core/style.css
+++ b/core/style.css
@@ -977,7 +977,7 @@ h3.title {
   height: 17px;
   top: 3px;
   cursor: pointer;
-  border: 1px solid rgb(32, 168, 177);
+  border: 1px solid var(--ui-border-color);
   background-color: rgba(0, 0, 0, 0);
   padding: 0;
 }
@@ -1012,7 +1012,7 @@ h3.title {
   width: 11px;
   margin-left: -6px;
   height: 0;
-  border-top: 2px solid rgb(32, 168, 177);
+  border-top: 2px solid var(--ui-border-color);
 }
 .ui-dialog-titlebar-button-close::after {
   transform: translateY(3.5px) rotate(45deg);

--- a/core/style.css
+++ b/core/style.css
@@ -215,16 +215,6 @@ a:hover {
   width: 0;
 }
 
-/* field mu count */
-.fieldmu {
-  color: var(--highlight-text-color);
-  font-size: 13px;
-  font-family: Roboto, "Helvetica Neue", Helvetica, sans-serif; /*override leaflet-container */
-  text-align: center;
-  text-shadow: 0 0 0.2em black, 0 0 0.2em black, 0 0 0.2em black;
-  pointer-events: none;
-}
-
 
 /* chat ***************************************************************/
 

--- a/core/style.css
+++ b/core/style.css
@@ -3,6 +3,7 @@
 /* color vars */
 :root {
   --html-background-color: #0e3d4e;
+  --ui-border-color: #20a8b1;
 }
 
 /* for printing directly from the browser, hide all UI components
@@ -75,7 +76,7 @@ i.large { font-size: 6rem; }
 
 #sidebar {
   background-color: rgba(8, 48, 78, 0.9);
-  border-left: 1px solid #20A8B1;
+  border-left: 1px solid var(--ui-border-color);
   color: #888;
   position: relative;
   left: 0;
@@ -96,7 +97,7 @@ i.large { font-size: 6rem; }
   z-index: 3002;
   background-color: rgba(8, 48, 78, 0.9);
   color: #FFCE00;
-  border: 1px solid #20A8B1;
+  border: 1px solid var(--ui-border-color);
   border-right: none;
   border-radius: 5px 0 0 5px;
   text-decoration: none;
@@ -207,7 +208,7 @@ a:hover {
   text-align: center;
   height: 24px;
   line-height: 24px;
-  border: 1px solid #20A8B1;
+  border: 1px solid var(--ui-border-color);
   vertical-align: top;
 }
 
@@ -276,7 +277,7 @@ a:hover {
   background: rgba(8, 48, 78, 0.9);
   line-height: 15px;
   color: #eee;
-  border: 1px solid #20A8B1;
+  border: 1px solid var(--ui-border-color);
   border-bottom: 0;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -378,7 +379,7 @@ summary {
   background: rgba(8, 48, 78, 0.9);
   width: 708px;
   height: 23px;
-  border: 1px solid #20A8B1;
+  border: 1px solid var(--ui-border-color);
   z-index: 3001;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -404,7 +405,7 @@ summary {
 /* sidebar ************************************************************/
 
 #sidebar > * {
-  border-bottom: 1px solid #20A8B1;
+  border-bottom: 1px solid var(--ui-border-color);
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
@@ -860,8 +861,8 @@ h3.title {
 #updatestatus {
   background-color: rgba(8, 48, 78, 0.9);
   border-bottom: 0;
-  border-top: 1px solid #20A8B1;
-  border-left: 1px solid #20A8B1;
+  border-top: 1px solid var(--ui-border-color);
+  border-left: 1px solid var(--ui-border-color);
   bottom: 0;
   color: #ffce00;
   font-size:13px;
@@ -883,7 +884,7 @@ h3.title {
   color: #000000;
   display: inline-block;
   min-width: 1.8em;
-  border: 1px solid #20A8B1;
+  border: 1px solid var(--ui-border-color);
   border-width: 0 1px;
   margin: -4px 0;
   padding: 4px 0.2em;
@@ -895,7 +896,7 @@ h3.title {
   position: absolute;
   z-index: 9500;
   background-color: rgba(8, 48, 78, 0.9);
-  border: 1px solid #20A8B1;
+  border: 1px solid var(--ui-border-color);
   color: #eee;
   font-size: 13px;
   line-height: 15px;
@@ -1052,7 +1053,7 @@ h3.title {
 
 .ui-dialog-buttonpane {
   padding: 6px;
-  border-top: 1px solid #20A8B1;
+  border-top: 1px solid var(--ui-border-color);
 }
 
 .ui-dialog-buttonset {
@@ -1203,7 +1204,7 @@ table.artifact .portal {
 #map .leaflet-popup-content-wrapper {
   border-radius: 0px;
   -webkit-border-radius: 0px;
-  border: 1px solid #20A8B1;
+  border: 1px solid var(--ui-border-color);
   background: var(--html-background-color);
   pointer-events: auto;
 }
@@ -1225,7 +1226,7 @@ table.artifact .portal {
 
 #map .leaflet-popup-tip {
   /* change the tip from an arrow to a simple line */
-  background: #20A8B1;
+  background: var(--ui-border-color);
   width: 1px;
   height: 20px;
   padding: 0;
@@ -1247,7 +1248,7 @@ table.artifact .portal {
 
 /* region scores */
 .cellscore .ui-accordion-header, .cellscore .ui-accordion-content {
-	border: 1px solid #20a8b1;
+	border: 1px solid var(--ui-border-color);
 	margin-top: -1px;
 	display: block;
 }
@@ -1334,7 +1335,7 @@ g.checkpoint:hover circle {
 /* tabs */
 .ui-tabs-nav {
 	display: block;
-	border-bottom: 1px solid #20a8b1;
+	border-bottom: 1px solid var(--ui-border-color);
 	border-top: 1px solid transparent;
 	margin: 3px 0 0;
 	padding: 0;
@@ -1351,7 +1352,7 @@ g.checkpoint:hover circle {
 	display: block;
 	float:left;
 	margin: 0 0 -1px;
-	border: 1px solid #20a8b1;
+	border: 1px solid var(--ui-border-color);
 }
 .ui-tabs-nav li.ui-tabs-active {
 	border-bottom-color: #0F2C3F;

--- a/core/style.css
+++ b/core/style.css
@@ -1,5 +1,10 @@
 /* general rules ******************************************************/
 
+/* color vars */
+:root {
+  --html-background-color: #0e3d4e;
+}
+
 /* for printing directly from the browser, hide all UI components
  * NOTE: @media needs to be first?
  */
@@ -25,7 +30,7 @@ html, body {
   height: 100%;
   width: 100%;
   overflow: hidden; /* workaround for #373 */
-  background: #0e3d4e;
+  background: var(--html-background-color);
 }
 
 #map {
@@ -1199,7 +1204,7 @@ table.artifact .portal {
   border-radius: 0px;
   -webkit-border-radius: 0px;
   border: 1px solid #20A8B1;
-  background: #0e3d4e;
+  background: var(--html-background-color);
   pointer-events: auto;
 }
 

--- a/core/style.css
+++ b/core/style.css
@@ -41,6 +41,10 @@
   --ui-text-off-color: #ff4a4a;
 
   --ui-content-color: #eee;
+
+  --input-background-color: rgba(0, 0, 0, 0.3);
+
+  --placeholder-background-color: rgba(0, 0, 0, 0.3);
 }
 
 /* for printing directly from the browser, hide all UI components
@@ -547,7 +551,7 @@ input:not([type]), .input,
 input[type="text"], input[type="password"],
 input[type="number"], input[type="email"],
 input[type="search"], input[type="url"] {
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: var(--input-background-color);
   color: var(--highlight-text-color);
   height: 24px;
   padding:0px 4px 0px 4px;
@@ -689,7 +693,7 @@ h3.title {
 }
 
 .mods span {
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: var(--placeholder-background-color);
   /* can’t use inline-block because Webkit's implementation is buggy and
    * introduces additional margins in random cases. No clear necessary,
    * as that’s solved by setting height on .mods. */
@@ -788,7 +792,7 @@ h3.title {
 }
 
 .meter {
-  background: #000;
+  background: var(--placeholder-background-color);
   cursor: help;
   display: inline-block;
   height: 18px;

--- a/core/style.css
+++ b/core/style.css
@@ -110,7 +110,7 @@ i.large { font-size: 6rem; }
 #sidebar {
   background-color: var(--ui-background-color);
   border-left: 1px solid var(--ui-border-color);
-  color: #888;
+  color: var(--ui-content-color);
   position: relative;
   left: 0;
   top: 0;
@@ -529,12 +529,12 @@ h2 sup, h2 sub {
 }
 
 #gamestat .res {
-  background: #005684;
+  background: linear-gradient(#0007,#0007) var(--faction-res-color);
   text-align: right;
 }
 
 #gamestat .enl {
-  background: #017f01;
+  background: linear-gradient(#0007,#0007) var(--faction-enl-color);
 }
 
 

--- a/core/style.css
+++ b/core/style.css
@@ -41,6 +41,7 @@
   --ui-text-off-color: #ff4a4a;
 
   --ui-content-color: #eee;
+  --ui-content-secondary-color: #bbb;
 
   --input-background-color: rgba(0, 0, 0, 0.3);
 
@@ -369,7 +370,7 @@ em {
   width: 44px;
   overflow: hidden;
   padding-left: 2px;
-  color: #bbb;
+  color: var(--ui-content-secondary-color);
   white-space: nowrap;
 }
 
@@ -403,7 +404,7 @@ mark {
 
 /* divider */
 summary {
-  color: #bbb;
+  color: var(--ui-content-secondary-color);
   display: inline-block;
   height: 16px;
   overflow: hidden;
@@ -626,7 +627,7 @@ input[type="search"], input[type="url"] {
   text-decoration: underline;
 }
 #searchwrapper li em {
-  color: #ccc;
+  color: var(--ui-content-secondary-color);
   font-size: 0.9em;
 }
 

--- a/core/style.css
+++ b/core/style.css
@@ -5,6 +5,7 @@
   --html-background-color: #0e3d4e;
   --ui-border-color: #20a8b1;
   --ui-background-color: rgba(8, 48, 78, 0.9);
+  --ui-background-color-no-alpha: rgb(8, 48, 78);
   --ui-title-background-color: rgba(8, 60, 78, 0.9);
   --ui-title-button-background-color: #20a8b1;
   --highlight-text-color: #ffce00;
@@ -227,7 +228,7 @@ a:hover {
   border-color: var(--highlight-border-color);
   border-bottom-width:0px;
   font-weight:bold;
-  background: rgb(8, 48, 78);
+  background: var(--ui-background-color-no-alpha);
 }
 
 #chatcontrols a.active + a {
@@ -474,7 +475,6 @@ h2 #stats {
   position: absolute;
   top: 0;
   right: 0;
-  background-color: rgba(8, 48, 78, 0.5);
   display: none; /* starts hidden */
 }
 #name:hover #signout {

--- a/core/style.css
+++ b/core/style.css
@@ -28,6 +28,15 @@
   --level-6-color: #eb26cd;
   --level-7-color: #c124e0;
   --level-8-color: #9627f4;
+
+  --rarity-common-color: #8cffbf;
+  --rarity-rare-color: #73a8ff;
+  --rarity-very-rare: #b08cff;
+
+  --ui-text-on-color: #03fe03;
+  --ui-text-off-color: #ff4a4a;
+
+  --ui-content-color: #eee;
 }
 
 /* for printing directly from the browser, hide all UI components
@@ -129,11 +138,11 @@ i.large { font-size: 6rem; }
 }
 
 .enl {
-  color: #03fe03 !important;
+  color: var(--faction-enl-color) !important;
 }
 
 .res {
-  color: #00c5ff !important;
+  color: var(--faction-res-color) !important;
 }
 
 .none {
@@ -300,7 +309,7 @@ a:hover {
   z-index: 3000;
   background: var(--ui-background-color);
   line-height: 15px;
-  color: #eee;
+  color: var(--ui-content-color);
   border: 1px solid var(--ui-border-color);
   border-bottom: 0;
   -webkit-box-sizing: border-box;
@@ -418,7 +427,7 @@ summary {
 
 #chatinput input {
   background: transparent;
-  color: #EEEEEE;
+  color: var(--ui-content-color);
   width: 100%;
   height: 100%;
   padding:3px 4px 1px 4px;
@@ -873,11 +882,11 @@ h3.title {
 }
 
 #historydetails span {
-  color: #ff4a4a;
+  color: var(--ui-text-off-color);
 }
 
 #historydetails span.completed {
-  color: #03fe03;
+  color: var(--ui-text-on-color);
 }
 
 /* update status */
@@ -920,7 +929,7 @@ h3.title {
   z-index: 9500;
   background-color: var(--ui-background-color);
   border: 1px solid var(--ui-border-color);
-  color: #eee;
+  color: var(--ui-content-color);
   font-size: 13px;
   line-height: 15px;
   padding: 2px 4px;
@@ -1166,11 +1175,11 @@ td + td {
 }
 
 .RESISTANCE {
-  color: #00c2ff;
+  color: var(--faction-res-color);
 }
 
 .ALIENS, .ENLIGHTENED {
-  color: #28f428;
+  color: var(--faction-enl-color);
 }
 
 #portal_highlight_select {
@@ -1179,9 +1188,8 @@ td + td {
   left:10px;
   z-index: 2500;
   font-size:11px;
-  background-color:#0E3C46;
-  color:var(--highlight-text-color);
-
+  background-color: inherit;
+  color: var(--highlight-text-color);
 }
 
 

--- a/core/style.css
+++ b/core/style.css
@@ -4,6 +4,9 @@
 :root {
   --html-background-color: #0e3d4e;
   --ui-border-color: #20a8b1;
+  --highlight-text-color: #ffce00;
+  --highlight-border-color: #ffce00;
+  --arrow-toggle-color: #ffce00;
 }
 
 /* for printing directly from the browser, hide all UI components
@@ -96,7 +99,7 @@ i.large { font-size: 6rem; }
   top: 108px;
   z-index: 3002;
   background-color: rgba(8, 48, 78, 0.9);
-  color: #FFCE00;
+  color: var(--highlight-text-color);
   border: 1px solid var(--ui-border-color);
   border-right: none;
   border-radius: 5px 0 0 5px;
@@ -121,7 +124,7 @@ i.large { font-size: 6rem; }
 }
 
 a {
-  color: #ffce00;
+  color: var(--highlight-text-color);
   cursor: pointer;
   text-decoration: none;
 }
@@ -175,7 +178,7 @@ a:hover {
 
 /* field mu count */
 .fieldmu {
-  color: #FFCE00;
+  color: var(--highlight-text-color);
   font-size: 13px;
   font-family: Roboto, "Helvetica Neue", Helvetica, sans-serif; /*override leaflet-container */
   text-align: center;
@@ -187,7 +190,7 @@ a:hover {
 /* chat ***************************************************************/
 
 #chatcontrols {
-  color: #FFCE00;
+  color: var(--highlight-text-color);
   background: rgba(8, 48, 78, 0.9);
   position: absolute;
   left: 0;
@@ -218,26 +221,26 @@ a:hover {
 }
 
 #chatcontrols a.active {
-  border-color: #FFCE00;
+  border-color: var(--highlight-border-color);
   border-bottom-width:0px;
   font-weight:bold;
   background: rgb(8, 48, 78);
 }
 
 #chatcontrols a.active + a {
-  border-left-color: #FFCE00
+  border-left-color: var(--highlight-border-color)
 }
 
 
 #chatcontrols .toggle {
   border-left: 10px solid transparent;
   border-right: 10px solid transparent;
-  border-bottom: 10px solid #FFCE00;
+  border-bottom: 10px solid var(--arrow-toggle-color);
   margin: 6px auto auto;
 }
 
 #chatcontrols.expand .toggle {
-  border-top: 10px solid #FFCE00;
+  border-top: 10px solid var(--arrow-toggle-color);
   border-bottom: none;
 }
 
@@ -419,11 +422,11 @@ summary {
 }
 
 #sidebartoggle .open {
-  border-right: 10px solid #FFCE00;
+  border-right: 10px solid var(--arrow-toggle-color);
 }
 
 #sidebartoggle .close {
-  border-left: 10px solid #FFCE00;
+  border-left: 10px solid var(--arrow-toggle-color);
 }
 
 /* player stats */
@@ -432,7 +435,7 @@ summary {
 }
 
 h2 {
-  color: #ffce00;
+  color: var(--highlight-text-color);
   font-size: 21px;
   padding: 0 4px;
   margin: 0;
@@ -512,7 +515,7 @@ input[type="text"], input[type="password"],
 input[type="number"], input[type="email"],
 input[type="search"], input[type="url"] {
   background-color: rgba(0, 0, 0, 0.3);
-  color: #ffce00;
+  color: var(--highlight-text-color);
   height: 24px;
   padding:0px 4px 0px 4px;
   font-size: 12px;
@@ -541,7 +544,7 @@ input[type="search"], input[type="url"] {
   background-color: transparent;
 }
 #buttongeolocation:focus {
-  outline: 1px dotted #ffce00;
+  outline: 1px dotted var(--highlight-border-color);
 }
 #buttongeolocation img {
   display: block;
@@ -836,14 +839,14 @@ h3.title {
   top: -2px;
   right: 2px;
   cursor: pointer;
-  color: #FFCE00;
+  color: var(--highlight-text-color);
   font-size: 16px;
 }
 
 /* history details */
 #historydetails {
   text-align: center;
-  color: #ffce00;
+  color: var(--highlight-text-color);
 }
 
 #historydetails .missing {
@@ -864,7 +867,7 @@ h3.title {
   border-top: 1px solid var(--ui-border-color);
   border-left: 1px solid var(--ui-border-color);
   bottom: 0;
-  color: #ffce00;
+  color: var(--highlight-text-color);
   font-size:13px;
   padding: 4px;
   position: fixed;
@@ -927,7 +930,7 @@ h3.title {
 }
 
 .ui-tooltip, .ui-dialog a {
-  color: #FFCE00;
+  color: var(--highlight-text-color);
 }
 
 .ui-dialog {
@@ -955,7 +958,7 @@ h3.title {
 }
 
 .ui-dialog-title-active {
-  color: #ffce00;
+  color: var(--highlight-text-color);
 }
 
 .ui-dialog-title-inactive {
@@ -1064,8 +1067,8 @@ h3.title {
 .ui-dialog-content button {
   padding: 2px;
   min-width: 40px;
-  color: #FFCE00;
-  border: 1px solid #FFCE00;
+  color: var(--highlight-text-color);
+  border: 1px solid var(--highlight-border-color);
   background-color: rgba(8, 48, 78, 0.9);
 }
 
@@ -1157,7 +1160,7 @@ td + td {
   z-index: 2500;
   font-size:11px;
   background-color:#0E3C46;
-  color:#ffce00;
+  color:var(--highlight-text-color);
 
 }
 
@@ -1210,7 +1213,7 @@ table.artifact .portal {
 }
 
 #map .leaflet-popup-content {
-  color: #ffce00;
+  color: var(--highlight-text-color);
   margin: 5px 8px;
 }
 
@@ -1241,7 +1244,7 @@ table.artifact .portal {
 
 /* misc */
 .layer_off_warning {
-  color: #FFCE00;
+  color: var(--highlight-text-color);
   margin: 8px;
   text-align: center;
 }
@@ -1253,7 +1256,7 @@ table.artifact .portal {
 	display: block;
 }
 .cellscore .ui-accordion-header {
-	color: #ffce00;
+	color: var(--highlight-text-color);
 	outline: none
 }
 .cellscore .ui-accordion-header:before {


### PR DESCRIPTION
Thanks to CSS, we can use variables to:
 - avoid repetition of a color with the same semantic in IITC style
 - expose colors for plugins to use instead of copy/paste
 - make style (color) customization simpler (from plugins or in order to make a darktheme)

a purple lover could use
```css
:root {
  --ui-background-color: purple;
  --highlight-text-color: yellow;
}
```

![image](https://user-images.githubusercontent.com/64744459/111391962-ef7bc280-86b5-11eb-843b-a32f6706ff75.png)

while a dark mode could looks like
```css
@media (prefers-color-scheme: dark) {
 :root {
  --ui-background-color: #000e;
  --highlight-text-color: #ccc;
  --ui-border-color: #000;
  --ui-background-color-no-alpha: #000;
  --ui-title-background-color: #0008;
  --highlight-border-color: #fff;
  --arrow-toggle-color: #fff; 
 }
}
```

![image](https://user-images.githubusercontent.com/64744459/111392625-446c0880-86b7-11eb-9b75-fef080f13f40.png)

