### PR TITLE
[Release] 0.32.1 (bump versions)

### DIFF
--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -1,6 +1,6 @@
 // @author         jonatkins
 // @name           IITC: Ingress intel map total conversion
-// @version        0.32.0
+// @version        0.32.1
 // @description    Total conversion for the ingress intel map.
 // @run-at         document-end
 

--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -32,7 +32,7 @@ android {
         minSdkVersion 17
         targetSdkVersion 29
         versionCode = getVersionCodeTimeStamps()
-        versionName "0.32.0"
+        versionName "0.32.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     signingConfigs {

--- a/plugins/missions.js
+++ b/plugins/missions.js
@@ -1,7 +1,7 @@
 // @author         jonatkins
 // @name           Missions
 // @category       Info
-// @version        0.2.1
+// @version        0.2.2
 // @description    View missions. Marking progress on waypoints/missions basis. Showing mission paths on the map.
 
 

--- a/plugins/multi-projects-extension.js
+++ b/plugins/multi-projects-extension.js
@@ -1,7 +1,7 @@
 // @author         ZasoGD
 // @name           Multi Projects Extension
 // @category       Controls
-// @version        0.1.0
+// @version        0.1.1
 // @description    Create separated projects in some plugins.
 
 //

--- a/plugins/pan-control.js
+++ b/plugins/pan-control.js
@@ -1,7 +1,7 @@
 // @author         fragger
 // @name           Pan control
 // @category       Controls
-// @version        0.2.1
+// @version        0.2.2
 // @description    Show a panning control on the map.
 
 

--- a/plugins/scale-bar.js
+++ b/plugins/scale-bar.js
@@ -1,7 +1,7 @@
 // @author         breunigs
 // @name           Scale bar
 // @category       Controls
-// @version        0.1.0
+// @version        0.1.1
 // @description    Show scale bar on the map.
 
 


### PR DESCRIPTION
Fix known issues of prev. release
## IITC main script
- boot.js: add timeout to defer boot until all the plugins are loaded #522
- do not rely on `iitcLoaded` hook when not really needed (otherwise it should prepended with `window.iitcLoaded` check) #520, #523, #524, #525
- core: avoid stock intel exception #521

## Plugins
- MPE: Fix icon in toolbox #526

## Build scripts
- Disabled the build of release version in master branch #528