### PR TITLE
Fix: chat is broken on kitkat

### DIFF
--- a/core/code/chat.js
+++ b/core/code/chat.js
@@ -333,8 +333,11 @@ window.chat.writeDataToHash = function(newData, storageHash, isPublicChannel, is
       guid: newData.result[newData.result.length-1][0],
       time: newData.result[newData.result.length-1][1]
     };
-    if (isAscendingOrder)
-      [first, last] = [last, first];
+    if (isAscendingOrder) {
+      var temp = first;
+      first = last;
+      last = temp;
+    }
     if (storageHash.oldestTimestamp === -1 || storageHash.oldestTimestamp >= last.time) {
       if (isOlderMsgs || storageHash.oldestTimestamp != last.time) {
         storageHash.oldestTimestamp = last.time;


### PR DESCRIPTION
Destructuring assignment is not supported on android kitkat (`[a,b] = [b,a]`)
fix bug introduced by 5590364f46e55f9c463dab041cc96b05a6b98dab

this bug raises an uncaught exception while handling chat data, preventing the rendering 