### PR TITLE
Use Date/toLocale* to format date/time

### DIFF
--- a/core/code/chat.js
+++ b/core/code/chat.js
@@ -487,14 +487,28 @@ window.chat.renderDivider = function(text) {
 }
 
 
+window.chat.timeFormat = {
+  timeStyle: 'short'
+};
+
+window.chat.timeDateFormat = {
+  year: 'numeric', month: '2-digit', day: '2-digit',
+  hour: '2-digit', minute: '2-digit',
+  hour12: false,
+  fractionalSecondDigits: 3
+};
+
 window.chat.renderMsg = function(msg, nick, time, team, msgToPlayer, systemNarrowcast) {
-  var ta = unixTimeToHHmm(time);
-  var tb = unixTimeToDateTimeString(time, true);
+  var date = new Date(time);
+  var timeLong = date.toLocaleString(window.locale, window.chat.timeDateFormat);
   //add <small> tags around the milliseconds
-  tb = (tb.slice(0,19)+'<small class="milliseconds">'+tb.slice(19)+'</small>').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  var repl = '<small class="milliseconds">$1</small>'.replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  timeLong = timeLong.replace(/(\.\d{3})$/, repl);
 
   // help cursor via “#chat time”
-  var t = '<time title="'+tb+'" data-timestamp="'+time+'">'+ta+'</time>';
+  var t = '<time title="' + timeLong + '" data-timestamp="' + time + '">'
+    + date.toLocaleTimeString(window.locale, window.chat.timeFormat)
+    + '</time>';
   if ( msgToPlayer )
   {
     t = '<div class="pl_nudge_date">' + t + '</div><div class="pl_nudge_pointy_spacer"></div>';

--- a/core/code/region_scoreboard.js
+++ b/core/code/region_scoreboard.js
@@ -425,30 +425,31 @@ window.RegionScoreboard = (function() {
   }
 
   function onTimer() {
-    var d = regionScore.getCheckpointEnd(regionScore.getLastCP() + 1) - (new Date());
-    $('#cycletimer',mainDialog).html(formatMinutes( Math.max(0,Math.floor(d/1000))) );
+    var d = regionScore.getCheckpointEnd(regionScore.getLastCP() + 1) - Date.now();
+    $('#cycletimer', mainDialog).html(formatMinutes( Math.max(0, d)) );
   }
 
-  function formatMinutes(sec) {
-    var hours   = Math.floor(sec / 3600);
-    var minutes = Math.floor((sec % 3600) / 60);
-    sec = sec % 60;
-
-    var time='';
-    time += hours + ':';
-    if (minutes<10) time += '0';
-    time += minutes;
-    time += ':';
-    if (sec<10) time += '0';
-    time += sec;
-    return time;
+  // https://stackoverflow.com/a/25279399/2520247
+  function formatMinutes (ms) {
+    // valid while ms value is not greater than 24h
+    return new Date(ms).toISOString().substr(12, 7);
   }
+
+  this.timeFormat = {
+    hour: 'numeric', minute: 'numeric'
+  };
 
   function formatHours(time) {
-    return ('0' + time.getHours()).slice(-2) + ':00';
+    return time.toLocaleTimeString(window.locale, this.timeFormat);
   }
+
+  this.dateTimeFormat = {
+    month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit'
+  };
+
   function formatDayHours(time) {
-    return ('0' + time.getDate()).slice(-2) + '.' + ('0' + (time.getMonth() + 1)).slice(-2) + ' ' + ('0' + time.getHours()).slice(-2) + ':00';
+    return time.toLocaleString(window.locale, this.dateTimeFormat);
   }
 
   function setup() {

--- a/core/style.css
+++ b/core/style.css
@@ -319,11 +319,13 @@ em {
 
 /* time */
 #chat td:first-child, #chatinput td:first-child {
-  width: 44px;
+  width: 55px;
   overflow: hidden;
   padding-left: 2px;
+  padding-right: 2px;
   color: #bbb;
   white-space: nowrap;
+  text-align: right;
 }
 
 #chat time {

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -162,6 +162,9 @@ window.TEAM_ENL = 2;
 window.TEAM_TO_CSS = ['none', 'res', 'enl'];
 window.TEAM_NAMES = ['Neutral', 'Resistance', 'Enlightened'];
 
+// used in time/date formatting routines
+window.locale = navigator.languages.slice();
+
 // STORAGE ///////////////////////////////////////////////////////////
 // global variables used for storage. Most likely READ ONLY. Proper
 // way would be to encapsulate them in an anonymous function and write


### PR DESCRIPTION
New `window.locale` variable to store preferred languages (to use in date/time formatting).
Exact time/date format is defined with [`Intl.DateTimeFormat`] options.
Applied to `chat` and `region_scoreboard`.

Same for plugins: #397.
General discussion: #458.

[`Intl.DateTimeFormat`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iitc-ce/ingress-intel-total-conversion/475)
<!-- Reviewable:end -->
