### PR TITLE
draw-tools: fix "snap to portals" precision

### DIFF
--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -584,7 +584,7 @@ window.plugin.drawTools.snapToPortals = function() {
       if (visibleBounds.contains(ll)) {
         testCount++;
         var newll = findClosestPortalLatLng(ll);
-        if (newll.lat !== ll.lat || newll.lng !== ll.lng) {
+        if (newll.lat !== ll.lat || newll.lng !== ll.lng) { // must be strict
           layer.setLatLng(new L.LatLng(newll.lat, newll.lng));
           changedCount++;
         }

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -584,8 +584,8 @@ window.plugin.drawTools.snapToPortals = function() {
       if (visibleBounds.contains(ll)) {
         testCount++;
         var newll = findClosestPortalLatLng(ll);
-        if (!newll.equals(ll)) {
-          layer.setLatLng(new L.LatLng(newll.lat,newll.lng));
+        if (newll.lat !== ll.lat || newll.lng !== ll.lng) {
+          layer.setLatLng(new L.LatLng(newll.lat, newll.lng));
           changedCount++;
         }
       }
@@ -596,8 +596,8 @@ window.plugin.drawTools.snapToPortals = function() {
         if (visibleBounds.contains(lls[i])) {
           testCount++;
           var newll = findClosestPortalLatLng(lls[i]);
-          if (!newll.equals(lls[i])) {
-            lls[i] = new L.LatLng(newll.lat,newll.lng);
+          if (newll.lat !== lls[i].lat || newll.lng !== lls[i].lng) {
+            lls[i] = new L.LatLng(newll.lat, newll.lng);
             changedCount++;
             layerChanged = true;
           }


### PR DESCRIPTION
If a draw-tools marker is just slightly off (<1e-9) snap won't change the
location. By using a hard comparison instead of the soft "equal" it will
reset the position to the portal position in every case.

example:
`{"lat":51.16280299999999,"lng":4.3944160000000165},`
won't get "snapped" to
`{ "lat": "51.162803", "lng": "4.394416" },`