### PR TITLE
boot.js: replace jQuery(callback) with plain js 'load' listener

### DIFF
--- a/core/code/boot.js
+++ b/core/code/boot.js
@@ -855,4 +855,8 @@ try {
   throw e;
 }
 
-$(boot);
+if (document.readyState === 'complete') { // IITCm
+  setTimeout(boot);
+} else {
+  window.addEventListener('load', boot);
+}


### PR DESCRIPTION
Reason: it's hard to debug boot functions wrapped into jQuery Deferred
Ref: https://api.jquery.com/jquery/#jQuery3
