### PR TITLE
Iitc tool as new tag

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,5 +26,8 @@
         "eol-last": "error",
         "quote-props": ["error","consistent-as-needed"],
         "no-unused-expressions": "error"
-    }
+    },
+    "globals": {
+        "IITCTool": "readonly"
+    }    
 }

--- a/build_plugin.py
+++ b/build_plugin.py
@@ -148,7 +148,12 @@ def expand_template(match, path=None):
     elif kw == 'importCSS':
         pattern = r'(?<=url\()["\']?(?P<filename>[^)#]+?)["\']?(?=\))'
         css = re.sub(pattern, partial(imgrepl, path=fullname.parent), readtext(fullname))
-        return quote % multi_line(css)
+        return """// *** included: {filename} ***
+;(function() {{ var style = document.createElement('style');
+style.appendChild(document.createTextNode('{content}'));
+document.head.appendChild(style);
+}})();
+""".format(filename=filename, content=multi_line(css))
     else:
         raise Exception(f'Error: function {kw} unknown')
 

--- a/build_plugin.py
+++ b/build_plugin.py
@@ -121,7 +121,11 @@ def bundle_code(_, path=None):
 
 
 def imgrepl(match, path=None):
-    fullname = path / match.group('filename')
+    filename = match.group('filename')
+    if filename.startswith("data:"):
+        return filename
+
+    fullname = path / filename
     return load_image(fullname)
 
 

--- a/core/code/boot.js
+++ b/core/code/boot.js
@@ -556,11 +556,11 @@ window.setupLayerChooserApi = function() {
   }
 }
 
-window.extendLeaflet = function() {
+window.extendLeaflet = function () {
   L.Icon.Default.mergeOptions({
-    iconUrl: '@include_img:images/marker-ingress.png@',
-    iconRetinaUrl: '@include_img:images/marker-ingress-2x.png@',
-    shadowUrl: '@include_img:external/images/marker-shadow.png@'
+    iconUrl: IITCTool.importImage('images/marker-ingress.png'),
+    iconRetinaUrl: IITCTool.importImage('images/marker-ingress-2x.png'),
+    shadowUrl: IITCTool.importImage('external/images/marker-shadow.png')
   });
   L.Icon.Default.imagePath = ' '; // in order to suppress _detectIconPath (it fails with data-urls)
 
@@ -832,23 +832,23 @@ window.registerMarkerForOMS = function(marker) {
 }
 
 try {
-  '@include_raw:external/autolink-min.js@';
+  IITCTool.import('external/autolink-min.js');
 
-  window.L_NO_TOUCH = navigator.maxTouchPoints===0; // prevent mobile style on desktop https://github.com/IITC-CE/ingress-intel-total-conversion/pull/189
-  '@include_raw:external/leaflet-src.js@';
-  '@include_raw:external/L.Geodesic.js@';
-  '@include_raw:external/Leaflet.GoogleMutant.js@';
-  '@include_raw:external/oms.min.js@';
+  window.L_NO_TOUCH = navigator.maxTouchPoints === 0; // prevent mobile style on desktop https://github.com/IITC-CE/ingress-intel-total-conversion/pull/189
+  IITCTool.import('external/leaflet-src.js');
+  IITCTool.import('external/L.Geodesic.js');
+  IITCTool.import('external/Leaflet.GoogleMutant.js');
+  IITCTool.import('external/oms.min.js');
   L.CanvasIconLayer = (function (module) {
-    '@include_raw:external/rbush.min.js@';
-    '@include_raw:external/leaflet.canvas-markers.js@';
+    IITCTool.import('external/rbush.min.js');
+    IITCTool.import('external/leaflet.canvas-markers.js');
     return module;
   }({})).exports(L);
 
-  '@include_raw:external/jquery-3.5.1.min.js@';
-  '@include_raw:external/jquery-ui-1.12.1.min.js@';
-  '@include_raw:external/taphold.js@';
-  '@include_raw:external/jquery.qrcode.min.js@';
+  IITCTool.import('external/jquery-3.5.1.min.js');
+  IITCTool.import('external/jquery-ui-1.12.1.min.js');
+  IITCTool.import('external/taphold.js');
+  IITCTool.import('external/jquery.qrcode.min.js');
 
 } catch (e) {
   log.error("External's js loading failed");

--- a/core/code/search.js
+++ b/core/code/search.js
@@ -276,9 +276,9 @@ addHook('search', function(query) {
         title: data.title,
         description: teams[team] + ', L' + data.level + ', ' + data.health + '%, ' + data.resCount + ' Resonators',
         position: portal.getLatLng(),
-        icon: 'data:image/svg+xml;base64,'+btoa('@include_string:images/icon-portal.svg@'.replace(/%COLOR%/g, color)),
-        onSelected: function(result, event) {
-          if(event.type == 'dblclick') {
+        icon: 'data:image/svg+xml;base64,' + btoa(IITCTool.importString('images/icon-portal.svg').replace(/%COLOR%/g, color)),
+        onSelected: function (result, event) {
+          if (event.type == 'dblclick') {
             zoomToAndShowPortal(guid, portal.getLatLng());
           } else if(window.portals[guid]) {
             if(!map.getBounds().contains(result.position)) map.setView(result.position);

--- a/core/code/smartphone.js
+++ b/core/code/smartphone.js
@@ -22,10 +22,7 @@ window.runOnSmartphonesBeforeBoot = function() {
   log.warn('running smartphone pre boot stuff');
 
   // add smartphone stylesheet
-  var style = document.createElement('style');
-  style.type = 'text/css';
-  style.appendChild(document.createTextNode(IITCTool.importString('smartphone.css')));
-  document.head.appendChild(style);
+  IITCTool.importCSS('smartphone.css');
 
   // don’t need many of those
   window.setupStyles = function() {

--- a/core/code/smartphone.js
+++ b/core/code/smartphone.js
@@ -24,7 +24,7 @@ window.runOnSmartphonesBeforeBoot = function() {
   // add smartphone stylesheet
   var style = document.createElement('style');
   style.type = 'text/css';
-  style.appendChild(document.createTextNode('@include_string:smartphone.css@'));
+  style.appendChild(document.createTextNode(IITCTool.importString('smartphone.css')));
   document.head.appendChild(style);
 
   // don’t need many of those

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -33,10 +33,7 @@ if (!window.PLAYER || !PLAYER.nickname) {
   // FIXME: handle nia takedown in progress
 
   // add login form stylesheet
-  var style = document.createElement('style');
-  style.type = 'text/css';
-  style.appendChild(document.createTextNode(IITCTool.importString('login.css')));
-  document.head.appendChild(style);
+  IITCTool.importCSS('login.css');
 
   throw new Error("Couldn't retrieve player data. Are you logged in?");
 }
@@ -50,9 +47,10 @@ if (!window.PLAYER || !PLAYER.nickname) {
 document.head.innerHTML = ''
   + '<title>Ingress Intel Map</title>'
   + '<style>' + IITCTool.importString('style.css') + '</style>'
-  + '<style>' + IITCTool.importString('external/leaflet.css') + '</style>'
   // note: smartphone.css injection moved into code/smartphone.js
   + '<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:100,100italic,300,300italic,400,400italic,500,500italic,700,700italic&subset=latin,cyrillic-ext,greek-ext,greek,vietnamese,latin-ext,cyrillic"/>';
+
+IITCTool.importCSS('external/leaflet.css');
 
 // remove body element entirely to remove event listeners
 document.body = document.createElement('body');

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -50,7 +50,7 @@ if (!window.PLAYER || !PLAYER.nickname) {
 document.head.innerHTML = ''
   + '<title>Ingress Intel Map</title>'
   + '<style>' + IITCTool.importString('style.css') + '</style>'
-  + '<style>' + IITCTool.importCSS('external/leaflet.css') + '</style>'
+  + '<style>' + IITCTool.importString('external/leaflet.css') + '</style>'
   // note: smartphone.css injection moved into code/smartphone.js
   + '<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:100,100italic,300,300italic,400,400italic,500,500italic,700,700italic&subset=latin,cyrillic-ext,greek-ext,greek,vietnamese,latin-ext,cyrillic"/>';
 

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -35,7 +35,7 @@ if (!window.PLAYER || !PLAYER.nickname) {
   // add login form stylesheet
   var style = document.createElement('style');
   style.type = 'text/css';
-  style.appendChild(document.createTextNode('@include_string:login.css@'));
+  style.appendChild(document.createTextNode(IITCTool.importString('login.css')));
   document.head.appendChild(style);
 
   throw new Error("Couldn't retrieve player data. Are you logged in?");
@@ -49,9 +49,9 @@ if (!window.PLAYER || !PLAYER.nickname) {
 // possible without requiring scripts.
 document.head.innerHTML = ''
   + '<title>Ingress Intel Map</title>'
-  + '<style>'+'@include_string:style.css@'+'</style>'
-  + '<style>'+'@include_css:external/leaflet.css@'+'</style>'
-//note: smartphone.css injection moved into code/smartphone.js
+  + '<style>' + IITCTool.importString('style.css') + '</style>'
+  + '<style>' + IITCTool.importCSS('external/leaflet.css') + '</style>'
+  // note: smartphone.css injection moved into code/smartphone.js
   + '<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:100,100italic,300,300italic,400,400italic,500,500italic,700,700italic&subset=latin,cyrillic-ext,greek-ext,greek,vietnamese,latin-ext,cyrillic"/>';
 
 // remove body element entirely to remove event listeners
@@ -80,7 +80,7 @@ document.body.innerHTML = ''
   + '    <div id="playerstat">t</div>'
   + '    <div id="gamestat">&nbsp;loading global control stats</div>'
   + '    <div id="searchwrapper">'
-  + '      <button title="Current location" id="buttongeolocation"><img src="'+'@include_img:images/current-location.png@'+'" alt="Current location"/></button>'
+  + '      <button title="Current location" id="buttongeolocation"><img src="' + IITCTool.importImage('images/current-location.png') + '" alt="Current location"/></button>'
   + '      <input id="search" placeholder="Search location…" type="search" accesskey="f" title="Search for a place [f]"/>'
   + '    </div>'
   + '    <div id="portaldetails"></div>'
@@ -193,11 +193,11 @@ window.overlayStatus = {};
 if(typeof window.plugin !== 'function') window.plugin = function() {};
 
 var ulog = (function (module) {
-  '@include_raw:external/ulog.min.js@';
+  IITCTool.import('external/ulog.min.js');
   return module;
 }({})).exports;
 
-'@bundle_code@';
+IITCTool.importCode();
 
-  // fixed Addons
-  RegionScoreboard.setup();
+// fixed Addons
+RegionScoreboard.setup();

--- a/mobile/plugins/user-location.js
+++ b/mobile/plugins/user-location.js
@@ -13,7 +13,7 @@ window.plugin.userLocation.user = { latlng:null, direction:null };
 window.plugin.userLocation.setup = function() {
   window.pluginCreateHook('pluginUserLocation');
 
-  $('<style>').prop('type', 'text/css').html('@include_string:user-location.css@').appendTo('head');
+  IITCTool.importCSS('user-location.css');
 
   var cssClass = PLAYER.team === 'RESISTANCE' ? 'res' : 'enl';
 

--- a/plugins/basemap-bing.js
+++ b/plugins/basemap-bing.js
@@ -37,16 +37,16 @@ function setup () {
   }
 };
 
-function setupBingLeaflet () {
+function setupBingLeaflet() {
   try {
     // https://github.com/shramov/leaflet-plugins/blob/master/layer/tile/Bing.js
-    '@include_raw:external/Bing.js@';
+    IITCTool.import('external/Bing.js');
 
     // https://github.com/shramov/leaflet-plugins/blob/master/layer/tile/Bing.addon.applyMaxNativeZoom.js
-    '@include_raw:external/Bing.addon.applyMaxNativeZoom.js@';
+    IITCTool.import('external/Bing.addon.applyMaxNativeZoom.js');
 
-    } catch (e) {
-      console.error('Bing.js loading failed');
-      throw e;
-    }
+  } catch (e) {
+    console.error('Bing.js loading failed');
+    throw e;
+  }
 }

--- a/plugins/basemap-blank.js
+++ b/plugins/basemap-blank.js
@@ -10,9 +10,9 @@ window.plugin.mapTileBlank = function() {};
 
 window.plugin.mapTileBlank.addLayer = function() {
 
-  var blankOpt = {attribution: '', maxNativeZoom: 18, maxZoom: 21};
-  var blankWhite = new L.TileLayer('@include_img:images/basemap-blank-tile-white.png@', blankOpt);
-  var blankBlack = new L.TileLayer('@include_img:images/basemap-blank-tile-black.png@', blankOpt);
+  var blankOpt = { attribution: '', maxNativeZoom: 18, maxZoom: 21 };
+  var blankWhite = new L.TileLayer(IITCTool.importImage('images/basemap-blank-tile-white.png'), blankOpt);
+  var blankBlack = new L.TileLayer(IITCTool.importImage('images/basemap-blank-tile-black.png'), blankOpt);
 
   layerChooser.addBaseLayer(blankWhite, "Blank Map (White)");
   layerChooser.addBaseLayer(blankBlack, "Blank Map (Black)");

--- a/plugins/basemap-yandex.js
+++ b/plugins/basemap-yandex.js
@@ -39,12 +39,11 @@ function setupYandexLeaflet () {
 
   try {
     // https://github.com/shramov/leaflet-plugins/blob/master/layer/tile/Yandex.js
-    '@include_raw:external/Yandex.js@';
+    IITCTool.import('external/Yandex.js');
+    IITCTool.import('external/Yandex.addon.LoadApi.js');
 
-    '@include_raw:external/Yandex.addon.LoadApi.js@';
-    
-    } catch (e) {
-      console.error('Yandex.js loading failed');
-      throw e;
-    }
+  } catch (e) {
+    console.error('Yandex.js loading failed');
+    throw e;
+  }
 }

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -1358,5 +1358,5 @@ window.plugin.bookmarks.initMPE = function(){
 
 // moved setupCSS to the end to improve readability of built script
 window.plugin.bookmarks.setupCSS = function () {
-  $('<style>').prop('type', 'text/css').html(IITCTool.importCSS('bookmarks.css')).appendTo('head');
+  IITCTool.importCSS('bookmarks.css');
 };

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -501,32 +501,23 @@ window.plugin.bookmarks.loadStorageBox = function() {
       $.each(folder.bkmrk, function(id, bookmark) {
         if(bookmark.label.toLowerCase().indexOf(term) === -1) return;
 
-        query.addResult({
-          title: escapeHtmlSpecialChars(bookmark.label),
-          description: 'Map in folder "' + escapeHtmlSpecialChars(folder.label) + '"',
-          icon: '@include_img:images/icon-bookmark-map.png@',
-          position: L.latLng(bookmark.latlng.split(",")),
-          zoom: bookmark.z,
-          onSelected: window.plugin.bookmarks.onSearchResultSelected,
-        });
+      query.addResult({
+        title: escapeHtmlSpecialChars(bookmark.label),
+        description: 'Map in folder "' + escapeHtmlSpecialChars(folder.label) + '"',
+        icon: IITCTool.importImage('images/icon-bookmark-map.png'),
+        position: L.latLng(bookmark.latlng.split(",")),
+        zoom: bookmark.z,
+        onSelected: window.plugin.bookmarks.onSearchResultSelected,
       });
     });
+  });
 
-    $.each(plugin.bookmarks.bkmrksObj.portals, function(id, folder) {
-      $.each(folder.bkmrk, function(id, bookmark) {
-        if(bookmark.label.toLowerCase().indexOf(term) === -1) return;
+    $.each(plugin.bookmarks.bkmrksObj.portals, function (id, folder) {
+      $.each(folder.bkmrk, function (id, bookmark) {
+        if (bookmark.label.toLowerCase().indexOf(term) === -1) return;
 
-        query.addResult({
-          title: escapeHtmlSpecialChars(bookmark.label),
-          description: 'Bookmark in folder "' + escapeHtmlSpecialChars(folder.label) + '"',
-          icon: '@include_img:images/icon-bookmark.png@',
-          position: L.latLng(bookmark.latlng.split(",")),
-          guid: bookmark.guid,
-          onSelected: window.plugin.bookmarks.onSearchResultSelected,
-        });
-      });
-    });
-  };
+  });
+};
 
   window.plugin.bookmarks.onSearchResultSelected = function(result, event) {
     if(result.guid) { // portal
@@ -1100,17 +1091,18 @@ window.plugin.bookmarks.loadStorageBox = function() {
     console.log("resetAllStars done");
   }
 
-  window.plugin.bookmarks.addStar = function(guid, latlng, lbl) {
-    var star = L.marker(latlng, {
-      title: lbl,
-      icon: L.icon({
-        iconUrl: '@include_img:images/marker-star.png@',
-        iconAnchor: [15,40],
-        iconSize: [30,40]
-      })
-    });
-    window.registerMarkerForOMS(star);
-    star.on('spiderfiedclick', function() { renderPortalDetails(guid); });
+    window.plugin.bookmarks.addStar = function (guid, latlng, lbl) {
+      var star = L.marker(latlng, {
+        title: lbl,
+        icon: L.icon({
+          iconUrl: IITCTool.importImage('images/marker-star.png'),
+          iconAnchor: [15, 40],
+          iconSize: [30, 40]
+        })
+      });
+
+      window.registerMarkerForOMS(star);
+      star.on('spiderfiedclick', function () { renderPortalDetails(guid); });
 
     window.plugin.bookmarks.starLayers[guid] = star;
     star.addTo(window.plugin.bookmarks.starLayerGroup);
@@ -1363,7 +1355,8 @@ window.plugin.bookmarks.initMPE = function(){
     }
 
   }
+
 // moved setupCSS to the end to improve readability of built script
-    window.plugin.bookmarks.setupCSS = function() {
-    $('<style>').prop('type', 'text/css').html('@include_css:bookmarks.css@').appendTo('head');
-  }
+window.plugin.bookmarks.setupCSS = function () {
+  $('<style>').prop('type', 'text/css').html(IITCTool.importCSS('bookmarks.css')).appendTo('head');
+};

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -501,23 +501,32 @@ window.plugin.bookmarks.loadStorageBox = function() {
       $.each(folder.bkmrk, function(id, bookmark) {
         if(bookmark.label.toLowerCase().indexOf(term) === -1) return;
 
-      query.addResult({
-        title: escapeHtmlSpecialChars(bookmark.label),
-        description: 'Map in folder "' + escapeHtmlSpecialChars(folder.label) + '"',
-        icon: IITCTool.importImage('images/icon-bookmark-map.png'),
-        position: L.latLng(bookmark.latlng.split(",")),
-        zoom: bookmark.z,
-        onSelected: window.plugin.bookmarks.onSearchResultSelected,
+        query.addResult({
+          title: escapeHtmlSpecialChars(bookmark.label),
+          description: 'Map in folder "' + escapeHtmlSpecialChars(folder.label) + '"',
+          icon: IITCTool.importImage('images/icon-bookmark-map.png'),
+          position: L.latLng(bookmark.latlng.split(",")),
+          zoom: bookmark.z,
+          onSelected: window.plugin.bookmarks.onSearchResultSelected,
+        });
       });
     });
-  });
 
-    $.each(plugin.bookmarks.bkmrksObj.portals, function (id, folder) {
-      $.each(folder.bkmrk, function (id, bookmark) {
-        if (bookmark.label.toLowerCase().indexOf(term) === -1) return;
+    $.each(plugin.bookmarks.bkmrksObj.portals, function(id, folder) {
+      $.each(folder.bkmrk, function(id, bookmark) {
+        if(bookmark.label.toLowerCase().indexOf(term) === -1) return;
 
-  });
-};
+        query.addResult({
+          title: escapeHtmlSpecialChars(bookmark.label),
+          description: 'Bookmark in folder "' + escapeHtmlSpecialChars(folder.label) + '"',
+          icon: IITCTool.importImage('images/icon-bookmark.png'),
+          position: L.latLng(bookmark.latlng.split(",")),
+          guid: bookmark.guid,
+          onSelected: window.plugin.bookmarks.onSearchResultSelected,
+        });
+      });
+    });
+  };
 
   window.plugin.bookmarks.onSearchResultSelected = function(result, event) {
     if(result.guid) { // portal
@@ -1091,18 +1100,17 @@ window.plugin.bookmarks.loadStorageBox = function() {
     console.log("resetAllStars done");
   }
 
-    window.plugin.bookmarks.addStar = function (guid, latlng, lbl) {
-      var star = L.marker(latlng, {
-        title: lbl,
-        icon: L.icon({
-          iconUrl: IITCTool.importImage('images/marker-star.png'),
-          iconAnchor: [15, 40],
-          iconSize: [30, 40]
-        })
-      });
-
-      window.registerMarkerForOMS(star);
-      star.on('spiderfiedclick', function () { renderPortalDetails(guid); });
+  window.plugin.bookmarks.addStar = function(guid, latlng, lbl) {
+    var star = L.marker(latlng, {
+      title: lbl,
+      icon: L.icon({
+        iconUrl: IITCTool.importImage('images/marker-star.png'),
+        iconAnchor: [15,40],
+        iconSize: [30,40]
+      })
+    });
+    window.registerMarkerForOMS(star);
+    star.on('spiderfiedclick', function() { renderPortalDetails(guid); });
 
     window.plugin.bookmarks.starLayers[guid] = star;
     star.addTo(window.plugin.bookmarks.starLayerGroup);
@@ -1298,7 +1306,7 @@ window.plugin.bookmarks.initMPE = function(){
     window.plugin.bookmarks.loadStorage();
     window.plugin.bookmarks.loadStorageBox();
     window.plugin.bookmarks.setupContent();
-    window.plugin.bookmarks.setupCSS();
+    IITCTool.importCSS('bookmarks.css');
 
     if(!window.plugin.bookmarks.isSmart) {
       $('body').append(window.plugin.bookmarks.htmlBoxTrigger + window.plugin.bookmarks.htmlBkmrksBox);
@@ -1355,8 +1363,3 @@ window.plugin.bookmarks.initMPE = function(){
     }
 
   }
-
-// moved setupCSS to the end to improve readability of built script
-window.plugin.bookmarks.setupCSS = function () {
-  IITCTool.importCSS('bookmarks.css');
-};

--- a/plugins/distance-to-portal.js
+++ b/plugins/distance-to-portal.js
@@ -106,19 +106,19 @@ window.plugin.distanceToPortal.setupPortalsList = function() {
 }
 
 
-window.plugin.distanceToPortal.setup  = function() {
+window.plugin.distanceToPortal.setup = function () {
   // https://github.com/gregallensworth/Leaflet/
-  '@include_raw:external/LatLng_Bearings.js@';
+  IITCTool.import('external/LatLng_Bearings.js');
 
   try {
     window.plugin.distanceToPortal.currentLoc = L.latLng(JSON.parse(localStorage['plugin-distance-to-portal']));
-  } catch(e) {
+  } catch (e) {
     window.plugin.distanceToPortal.currentLoc = null;
   }
 
   window.plugin.distanceToPortal.currentLocMarker = null;
 
-  $('<style>').prop('type', 'text/css').html('@include_string:distance-to-portal.css@').appendTo('head');
+  $('<style>').prop('type', 'text/css').html(IITCTool.importString('distance-to-portal.css')).appendTo('head');
 
   addHook('portalDetailsUpdated', window.plugin.distanceToPortal.addDistance);
 

--- a/plugins/distance-to-portal.js
+++ b/plugins/distance-to-portal.js
@@ -118,7 +118,7 @@ window.plugin.distanceToPortal.setup = function () {
 
   window.plugin.distanceToPortal.currentLocMarker = null;
 
-  $('<style>').prop('type', 'text/css').html(IITCTool.importString('distance-to-portal.css')).appendTo('head');
+  IITCTool.importCSS('distance-to-portal.css');
 
   addHook('portalDetailsUpdated', window.plugin.distanceToPortal.addDistance);
 

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -737,14 +737,12 @@ function setup () {
 function loadExternals () {
   try {
     // https://github.com/Leaflet/Leaflet.draw
-    '@include_raw:external/leaflet.draw-src.js@';
-    $('<style>').html('@include_css:external/leaflet.draw-src.css@').appendTo('head');
+    IITCTool.import('external/leaflet.draw-src.js');
+    $('<style>').html(IITCTool.importCSS('external/leaflet.draw-src.css')).appendTo('head');
+    $('<style>').html(IITCTool.importCSS('external/leaflet.draw-fix.css')).appendTo('head');
 
-    $('<style>').html('@include_css:external/leaflet.draw-fix.css@').appendTo('head');
-
-    '@include_raw:external/leaflet.draw-snap.js@';
-
-    '@include_raw:external/leaflet.draw-geodesic.js@';
+    IITCTool.import('external/leaflet.draw-snap.js');
+    IITCTool.import('external/leaflet.draw-geodesic.js');
 
     // support Leaflet >= 1
     // https://github.com/Leaflet/Leaflet.draw/pull/911
@@ -774,8 +772,8 @@ function loadExternals () {
 
   try {
     // https://github.com/bgrins/spectrum
-    '@include_raw:external/spectrum.js@';
-    $('<style>').html('@include_string:external/spectrum.css@').appendTo('head');
+    IITCTool.import('external/spectrum.js');
+    $('<style>').html(IITCTool.importString("external/spectrum.css")).appendTo('head');
 
   } catch (e) {
     console.error('spectrum.js loading failed');

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -773,7 +773,7 @@ function loadExternals () {
   try {
     // https://github.com/bgrins/spectrum
     IITCTool.import('external/spectrum.js');
-    $('<style>').html(IITCTool.importString("external/spectrum.css")).appendTo('head');
+    IITCTool.importCSS('external/spectrum.css');
 
   } catch (e) {
     console.error('spectrum.js loading failed');

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -738,8 +738,8 @@ function loadExternals () {
   try {
     // https://github.com/Leaflet/Leaflet.draw
     IITCTool.import('external/leaflet.draw-src.js');
-    $('<style>').html(IITCTool.importCSS('external/leaflet.draw-src.css')).appendTo('head');
-    $('<style>').html(IITCTool.importCSS('external/leaflet.draw-fix.css')).appendTo('head');
+    IITCTool.importCSS('external/leaflet.draw-src.css');
+    IITCTool.importCSS('external/leaflet.draw-fix.css');
 
     IITCTool.import('external/leaflet.draw-snap.js');
     IITCTool.import('external/leaflet.draw-geodesic.js');

--- a/plugins/keys.js
+++ b/plugins/keys.js
@@ -153,12 +153,6 @@ window.plugin.keys.loadKeys = function() {
   if(keysObject.keys) plugin.keys.storeLocal(plugin.keys.KEY);
 }
 
-window.plugin.keys.setupCSS = function () {
-  $("<style>")
-    .prop("type", "text/css")
-    .html(IITCTool.importString('keys.css'))
-    .appendTo("head");
-}
 
 window.plugin.keys.setupContent = function() {
   plugin.keys.contentHTML = '<div id="keys-content-outer">'
@@ -229,7 +223,8 @@ var setup =  function() {
   // - pluginKeysUpdateKey
   // - pluginKeysRefreshAll
 
-  window.plugin.keys.setupCSS();
+  IITCTool.importCSS('keys.css');
+
   window.plugin.keys.setupContent();
   window.plugin.keys.loadLocal(plugin.keys.UPDATE_QUEUE);
   window.plugin.keys.loadKeys();

--- a/plugins/keys.js
+++ b/plugins/keys.js
@@ -153,10 +153,10 @@ window.plugin.keys.loadKeys = function() {
   if(keysObject.keys) plugin.keys.storeLocal(plugin.keys.KEY);
 }
 
-window.plugin.keys.setupCSS = function() {
+window.plugin.keys.setupCSS = function () {
   $("<style>")
     .prop("type", "text/css")
-    .html('@include_string:keys.css@')
+    .html(IITCTool.importString('keys.css'))
     .appendTo("head");
 }
 

--- a/plugins/layer-count.js
+++ b/plugins/layer-count.js
@@ -107,8 +107,8 @@ plugin.layerCount.calculate = function(ev) {
 	return false;
 };
 
-var setup = function() {
-	$('<style>').prop('type', 'text/css').html('@include_string:layer-count.css@').appendTo('head');
+var setup = function () {
+  $('<style>').prop('type', 'text/css').html(IITCTool.importString('layer-count.css')).appendTo('head');
 
 	var parent = $(".leaflet-top.leaflet-left", window.map.getContainer());
 

--- a/plugins/layer-count.js
+++ b/plugins/layer-count.js
@@ -108,7 +108,7 @@ plugin.layerCount.calculate = function(ev) {
 };
 
 var setup = function () {
-  $('<style>').prop('type', 'text/css').html(IITCTool.importString('layer-count.css')).appendTo('head');
+  IITCTool.importCSS('layer-count.css');
 
 	var parent = $(".leaflet-top.leaflet-left", window.map.getContainer());
 

--- a/plugins/linked-portals-show.js
+++ b/plugins/linked-portals-show.js
@@ -169,5 +169,5 @@ plugin.showLinkedPortal.removePreview = function() {
 
 var setup = function () {
   window.addHook('portalDetailsUpdated', window.plugin.showLinkedPortal.portalDetail);
-  $('<style>').prop('type', 'text/css').html(IITCTool.importCSS('linked-portals-show.css')).appendTo('head');
+  IITCTool.importCSS('linked-portals-show.css');
 }

--- a/plugins/linked-portals-show.js
+++ b/plugins/linked-portals-show.js
@@ -169,5 +169,5 @@ plugin.showLinkedPortal.removePreview = function() {
 
 var setup = function () {
   window.addHook('portalDetailsUpdated', window.plugin.showLinkedPortal.portalDetail);
-  $('<style>').prop('type', 'text/css').html('@include_string:linked-portals-show.css@').appendTo('head');
+  $('<style>').prop('type', 'text/css').html(IITCTool.importCSS('linked-portals-show.css')).appendTo('head');
 }

--- a/plugins/minimap.js
+++ b/plugins/minimap.js
@@ -142,11 +142,11 @@ function setup () {
   }
 }
 
-function loadLeafletMiniMap () {
+function loadLeafletMiniMap() {
   try {
     // https://github.com/Norkart/Leaflet-MiniMap
-    '@include_raw:external/Control.MiniMap.js@';
-    $('<style>').html('@include_css:external/Control.MiniMap.css@').appendTo('head');
+    IITCTool.import('external/Control.MiniMap.js');
+    $('<style>').html(IITCTool.importCSS('external/Control.MiniMap.css')).appendTo('head');
 
   } catch (e) {
     console.error('Control.MiniMap.js loading failed');

--- a/plugins/minimap.js
+++ b/plugins/minimap.js
@@ -146,7 +146,7 @@ function loadLeafletMiniMap() {
   try {
     // https://github.com/Norkart/Leaflet-MiniMap
     IITCTool.import('external/Control.MiniMap.js');
-    $('<style>').html(IITCTool.importCSS('external/Control.MiniMap.css')).appendTo('head');
+    IITCTool.importCSS('external/Control.MiniMap.css');
 
   } catch (e) {
     console.error('Control.MiniMap.js loading failed');

--- a/plugins/missions.js
+++ b/plugins/missions.js
@@ -68,12 +68,12 @@ window.plugin.missions = {
 	SYNC_DELAY: 5000,
 	enableSync: false,
 
-	missionTypeImages: [
-		'@include_img:images/mission-type-unknown.png@',
-		'@include_img:images/mission-type-sequential.png@',
-		'@include_img:images/mission-type-random.png@',
-		'@include_img:images/mission-type-hidden.png@',
-	],
+  missionTypeImages: [
+    IITCTool.importImage('images/mission-type-unknown.png'),
+    IITCTool.importImage('images/mission-type-sequential.png'),
+    IITCTool.importImage('images/mission-type-random.png'),
+    IITCTool.importImage('images/mission-type-hidden.png'),
+  ],
 
 	onPortalSelected: function(event) {
 		/*if(event.selectedPortalGuid === event.unselectedPortalGuid) {
@@ -381,9 +381,8 @@ window.plugin.missions = {
 				infoLength.title = 'Length of this mission.\n\nNOTE: The actual distance required to cover may vary depending on several factors!';
 				infoLength.textContent = len;
 				img = infoLength.insertBefore(document.createElement('img'), infoLength.firstChild);
-				img.src = '@include_img:images/mission-length.png@';
-			}
-			
+                img.src = IITCTool.importImage('images/mission-length.png');
+            }
 			if(window.plugin.distanceToPortal && window.plugin.distanceToPortal.currentLoc) {
 				var infoDistance = container.appendChild(document.createElement('span'));
 				infoDistance.className = 'plugin-mission-info distance help';
@@ -984,7 +983,7 @@ window.plugin.missions = {
 
 		this.loadData();
 
-		$('<style>').prop('type', 'text/css').html('@include_string:missions.css@').appendTo('head');
+		$('<style>').prop('type', 'text/css').html(IITCTool.importCSS('missions.css')).appendTo('head');
 		$('#toolbox').append('<a tabindex="0" onclick="plugin.missions.openTopMissions();">Missions in view</a>');
 
 		if(window.useAndroidPanes()) {

--- a/plugins/missions.js
+++ b/plugins/missions.js
@@ -983,7 +983,7 @@ window.plugin.missions = {
 
 		this.loadData();
 
-		$('<style>').prop('type', 'text/css').html(IITCTool.importCSS('missions.css')).appendTo('head');
+		IITCTool.importCSS('missions.css');
 		$('#toolbox').append('<a tabindex="0" onclick="plugin.missions.openTopMissions();">Missions in view</a>');
 
 		if(window.useAndroidPanes()) {

--- a/plugins/overlay-kml.js
+++ b/plugins/overlay-kml.js
@@ -242,10 +242,10 @@ function setup () {
   */
 }
 
-function loadLeafletFileLayer () {
+function loadLeafletFileLayer() {
   try {
     // https://github.com/mapbox/togeojson/
-    '@include_raw:external/togeojson.js@';
+    IITCTool.import('external/togeojson.js');
 
   } catch (e) {
     console.error('togeojson.js loading failed');
@@ -256,7 +256,7 @@ function loadLeafletFileLayer () {
 
   try {
     // https://github.com/makinacorpus/Leaflet.FileLayer/
-    '@include_raw:external/leaflet.filelayer.js@';
+    IITCTool.import('external/leaflet.filelayer.js');
 
   } catch (e) {
     console.error('leaflet.filelayer.js loading failed');

--- a/plugins/pan-control.js
+++ b/plugins/pan-control.js
@@ -48,7 +48,7 @@ function loadLeafletPancontrol() {
   try {
     // https://github.com/kartena/Leaflet.Pancontrol
     IITCTool.import('external/L.Control.Pan.js');
-    $('<style>').html(IITCTool.importCSS('external/L.Control.Pan.css')).appendTo('head');
+    IITCTool.importCSS('external/L.Control.Pan.css');
 
   } catch (e) {
     console.error('L.Control.Pan.js loading failed');

--- a/plugins/pan-control.js
+++ b/plugins/pan-control.js
@@ -44,11 +44,11 @@ function setup () {
   ').appendTo('head');
 }
 
-function loadLeafletPancontrol () {
+function loadLeafletPancontrol() {
   try {
     // https://github.com/kartena/Leaflet.Pancontrol
-    '@include_raw:external/L.Control.Pan.js@';
-    $('<style>').html('@include_css:external/L.Control.Pan.css@').appendTo('head');
+    IITCTool.import('external/L.Control.Pan.js');
+    $('<style>').html(IITCTool.importCSS('external/L.Control.Pan.css')).appendTo('head');
 
   } catch (e) {
     console.error('L.Control.Pan.js loading failed');

--- a/plugins/player-activity-tracker.js
+++ b/plugins/player-activity-tracker.js
@@ -14,13 +14,13 @@ window.PLAYER_TRACKER_LINE_COLOUR = '#FF00FD';
 // use own namespace for plugin
 window.plugin.playerTracker = function() {};
 
-window.plugin.playerTracker.setup = function() {
-  $('<style>').prop('type', 'text/css').html('@include_string:player-tracker.css@').appendTo('head');
+window.plugin.playerTracker.setup = function () {
+  $('<style>').prop('type', 'text/css').html(IITCTool.importString('player-tracker.css')).appendTo('head');
 
-  var iconEnlImage = '@include_img:images/marker-green.png@';
-  var iconEnlRetImage = '@include_img:images/marker-green-2x.png@';
-  var iconResImage = '@include_img:images/marker-blue.png@';
-  var iconResRetImage = '@include_img:images/marker-blue-2x.png@';
+  var iconEnlImage = IITCTool.importImage('images/marker-green.png');
+  var iconEnlRetImage = IITCTool.importImage('images/marker-green-2x.png');
+  var iconResImage = IITCTool.importImage('images/marker-blue.png');
+  var iconResRetImage = IITCTool.importImage('images/marker-blue-2x.png');
 
   plugin.playerTracker.iconEnl = L.Icon.Default.extend({options: {
     iconUrl: iconEnlImage,

--- a/plugins/player-activity-tracker.js
+++ b/plugins/player-activity-tracker.js
@@ -15,7 +15,7 @@ window.PLAYER_TRACKER_LINE_COLOUR = '#FF00FD';
 window.plugin.playerTracker = function() {};
 
 window.plugin.playerTracker.setup = function () {
-  $('<style>').prop('type', 'text/css').html(IITCTool.importString('player-tracker.css')).appendTo('head');
+  IITCTool.importCSS('player-tracker.css');
 
   var iconEnlImage = IITCTool.importImage('images/marker-green.png');
   var iconEnlRetImage = IITCTool.importImage('images/marker-green-2x.png');

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -428,8 +428,5 @@ var setup =  function() {
     $('#toolbox').append('<a onclick="window.plugin.portalslist.displayPL()" title="Display a list of portals in the current view [t]" accesskey="t">Portals list</a>');
   }
 
-  $('<style>')
-    .prop('type', 'text/css')
-    .html(IITCTool.importString('portals-list.css'))
-    .appendTo('head');
+  IITCTool.importCSS('portals-list.css');
 };

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -428,9 +428,8 @@ var setup =  function() {
     $('#toolbox').append('<a onclick="window.plugin.portalslist.displayPL()" title="Display a list of portals in the current view [t]" accesskey="t">Portals list</a>');
   }
 
-  $("<style>")
-    .prop("type", "text/css")
-    .html('@include_string:portals-list.css@')
-    .appendTo("head");
-
-}
+  $('<style>')
+    .prop('type', 'text/css')
+    .html(IITCTool.importString('portals-list.css'))
+    .appendTo('head');
+};

--- a/plugins/regions.js
+++ b/plugins/regions.js
@@ -8,8 +8,8 @@
 // use own namespace for plugin
 window.plugin.regions = function() {};
 
-window.plugin.regions.setup  = function() {
-  '@include_raw:external/s2geometry.js@';
+window.plugin.regions.setup = function () {
+  IITCTool.import('external/s2geometry.js');
 
   window.plugin.regions.regionLayer = L.layerGroup();
 
@@ -149,13 +149,13 @@ window.plugin.regions.getSearchResult = function(match) {
 
   var result = {}, level;
 
-  if(id2 === undefined) {
+  if (id2 === undefined) {
     result.description = 'Regional score cells (cluster of 16 cells)';
-    result.icon = 'data:image/svg+xml;base64,'+btoa('@include_string:images/icon-cell.svg@'.replace(/orange/, 'gold'));
+    result.icon = 'data:image/svg+xml;base64,' + btoa(IITCTool.importString('images/icon-cell.svg').replace(/orange/, 'gold'));
     level = 4;
   } else {
     result.description = 'Regional score cell';
-    result.icon = 'data:image/svg+xml;base64,'+btoa('@include_string:images/icon-cell.svg@');
+    result.icon = 'data:image/svg+xml;base64,' + btoa(IITCTool.importString('images/icon-cell.svg'));
     level = 6;
 
     var xy = window.plugin.regions.d2xy(4, id2);

--- a/plugins/tidy-links.js
+++ b/plugins/tidy-links.js
@@ -113,10 +113,10 @@ function setup () {
   ').appendTo('head');
 }
 
-function loadDelaunay () {
+function loadDelaunay() {
   try {
     // https://github.com/ironwallaby/delaunay
-    '@include_raw:external/delaunay.js@';
+    IITCTool.import('external/delaunay.js');
 
     return Delaunay;
   } catch (e) {

--- a/plugins/uniques.js
+++ b/plugins/uniques.js
@@ -400,12 +400,12 @@ window.plugin.uniques.highlighter = {
 }
 
 
-window.plugin.uniques.setupCSS = function() {
-	$("<style>")
-	.prop("type", "text/css")
-	.html('@include_string:uniques.css@')
-	.appendTo("head");
-}
+window.plugin.uniques.setupCSS = function () {
+  $('<style>')
+    .prop('type', 'text/css')
+    .html(IITCTool.importString('uniques.css'))
+    .appendTo('head');
+};
 
 window.plugin.uniques.setupContent = function() {
 	plugin.uniques.contentHTML = '<div id="uniques-container">'

--- a/plugins/uniques.js
+++ b/plugins/uniques.js
@@ -400,14 +400,7 @@ window.plugin.uniques.highlighter = {
 }
 
 
-window.plugin.uniques.setupCSS = function () {
-  $('<style>')
-    .prop('type', 'text/css')
-    .html(IITCTool.importString('uniques.css'))
-    .appendTo('head');
-};
-
-window.plugin.uniques.setupContent = function() {
+window.plugin.uniques.setupContent = function () {
 	plugin.uniques.contentHTML = '<div id="uniques-container">'
 		+ '<label><input type="checkbox" id="visited" onclick="window.plugin.uniques.updateVisited($(this).prop(\'checked\'))"> Visited</label>'
 		+ '<label><input type="checkbox" id="captured" onclick="window.plugin.uniques.updateCaptured($(this).prop(\'checked\'))"> Captured</label>'
@@ -549,23 +542,23 @@ window.plugin.uniques.checkMissionWaypoints = function(mission) {
 };
 
 
-var setup = function() {
+var setup = function () {
 	// HOOKS:
 	// - pluginUniquesUpdateUniques
 	// - pluginUniquesRefreshAll
 
-	window.plugin.uniques.setupCSS();
+	IITCTool.importCSS('uniques.css');
 	window.plugin.uniques.setupContent();
 	window.plugin.uniques.loadLocal('uniques');
 	window.addPortalHighlighter('Uniques', window.plugin.uniques.highlighter);
 	window.addHook('portalDetailsUpdated', window.plugin.uniques.onPortalDetailsUpdated);
 	window.addHook('publicChatDataAvailable', window.plugin.uniques.onPublicChatDataAvailable);
 	window.plugin.uniques.registerFieldForSyncing();
-	
+
 	// to mark mission portals as visited
 	window.addHook('plugin-missions-mission-changed', window.plugin.uniques.onMissionChanged);
 	window.addHook('plugin-missions-loaded-mission', window.plugin.uniques.onMissionLoaded);
-	
+
 	if (window.plugin.portalslist) {
 		window.plugin.uniques.setupPortalsList();
 	}

--- a/plugins/zoom-slider.js
+++ b/plugins/zoom-slider.js
@@ -41,7 +41,7 @@ function loadLeafletZoomslider() {
   try {
     // https://github.com/kartena/Leaflet.zoomslider
     IITCTool.import('external/L.Control.Zoomslider.js');
-    $('<style>').html(IITCTool.importString('external/L.Control.Zoomslider.css')).appendTo('head');
+    IITCTool.importCSS('external/L.Control.Zoomslider.css');
 
   } catch (e) {
     console.error('L.Control.Zoomslider.js loading failed');

--- a/plugins/zoom-slider.js
+++ b/plugins/zoom-slider.js
@@ -37,11 +37,11 @@ function setup () {
     .appendTo('head');
 }
 
-function loadLeafletZoomslider () {
+function loadLeafletZoomslider() {
   try {
     // https://github.com/kartena/Leaflet.zoomslider
-    '@include_raw:external/L.Control.Zoomslider.js@';
-    $('<style>').html('@include_string:external/L.Control.Zoomslider.css@').appendTo('head');
+    IITCTool.import('external/L.Control.Zoomslider.js');
+    $('<style>').html(IITCTool.importString('external/L.Control.Zoomslider.css')).appendTo('head');
 
   } catch (e) {
     console.error('L.Control.Zoomslider.js loading failed');


### PR DESCRIPTION
Replace `@something@ ` build tags by something that look and feels like regular function calls.

old -> `'@include_raw:external/leaflet-src.js@';`
new -> `IITCTool.import('external/leaflet-src.js');`

old -> `iconUrl: '@include_img:images/marker-ingress.png@',`
new -> `iconUrl: IITCTool.importImage('images/marker-ingress.png'),`
( `include_string` looks the same)

with some extra code for css:
old ->`$('<style>').prop('type', 'text/css').html('@include_css:bookmarks.css@').appendTo('head');`
new -> `IITCTool.importCSS('bookmarks.css');`
