### PR TITLE
IITCm: preserve line number information for debugging stack traces

### DIFF
--- a/mobile/app/proguard-rules.pro
+++ b/mobile/app/proguard-rules.pro
@@ -12,9 +12,9 @@
 #   public *;
 #}
 
-# Uncomment this to preserve the line number information for
+# Comment this to unreserved the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes *Annotation*,SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.


### PR DESCRIPTION
Display full error log, getting rid of "Unknown Source" in builds with proguard enabled (beta and release builds)