### PR TITLE
IITC-Mobile: Allow plugins to register internal hostnames

### DIFF
--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_JSInterface.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_JSInterface.java
@@ -218,4 +218,9 @@ public class IITC_JSInterface {
             mIitc.reloadIITC();
         });
     }
+
+    @JavascriptInterface
+    public void addInternalHostname(String hostname) {
+        mIitc.addInternalHostname(hostname);
+    }
 }

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -113,6 +113,7 @@ public class IITC_Mobile extends AppCompatActivity
     private IITC_DebugHistory debugHistory;
     private int debugHistoryPosition = -1;
     private String debugInputStore = "";
+    private Set<String> mInternalHostnames = new HashSet<>();
 
     // Used for custom back stack handling
     private final Stack<Pane> mBackStack = new Stack<IITC_NavigationHelper.Pane>();
@@ -839,6 +840,7 @@ public class IITC_Mobile extends AppCompatActivity
         mIitcWebView.getWebViewClient().reset();
         mBackStack.clear();
         mCurrentPane = Pane.MAP;
+        mInternalHostnames = new HashSet<>();
     }
 
     // inject the iitc-script and load the intel url
@@ -1250,5 +1252,21 @@ public class IITC_Mobile extends AppCompatActivity
             }
         }
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
+
+    /**
+     * Add host name that should be opened in the internal webview.
+     * @param hostname host name.
+     */
+    public void addInternalHostname(String hostname) {
+        mInternalHostnames.add(hostname);
+    }
+
+    /**
+     * @param hostname host name.
+     * @return <code>true</code> if a host name should be opened in the internal webview.
+     */
+    public boolean isInternalHostname(String hostname) {
+        return mInternalHostnames.contains(hostname);
     }
 }

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_WebViewClient.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_WebViewClient.java
@@ -294,6 +294,10 @@ public class IITC_WebViewClient extends WebViewClient {
             Log.d("Google login");
             return false;
         }
+        if (mIitc.isInternalHostname(uriHost)) {
+            Log.d("internal host");
+            return false;
+        }
         Log.d("no ingress intel link, start external app to load url: " + url);
         final Intent intent = new Intent(Intent.ACTION_VIEW, uri);
         // make new activity independent from iitcm


### PR DESCRIPTION
Internal hostnames are not opened in an external browser, but instead in the IITC mobile webview.
This allows plugins to use authentication flows that use a domain different from Google / Facebook.