### PR TITLE
v0.32.0

### DIFF
--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -1,6 +1,6 @@
 // @author         jonatkins
 // @name           IITC: Ingress intel map total conversion
-// @version        0.31.1
+// @version        0.32.0
 // @description    Total conversion for the ingress intel map.
 // @run-at         document-end
 

--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -32,7 +32,7 @@ android {
         minSdkVersion 17
         targetSdkVersion 29
         versionCode = getVersionCodeTimeStamps()
-        versionName "0.31.1"
+        versionName "0.32.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     signingConfigs {

--- a/mobile/plugins/user-location.js
+++ b/mobile/plugins/user-location.js
@@ -1,7 +1,7 @@
 // @author         cradle
 // @name           User Location
 // @category       Tweaks
-// @version        0.2.1
+// @version        0.2.2
 // @description    Show user location marker on map
 
 

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -1,7 +1,7 @@
 // @author         ZasoGD
 // @name           Bookmarks for maps and portals
 // @category       Controls
-// @version        0.4.0
+// @version        0.4.1
 // @description    Save your favorite Maps and Portals and move the intel map with a click. Works with sync. Supports Multi-Project-Extension
 
 /* **********************************************************************

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -1,7 +1,7 @@
 // @author         breunigs
 // @name           Draw tools
 // @category       Draw
-// @version        0.8.0
+// @version        0.8.1
 // @description    Allow drawing things onto the current map so you may plan your next move. Supports Multi-Project-Extension.
 
 

--- a/plugins/zoom-slider.js
+++ b/plugins/zoom-slider.js
@@ -1,7 +1,7 @@
 // @author         fragger
 // @name           Zoom slider
 // @category       Controls
-// @version        0.2.0
+// @version        0.2.1
 // @description    Show a zoom slider on the map instead of the zoom buttons.
 
 


### PR DESCRIPTION
## IITC main script
### enhancements
- Support portal history #436
  Notes:
  - Intel is still buggy, e.g. it may require to reload page to get the history info.
  - Earlier some unusual cases were reported, 'captured' portals sometimes have not set 'visited' bit.
    Now logging this case to find whether it is common (or just rare intel bug) #455

### fixes
- chat appeared between sidebar and sidebar toggle #421
- chat: fix public/faction not cleared on move #454
- fix: dialog failed to collapse sometimes #460
- hooks: fix case when hook is removing in event handler #462
- `region_scoreboard`: fix daylightsaving hour #473
- fix Android KitKat support #469, #470, #499, #502 (`portallist`)

### development
- external: update Leaflet to 1.7.1+master.7db94fd #370
- external: update Leaflet.GridLayer.GoogleMutant to v0.13.4 #365 + #492
- external: update jQuery to 3.6.0 #506
- external: update `ulog` to 2.0.0-beta.7 #366
- external: update taphold to 5f069454d28c49a9b18228e75d5f18ec43e9a7e9 #512
- API: getCurrentZoomTileParameters -> getDataZoomTileParameters #464
  Deprecate `TILE_PARAMS.ZOOM_TO_LEVEL` and `getMapZoomTileParameters().level`
- `boot.js`: replace jQuery(callback) with plain js 'load' listener #485
- internal enhancements #444
- ESLint rules, `package.json` #335
- Fix function name typo in `DataCache` #449
- expose default cooldown time and hack count #465
- `build_plugin.py`: support multiline description #510

## Plugins
### new
- `highlight-portal-history` #436, with customizable styles #441
### enhancements
- `portals-list`: add portal history columns #443
- `basemap-yandex`: update upstream to 3.4.0 #433
### fixes
- `privacy-plugin`: fix privacy control in expanded chat #427
- `zoom-slider`: fix error starting plugin when no standard `zoomControl` is available #461
- `pan-control`: fix error starting plugin when no standard `zoomControl` is available #467
- Fix handling of placeholder portals #306 (`portals-list`, `portal-counts`, `ap-stats`)
- `missions`: fix minor bug in error handler #479
- `fix-china-map-offset`: fix for the latest GoogleMutant, and more #492
- `draw-tools`: fix "snap to portals" precision #481
## IITC-Mobile app
### fixes
- fix gps orientation side effect #432
### development
- improve intent-filter for plugins #328
- fix a dependency #431
- preserve line number information for debugging stack traces #482
