### PR TITLE
fix-china-map-offset: fix for the latest GoogleMutant, and more

### DIFF
--- a/core/external/versions.md
+++ b/core/external/versions.md
@@ -24,7 +24,7 @@
   leaflet-src.js, leaflet.css, images/*
 
 * https://gitlab.com/IvanSanchez/Leaflet.GridLayer.GoogleMutant
-  v0.11.3 + MR!53
+  v0.13.4
 
 * https://github.com/IITC-CE/Leaflet.Geodesic
   L.Geodesic.js: c9f84ab763e89fa172ed410037a67151ef56d06c

--- a/plugins/fix-china-map-offset.js
+++ b/plugins/fix-china-map-offset.js
@@ -1,7 +1,7 @@
 ﻿// @author         modos189
 // @name           Fix maps offsets in China
 // @category       Tweaks
-// @version        0.2.1
+// @version        0.2.2
 // @description    Show correct maps for China user by applying offset tweaks.
 
 
@@ -317,7 +317,7 @@ function setup () {
   L.GridLayer.GoogleMutant.include(fixChinaOffset);
   L.GridLayer.GoogleMutant.include(fixGoogleMutant);
   layerChooser._layers.forEach(function (item) {
-    if (item.layer._GAPIPromise) { // Google layer
+    if (item.layer instanceof L.GridLayer.GoogleMutant) {
       var o = item.layer.options;
       o.needFixChinaOffset = o.type !== 'satellite' && o.type !== 'hybride';
     }

--- a/plugins/fix-china-map-offset.js
+++ b/plugins/fix-china-map-offset.js
@@ -314,12 +314,12 @@ function setup () {
   L.TileLayer.include(fixChinaOffset);
 
   // GoogleMutant needs additional support
-  L.GridLayer.GoogleMutant.include(fixChinaOffset);
-  L.GridLayer.GoogleMutant.include(fixGoogleMutant);
-  layerChooser._layers.forEach(function (item) {
-    if (item.layer instanceof L.GridLayer.GoogleMutant) {
-      var o = item.layer.options;
-      o.needFixChinaOffset = o.type !== 'satellite' && o.type !== 'hybride';
-    }
-  });
+  L.GridLayer.GoogleMutant
+    .include(fixChinaOffset)
+    .include(fixGoogleMutant)
+    .addInitHook(function () {
+      var o = this.options;
+      o.needFixChinaOffset = o.type !== 'satellite' && o.type !== 'hybrid';
+    });
 }
+setup.priority = 'boot';


### PR DESCRIPTION
Fix #488
Also:
- simplify GoogleMutant _update hooking
- try to fix 'hybrid' labels placement
- save some cpu resources by caching data
- external: update Leaflet.GridLayer.GoogleMutant to v0.13.4

Some good place to check: https://intel.ingress.com/?ll=40.007935,116.304788&z=16
