### PR TITLE
Multi-Line-Headers

### DIFF
--- a/build_plugin.py
+++ b/build_plugin.py
@@ -24,6 +24,9 @@ def fill_meta(source, plugin_name, dist_path):
     meta = ['// ==UserScript==']
     keys = set()
 
+    # concatenate subsequent simple comment lines to the previous line (multi-line-headers)
+    source = re.sub(r'\n\/\/\s+([^@].+)$', r' \1', source, flags=re.MULTILINE)
+    
     def append_line(key, value):
         if key not in keys:
             meta.append(f'// @{key:<14} {value}')


### PR DESCRIPTION
build_plugin.py

Purpose: concatenate lines to avoid long headers, e.g. for Description.

Usecase: Long lines in the sources trigger eslint and reduce readability. 
As *monkey has no trick to handle multi-line headers we need to re-join these during build-process

How to use: This change will concatenate the next (comment) line to the previous header. Indentation is optional.
```
// @keyword line 1
//      line 2
//      line 3
// @keyword2 text
```
becomes
```
// @keyword line 1 line 2 line 3
// @keyword2 text
```
during build-process.

