### PR TITLE
build_plugin.py: support multiline description

### DIFF
--- a/build_plugin.py
+++ b/build_plugin.py
@@ -41,7 +41,12 @@ def fill_meta(source, plugin_name, dist_path):
             if text == '==UserScript==':
                 raise UserWarning(f'{plugin_name}: wrong metablock detected')
         else:
-            key = key[1:]
+            if key[0] == '@':
+                key = key[1:]
+            else:  # continue previous line
+                meta[-1] += ' ' + text
+                continue
+
             keys.add(key)
             if key == 'version':
                 if not re.match(r'^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$', value):


### PR DESCRIPTION
E.g.:
```
...
// @description    Allow drawing things onto the current map so you may plan your next move.
//                 Supports Multi-Project-Extension.
...
```

Alternative to #494