### PR TITLE
Disabled the build of release version in master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,9 +58,10 @@ deploy:
   # deploy to google play
   - provider: script
     skip_cleanup: true
-    script: bundle exec fastlane deploy_$BUILD_TYPE
+    script: if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[Release]"* or BUILD_TYPE = "release" ]]; then bundle exec fastlane deploy_$BUILD_TYPE; fi
     on:
       branch: master
+      tags: true
 
   # deploy to github releases
   - provider: releases


### PR DESCRIPTION
Disable sending beta version to GPlay with text *[Release]* in commit message to avoid conflict due to same versionCode (with same commit) when building release version from tags.

Part of https://github.com/IITC-CE/ingress-intel-total-conversion/pull/517/