### PR TITLE
implement location filters api, and other changes

### DIFF
--- a/core/code/utils_misc.js
+++ b/core/code/utils_misc.js
@@ -474,6 +474,37 @@ window.clampLatLngBounds = function (bounds) {
   return L.latLngBounds(clampLatLng(SW), clampLatLng(NE));
 }
 
+/*
+pnpoly Copyright (c) 1970-2003, Wm. Randolph Franklin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+     disclaimers.
+  2. Redistributions in binary form must reproduce the above copyright notice in the documentation and/or other
+     materials provided with the distribution.
+  3. The name of W. Randolph Franklin may not be used to endorse or promote products derived from this Software without
+     specific prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+window.pnpoly = function (polygon, point) {
+  var inside = 0;
+  // j records previous value. Also handles wrapping around.
+  for (var i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    inside ^= polygon[i].y > point.y !== polygon[j].y > point.y &&
+              point.x - polygon[i].x < (polygon[j].x - polygon[i].x) * (point.y - polygon[i].y) / (polygon[j].y - polygon[i].y);
+  }
+  // Let's make js as magical as C. Yay.
+  return !!inside;
+};
+
 // @function makePermalink(latlng?: LatLng, options?: Object): String
 // Makes the permalink for the portal with specified latlng, possibly including current map view.
 // Portal latlng can be omitted to create mapview-only permalink.

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -1,7 +1,7 @@
 // @author         breunigs
 // @name           Draw tools
 // @category       Draw
-// @version        0.8.1
+// @version        0.9.0
 // @description    Allow drawing things onto the current map so you may plan your next move. Supports Multi-Project-Extension.
 
 
@@ -728,11 +728,65 @@ window.plugin.drawTools.initMPE = function(){
   });
 }
 
+var cachedFilters;
+window.plugin.drawTools.getLocationFilters = function () {
+  if (cachedFilters) { return cachedFilters; }
+  var filters;
+  if (!map.hasLayer(plugin.drawTools.drawnItems)) {
+    return [];
+  }
+  var markers = [];
+  var polygons = [];
+  plugin.drawTools.drawnItems.eachLayer(function(layer) {
+    if (layer instanceof L.GeodesicPolygon) {
+      polygons.push(layer);
+    } else if (layer instanceof L.Marker) {
+      markers.push(layer);
+    }
+  });
+  markers = markers.filter(function(marker) { return marker._icon._leaflet_pos; });
+  polygons = polygons.filter(function(poly) { return poly._rings && poly._rings.length; });
+  polygons = polygons.map(function(poly) { return poly._rings[0]; });
+  filters = polygons.map(function (poly) {
+    return function (portal) { // portal|Point|LatLng
+      var point;
+      if ('_point' in portal || portal instanceof L.CircleMarker) {
+        point = portal._point;
+        if (!point) { return false; }
+      } else if ('x' in portal) {
+        point = portal;
+      } else if ('lat' in portal) {
+        point = map.latLngToLayerPoint(portal);
+      } else if (portal.getLatLng) {
+        point = map.latLngToLayerPoint(portal.getLatLng());
+      }
+      if (markers.some(function (marker) {
+        return marker._icon._leaflet_pos.equals(point);
+      })) {
+        return false;
+      }
+      return window.pnpoly(poly, point);
+    };
+  });
+  cachedFilters = filters;
+  return filters;
+}
+
 function setup () {
   loadExternals();
   window.plugin.drawTools.boot();
   window.plugin.drawTools.initMPE();
+
+  var filterEvents = new L.Evented();
+  window.map.on('draw:created draw:edited draw:deleted', function (e) {
+    filterEvents.fire('changed', { originalEvent: e });
+  });
+  filterEvents.on('changed', function () {
+    cachedFilters = null;
+  });
+  window.plugin.drawTools.filterEvents = filterEvents;
 }
+setup.priority = 'high';
 
 function loadExternals () {
   try {

--- a/plugins/fix-china-map-offset.js
+++ b/plugins/fix-china-map-offset.js
@@ -1,7 +1,7 @@
 ﻿// @author         modos189
 // @name           Fix maps offsets in China
 // @category       Tweaks
-// @version        0.3.0
+// @version        0.3.1
 // @description    Show correct maps for China user by applying offset tweaks.
 
 
@@ -68,48 +68,6 @@ window.plugin.fixChinaMapOffset = fixChinaMapOffset;
 var insane_is_in_china = (function () { // adapted from https://github.com/Artoria2e5/PRCoords/blob/master/js/misc/insane_is_in_china.js
 /* eslint-disable */
   'use strict';
-
-  /// *** pnpoly *** ///
-  // Wm. Franklin's 8-line point-in-polygon C program
-  // Copyright (c) 1970-2003, Wm. Randolph Franklin
-  // Copyright (c) 2017, Mingye Wang (js translation)
-  //
-  // Permission is hereby granted, free of charge, to any person obtaining
-  // a copy of this software and associated documentation files (the
-  // "Software"), to deal in the Software without restriction, including
-  // without limitation the rights to use, copy, modify, merge, publish,
-  // distribute, sublicense, and/or sell copies of the Software, and to
-  // permit persons to whom the Software is furnished to do so, subject to
-  // the following conditions:
-  //
-  //   1. Redistributions of source code must retain the above copyright
-  //      notice, this list of conditions and the following disclaimers.
-  //   2. Redistributions in binary form must reproduce the above
-  //      copyright notice in the documentation and/or other materials
-  //      provided with the distribution.
-  //   3. The name of W. Randolph Franklin may not be used to endorse or
-  //      promote products derived from this Software without specific
-  //      prior written permission.
-  //
-  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-  // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-  // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-  // NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-  // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-  // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-  // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-  var pnpoly = function (xs, ys, x, y) {
-    if (!(xs.length === ys.length)) { throw new Error('pnpoly: assert(xs.length === ys.length)'); }
-    var inside = 0;
-    // j records previous value. Also handles wrapping around.
-    for (var i = 0, j = xs.length - 1; i < xs.length; j = i++) {
-      inside ^= ys[i] > y !== ys[j] > y &&
-                x < (xs[j] - xs[i]) * (y - ys[i]) / (ys[j] - ys[i]) + xs[i];
-    }
-    // Let's make js as magical as C. Yay.
-    return !!inside;
-  };
-  /// ^^^ pnpoly ^^^ ///
 
   // This set of points roughly illustrates the scope of Google's
   // distortion. It has nothing to do with national borders etc.
@@ -195,12 +153,13 @@ var insane_is_in_china = (function () { // adapted from https://github.com/Artor
 
   var lats = POINTS.filter(function (_, idx) { return idx % 2 === 1; });
   var lons = POINTS.filter(function (_, idx) { return idx % 2 === 0; });
+  var XYs = lats.map(function (_, i) { return { x: lats[i], y: lons[i]}; });
 
   function isInChina (lat, lon) {
     // Yank out South China Sea as it's not distorted.
     if (lat >= 17.754 && lat <= 55.8271 &&
         lon >= 72.004 && lon <= 137.8347) {
-      return pnpoly(lats, lons, lat, lon);
+      return window.pnpoly(XYs, {x: lat, y: lon});
     }
   }
 

--- a/plugins/fly-links.js
+++ b/plugins/fly-links.js
@@ -22,8 +22,6 @@ window.plugin.flyLinks.updateLayer = function() {
 
   window.plugin.flyLinks.linksLayerGroup.clearLayers();
   window.plugin.flyLinks.fieldsLayerGroup.clearLayers();
-  var ctrl = [$('.leaflet-control-layers-selector + span:contains("Fly links")').parent(),
-              $('.leaflet-control-layers-selector + span:contains("Fly fields")').parent()];
 
   var distance = function(a, b) {
     return Math.sqrt((a.x - b.x) * (a.x - b.x) + (a.y - b.y) * (a.y - b.y));
@@ -59,7 +57,7 @@ window.plugin.flyLinks.updateLayer = function() {
         var c = points[index[i]];
         var d = -det(a, b, c);
         if (d > EPS) {
-            _index.push(index[i]);
+          _index.push(index[i]);
         }
         if (maxd < d - EPS) {
           maxd = d;
@@ -174,7 +172,8 @@ window.plugin.flyLinks.updateLayer = function() {
         var tlen = -1;
         var i;
         for (i = 0; i < line_edge_indexes.length; ++i) {
-          var [i0, i1] = line_edge_indexes[i];
+          var indexes = line_edge_indexes[i];
+          var i0 = indexes[0], i1 = indexes[1];
           if (k < i0 && i0 < k+len && (i1 < k || k+len < i1) ||
               k < i1 && i1 < k+len && (i0 < k || k+len < i0)) {
             break;
@@ -220,7 +219,7 @@ window.plugin.flyLinks.updateLayer = function() {
     if (best[index.length - 1][0].height > 0) {
       maketriangulation(index.length - 1, 0);
     } else {
-      console.log("Fly links: no triangulation");
+      console.log('Fly links: no triangulation');
     }
     return {edges: edges, triangles: triangles};
   };
@@ -304,7 +303,7 @@ window.plugin.flyLinks.updateLayer = function() {
       }
     }
     if (points.length >= window.plugin.flyLinks.MAX_PORTALS_TO_LINK) {
-      //alert("Some polygon contains more than 100 portals.");
+      // alert("Some polygon contains more than 100 portals.");
       return;
     }
     if (!points.length) return;
@@ -361,7 +360,7 @@ window.plugin.flyLinks.setup = function() {
   window.plugin.flyLinks.linksLayerGroup.on('add', update);
   window.plugin.flyLinks.fieldsLayerGroup.on('add', update);
 
-  window.addHook('mapDataRefreshEnd', function(e) {
+  window.addHook('mapDataRefreshEnd', function() {
     window.plugin.flyLinks.updateLayer();
   });
 

--- a/plugins/fly-links.js
+++ b/plugins/fly-links.js
@@ -16,8 +16,9 @@ window.plugin.flyLinks.fieldsLayerGroup = null;
 
 window.plugin.flyLinks.updateLayer = function() {
   if (!window.map.hasLayer(window.plugin.flyLinks.linksLayerGroup) &&
-      !window.map.hasLayer(window.plugin.flyLinks.fieldsLayerGroup))
+      !window.map.hasLayer(window.plugin.flyLinks.fieldsLayerGroup)) {
     return;
+  }
 
   window.plugin.flyLinks.linksLayerGroup.clearLayers();
   window.plugin.flyLinks.fieldsLayerGroup.clearLayers();
@@ -44,8 +45,9 @@ window.plugin.flyLinks.updateLayer = function() {
   };
 
   var convexHull = function(points) {
-    if (points.length < 3)
+    if (points.length < 3) {
       return [];
+    }
     var result = [];
     var func = function _func(ai, bi, index) {
       var maxd = 0;
@@ -76,10 +78,12 @@ window.plugin.flyLinks.updateLayer = function() {
     var index = [];
     for (var i = 0; i < points.length; ++i) {
       index.push(i);
-      if (points[minxi].x > points[i].x)
+      if (points[minxi].x > points[i].x) {
         minxi = i;
-      if (points[maxxi].x < points[i].x)
+      }
+      if (points[maxxi].x < points[i].x) {
         maxxi = i;
+      }
     }
     func(minxi, maxxi, index);
     func(maxxi, minxi, index);
@@ -87,15 +91,18 @@ window.plugin.flyLinks.updateLayer = function() {
   };
 
   var triangulate2 = function(index, line_indexes, line_edge_indexes, locations) {
-    if (index.length == 0)
+    if (index.length == 0) {
       return {edges: [], triangles: []};
+    }
     var data = [];
     var subtriangulate = function _subtriangulate(ai, bi, ci, index) {
       var _i = [ai, bi, ci].sort(function(a,b){return a-b;});
-      if (data[_i[0]] === undefined)
+      if (data[_i[0]] === undefined) {
         data[_i[0]] = [];
-      if (data[_i[0]][_i[1]-_i[0]] === undefined)
+      }
+      if (data[_i[0]][_i[1]-_i[0]] === undefined) {
         data[_i[0]][_i[1]-_i[0]] = [];
+      }
       if (data[_i[0]][_i[1]-_i[0]][_i[2]-_i[1]] === undefined) {
         var _index = [];
         for (var i = 0; i < index.length; ++i) {
@@ -112,10 +119,12 @@ window.plugin.flyLinks.updateLayer = function() {
         for (i = 0; i < line_indexes.length; ++i) {
           var f0 = _index.indexOf(line_indexes[i][0]) != -1;
           var f1 = _index.indexOf(line_indexes[i][1]) != -1;
-          if (f0 && !f1 && _i.indexOf(line_indexes[i][1]) == -1)
+          if (f0 && !f1 && _i.indexOf(line_indexes[i][1]) == -1) {
             break;
-          if (f1 && !f0 && _i.indexOf(line_indexes[i][0]) == -1)
+          }
+          if (f1 && !f0 && _i.indexOf(line_indexes[i][0]) == -1) {
             break;
+          }
         }
         if (i < line_indexes.length) {
           besth = 0;
@@ -167,8 +176,9 @@ window.plugin.flyLinks.updateLayer = function() {
         for (i = 0; i < line_edge_indexes.length; ++i) {
           var [i0, i1] = line_edge_indexes[i];
           if (k < i0 && i0 < k+len && (i1 < k || k+len < i1) ||
-              k < i1 && i1 < k+len && (i0 < k || k+len < i0))
+              k < i1 && i1 < k+len && (i0 < k || k+len < i0)) {
             break;
+          }
         }
         if (i >= line_edge_indexes.length) {
           for (var _len = 1; _len <= len - 1; ++_len) {
@@ -200,16 +210,18 @@ window.plugin.flyLinks.updateLayer = function() {
     };
     var maketriangulation = function _maketriangulation(len, a) {
       edges.push(new window.plugin.flyLinks.Edge(locations[index[a]], locations[index[a+len]], 0));
-      if (best[len][a].length == -1)
+      if (best[len][a].length == -1) {
         return;
+      }
       makesubtriangulation(index[a], index[a+best[len][a].length], index[a+len], 1);
       _maketriangulation(best[len][a].length, a);
       _maketriangulation(len - best[len][a].length, a + best[len][a].length);
     };
-    if (best[index.length - 1][0].height > 0)
+    if (best[index.length - 1][0].height > 0) {
       maketriangulation(index.length - 1, 0);
-    else
+    } else {
       console.log("Fly links: no triangulation");
+    }
     return {edges: edges, triangles: triangles};
   };
 
@@ -220,8 +232,9 @@ window.plugin.flyLinks.updateLayer = function() {
     for (var i = 0; i < line_indexes.length; ++i) {
       var i0 = index.indexOf(line_indexes[i][0]);
       var i1 = index.indexOf(line_indexes[i][1]);
-      if (i0 == -1 || i1 == -1)
+      if (i0 == -1 || i1 == -1) {
         continue;
+      }
       line_edge_indexes.push([i0, i1]);
     }
     return triangulate2(index, line_indexes, line_edge_indexes, locations);
@@ -251,18 +264,21 @@ window.plugin.flyLinks.updateLayer = function() {
     var result = [];
     var findPoint = function(points, point) {
       for (var i = 0; i < points.length; ++i) {
-        if (points[i].x === point.x && points[i].y === point.y)
+        if (points[i].x === point.x && points[i].y === point.y) {
           return i;
+        }
       }
       return -1;
     };
     for (var i = 0; i < lines.length; ++i) {
       var a = findPoint(points, lines[i][0]);
-      if (a == -1)
+      if (a == -1) {
         continue;
+      }
       var b = findPoint(points, lines[i][1]);
-      if (b == -1)
+      if (b == -1) {
         continue;
+      }
       result.push([a, b]);
     }
     return result;

--- a/plugins/fly-links.js
+++ b/plugins/fly-links.js
@@ -66,7 +66,7 @@ window.plugin.flyLinks.updateLayer = function() {
           maxdi = index[i];
         }
       }
-      if (maxdi != -1) {
+      if (maxdi !== -1) {
         _func(ai, maxdi, _index);
         _func(maxdi, bi, _index);
       } else {
@@ -91,7 +91,7 @@ window.plugin.flyLinks.updateLayer = function() {
   };
 
   var triangulate2 = function(index, line_indexes, line_edge_indexes, locations) {
-    if (index.length == 0) {
+    if (index.length === 0) {
       return {edges: [], triangles: []};
     }
     var data = [];
@@ -117,19 +117,19 @@ window.plugin.flyLinks.updateLayer = function() {
         var besthi = -1;
         var i;
         for (i = 0; i < line_indexes.length; ++i) {
-          var f0 = _index.indexOf(line_indexes[i][0]) != -1;
-          var f1 = _index.indexOf(line_indexes[i][1]) != -1;
-          if (f0 && !f1 && _i.indexOf(line_indexes[i][1]) == -1) {
+          var f0 = _index.indexOf(line_indexes[i][0]) !== -1;
+          var f1 = _index.indexOf(line_indexes[i][1]) !== -1;
+          if (f0 && !f1 && _i.indexOf(line_indexes[i][1]) === -1) {
             break;
           }
-          if (f1 && !f0 && _i.indexOf(line_indexes[i][0]) == -1) {
+          if (f1 && !f0 && _i.indexOf(line_indexes[i][0]) === -1) {
             break;
           }
         }
         if (i < line_indexes.length) {
           besth = 0;
           besthi = -1;
-        } else if (_index.length == 0) {
+        } else if (_index.length === 0) {
           var a = locations[ai];
           var b = locations[bi];
           var c = locations[ci];
@@ -197,7 +197,7 @@ window.plugin.flyLinks.updateLayer = function() {
     var triangles = [];
     var makesubtriangulation = function _makesubtriangulation(ai, bi, ci, depth) {
       var _i = [ai, bi, ci].sort(function(a,b){return a-b;});
-      if (data[_i[0]][_i[1]-_i[0]][_i[2]-_i[1]].index == -1) {
+      if (data[_i[0]][_i[1]-_i[0]][_i[2]-_i[1]].index === -1) {
         triangles.push(new window.plugin.flyLinks.Triangle(locations[ai], locations[bi], locations[ci], depth));
       } else {
         _makesubtriangulation(ai, bi, data[_i[0]][_i[1]-_i[0]][_i[2]-_i[1]].index, depth+1);
@@ -210,7 +210,7 @@ window.plugin.flyLinks.updateLayer = function() {
     };
     var maketriangulation = function _maketriangulation(len, a) {
       edges.push(new window.plugin.flyLinks.Edge(locations[index[a]], locations[index[a+len]], 0));
-      if (best[len][a].length == -1) {
+      if (best[len][a].length === -1) {
         return;
       }
       makesubtriangulation(index[a], index[a+best[len][a].length], index[a+len], 1);
@@ -232,7 +232,7 @@ window.plugin.flyLinks.updateLayer = function() {
     for (var i = 0; i < line_indexes.length; ++i) {
       var i0 = index.indexOf(line_indexes[i][0]);
       var i1 = index.indexOf(line_indexes[i][1]);
-      if (i0 == -1 || i1 == -1) {
+      if (i0 === -1 || i1 === -1) {
         continue;
       }
       line_edge_indexes.push([i0, i1]);
@@ -272,11 +272,11 @@ window.plugin.flyLinks.updateLayer = function() {
     };
     for (var i = 0; i < lines.length; ++i) {
       var a = findPoint(points, lines[i][0]);
-      if (a == -1) {
+      if (a === -1) {
         continue;
       }
       var b = findPoint(points, lines[i][1]);
-      if (b == -1) {
+      if (b === -1) {
         continue;
       }
       result.push([a, b]);

--- a/plugins/fly-links.js
+++ b/plugins/fly-links.js
@@ -21,7 +21,7 @@ window.plugin.flyLinks.updateLayer = function() {
 
   window.plugin.flyLinks.linksLayerGroup.clearLayers();
   window.plugin.flyLinks.fieldsLayerGroup.clearLayers();
-  var ctrl = [$('.leaflet-control-layers-selector + span:contains("Fly links")').parent(), 
+  var ctrl = [$('.leaflet-control-layers-selector + span:contains("Fly links")').parent(),
               $('.leaflet-control-layers-selector + span:contains("Fly fields")').parent()];
 
   var distance = function(a, b) {
@@ -32,17 +32,17 @@ window.plugin.flyLinks.updateLayer = function() {
     var poly = L.polyline([a.latlng, b.latlng], style);
     poly.addTo(window.plugin.flyLinks.linksLayerGroup);
   };
-  
+
   var drawField = function(a, b, c, style) {
     var poly = L.polygon([a.latlng, b.latlng, c.latlng], style);
     poly.addTo(window.plugin.flyLinks.fieldsLayerGroup);
   };
-  
+
   var EPS = 1e-9;
   var det = function(a, b, c) {
     return a.x * b.y - a.y * b.x + b.x * c.y - b.y * c.x + c.x * a.y - c.y * a.x;
   };
-  
+
   var convexHull = function(points) {
     if (points.length < 3)
       return [];
@@ -85,7 +85,7 @@ window.plugin.flyLinks.updateLayer = function() {
     func(maxxi, minxi, index);
     return result;
   };
-  
+
   var triangulate2 = function(index, line_indexes, line_edge_indexes, locations) {
     if (index.length == 0)
       return {edges: [], triangles: []};
@@ -335,7 +335,7 @@ window.plugin.flyLinks.Triangle = function(a, b, c, depth) {
 window.plugin.flyLinks.setup = function() {
   window.plugin.flyLinks.linksLayerGroup = new L.LayerGroup();
   window.plugin.flyLinks.fieldsLayerGroup = new L.LayerGroup();
-  
+
   function update () {
     if (!map.hasLayer(window.plugin.flyLinks.linksLayerGroup) ||
         !map.hasLayer(window.plugin.flyLinks.fieldsLayerGroup)) {

--- a/plugins/fly-links.js
+++ b/plugins/fly-links.js
@@ -31,17 +31,17 @@ window.plugin.flyLinks.updateLayer = function() {
   var drawLink = function(a, b, style) {
     var poly = L.polyline([a.latlng, b.latlng], style);
     poly.addTo(window.plugin.flyLinks.linksLayerGroup);
-  }
+  };
   
   var drawField = function(a, b, c, style) {
     var poly = L.polygon([a.latlng, b.latlng, c.latlng], style);
     poly.addTo(window.plugin.flyLinks.fieldsLayerGroup);
-  }
+  };
   
   var EPS = 1e-9;
   var det = function(a, b, c) {
     return a.x * b.y - a.y * b.x + b.x * c.y - b.y * c.x + c.x * a.y - c.y * a.x;
-  }
+  };
   
   var convexHull = function(points) {
     if (points.length < 3)
@@ -70,7 +70,7 @@ window.plugin.flyLinks.updateLayer = function() {
       } else {
         result.push(ai);
       }
-    }
+    };
     var minxi = 0;
     var maxxi = 0;
     var index = [];
@@ -84,7 +84,7 @@ window.plugin.flyLinks.updateLayer = function() {
     func(minxi, maxxi, index);
     func(maxxi, minxi, index);
     return result;
-  }
+  };
   
   var triangulate2 = function(index, line_indexes, line_edge_indexes, locations) {
     if (index.length == 0)
@@ -108,14 +108,14 @@ window.plugin.flyLinks.updateLayer = function() {
         }
         var besth = 0;
         var besthi = -1;
-        var i
+        var i;
         for (i = 0; i < line_indexes.length; ++i) {
-          var f0 = _index.indexOf(line_indexes[i][0]) != -1
-          var f1 = _index.indexOf(line_indexes[i][1]) != -1
+          var f0 = _index.indexOf(line_indexes[i][0]) != -1;
+          var f1 = _index.indexOf(line_indexes[i][1]) != -1;
           if (f0 && !f1 && _i.indexOf(line_indexes[i][1]) == -1)
-            break
+            break;
           if (f1 && !f0 && _i.indexOf(line_indexes[i][0]) == -1)
-            break
+            break;
         }
         if (i < line_indexes.length) {
           besth = 0;
@@ -148,13 +148,13 @@ window.plugin.flyLinks.updateLayer = function() {
         data[_i[0]][_i[1]-_i[0]][_i[2]-_i[1]] = {height: besth, index: besthi};
       }
       return data[_i[0]][_i[1]-_i[0]][_i[2]-_i[1]].height;
-    }
+    };
     var subindex = [];
     for (var i = 0; i < locations.length; ++i) {
       subindex.push(i);
     }
     var best = [];
-    best[1] = []
+    best[1] = [];
     for (var k = 0; k < index.length - 1; ++k) {
       best[1][k] = {height: Infinity, length: -1};
     }
@@ -163,16 +163,16 @@ window.plugin.flyLinks.updateLayer = function() {
       for (var k = 0; k < index.length - len; ++k) {
         var t = 0;
         var tlen = -1;
-        var i
+        var i;
         for (i = 0; i < line_edge_indexes.length; ++i) {
-          var [i0, i1] = line_edge_indexes[i]
+          var [i0, i1] = line_edge_indexes[i];
           if (k < i0 && i0 < k+len && (i1 < k || k+len < i1) ||
               k < i1 && i1 < k+len && (i0 < k || k+len < i0))
-            break
+            break;
         }
         if (i >= line_edge_indexes.length) {
           for (var _len = 1; _len <= len - 1; ++_len) {
-            var _t = Math.min(best[_len][k].height, best[len-_len][k+_len].height, subtriangulate(index[k], index[k+_len], index[k+len], subindex))
+            var _t = Math.min(best[_len][k].height, best[len-_len][k+_len].height, subtriangulate(index[k], index[k+_len], index[k+len], subindex));
             if (t < _t) {
               t = _t;
               tlen = _len;
@@ -197,7 +197,7 @@ window.plugin.flyLinks.updateLayer = function() {
         edges.push(new window.plugin.flyLinks.Edge(locations[bi], locations[data[_i[0]][_i[1]-_i[0]][_i[2]-_i[1]].index], depth));
         edges.push(new window.plugin.flyLinks.Edge(locations[ci], locations[data[_i[0]][_i[1]-_i[0]][_i[2]-_i[1]].index], depth));
       }
-    }
+    };
     var maketriangulation = function _maketriangulation(len, a) {
       edges.push(new window.plugin.flyLinks.Edge(locations[index[a]], locations[index[a+len]], 0));
       if (best[len][a].length == -1)
@@ -205,27 +205,27 @@ window.plugin.flyLinks.updateLayer = function() {
       makesubtriangulation(index[a], index[a+best[len][a].length], index[a+len], 1);
       _maketriangulation(best[len][a].length, a);
       _maketriangulation(len - best[len][a].length, a + best[len][a].length);
-    }
+    };
     if (best[index.length - 1][0].height > 0)
-      maketriangulation(index.length - 1, 0)
+      maketriangulation(index.length - 1, 0);
     else
-      console.log("Fly links: no triangulation")
+      console.log("Fly links: no triangulation");
     return {edges: edges, triangles: triangles};
-  }
+  };
 
   var triangulate = function(locations, lines) {
     var index = convexHull(locations);
-    var line_indexes = filterLines(locations, lines)
-    var line_edge_indexes = []
+    var line_indexes = filterLines(locations, lines);
+    var line_edge_indexes = [];
     for (var i = 0; i < line_indexes.length; ++i) {
-      var i0 = index.indexOf(line_indexes[i][0])
-      var i1 = index.indexOf(line_indexes[i][1])
+      var i0 = index.indexOf(line_indexes[i][0]);
+      var i1 = index.indexOf(line_indexes[i][1]);
       if (i0 == -1 || i1 == -1)
-        continue
-      line_edge_indexes.push([i0, i1])
+        continue;
+      line_edge_indexes.push([i0, i1]);
     }
     return triangulate2(index, line_indexes, line_edge_indexes, locations);
-  }
+  };
 
   var edges = [];
   var triangles = [];
@@ -242,7 +242,7 @@ window.plugin.flyLinks.updateLayer = function() {
       if (!polyline._rings) { return; }
       var p = polyline._rings[0];
       for (var j = 1; j < p.length; ++j) {
-        lines.push([p[j-1], p[j]])
+        lines.push([p[j-1], p[j]]);
       }
     });
   }
@@ -252,21 +252,21 @@ window.plugin.flyLinks.updateLayer = function() {
     var findPoint = function(points, point) {
       for (var i = 0; i < points.length; ++i) {
         if (points[i].x === point.x && points[i].y === point.y)
-          return i
+          return i;
       }
-      return -1
-    }
+      return -1;
+    };
     for (var i = 0; i < lines.length; ++i) {
-      var a = findPoint(points, lines[i][0])
+      var a = findPoint(points, lines[i][0]);
       if (a == -1)
-        continue
-      var b = findPoint(points, lines[i][1])
+        continue;
+      var b = findPoint(points, lines[i][1]);
       if (b == -1)
-        continue
-      result.push([a, b])
+        continue;
+      result.push([a, b]);
     }
-    return result
-  }
+    return result;
+  };
 
   var filters = plugin.drawTools && plugin.drawTools.getLocationFilters && plugin.drawTools.getLocationFilters();
   // fallback to map bounds if no drawn polygon (or no drawtools)
@@ -317,20 +317,20 @@ window.plugin.flyLinks.updateLayer = function() {
       interactive: false,
     });
   });
-}
+};
 
 window.plugin.flyLinks.Edge = function(a, b, depth) {
   this.a = a;
   this.b = b;
   this.depth = depth;
-}
+};
 
 window.plugin.flyLinks.Triangle = function(a, b, c, depth) {
   this.a = a;
   this.b = b;
   this.c = c;
   this.depth = depth;
-}
+};
 
 window.plugin.flyLinks.setup = function() {
   window.plugin.flyLinks.linksLayerGroup = new L.LayerGroup();
@@ -359,5 +359,5 @@ window.plugin.flyLinks.setup = function() {
 
   window.addLayerGroup('Fly links', window.plugin.flyLinks.linksLayerGroup, false);
   window.addLayerGroup('Fly fields', window.plugin.flyLinks.fieldsLayerGroup, false);
-}
+};
 var setup = window.plugin.flyLinks.setup;

--- a/plugins/layer-count.js
+++ b/plugins/layer-count.js
@@ -6,18 +6,19 @@
 
 
 // use own namespace for plugin
-plugin.layerCount = {}
+var layerCount = {};
+window.plugin.layerCount = layerCount;
 
-plugin.layerCount.onBtnClick = function(ev) {
-  var btn = plugin.layerCount.button,
-    tooltip = plugin.layerCount.tooltip,
-    layer = plugin.layerCount.layer;
+layerCount.onBtnClick = function(ev) {
+  var btn = layerCount.button,
+    tooltip = layerCount.tooltip,
+    layer = layerCount.layer;
 
   if(btn.classList.contains("active")) {
-    map.off("click", plugin.layerCount.calculate);
+    map.off("click", layerCount.calculate);
     btn.classList.remove("active");
   } else {
-    map.on("click", plugin.layerCount.calculate);
+    map.on("click", layerCount.calculate);
     btn.classList.add("active");
     setTimeout(function(){
       tooltip.textContent = "Click on map";
@@ -25,11 +26,11 @@ plugin.layerCount.onBtnClick = function(ev) {
   }
 };
 
-plugin.layerCount.latLngE6ToGooglePoint = function(point) {
+layerCount.latLngE6ToGooglePoint = function(point) {
   return new google.maps.LatLng(point.latE6/1E6, point.lngE6/1E6);
 }
 
-plugin.layerCount.calculate = function(ev) {
+layerCount.calculate = function(ev) {
   var point = ev.layerPoint;
   var fields = window.fields;
   var layersRes = layersEnl = layersDrawn = 0;
@@ -68,7 +69,7 @@ plugin.layerCount.calculate = function(ev) {
   if (layersDrawn != 0)
     content += "; draw: " + layersDrawn + " polygon(s)";
 
-  plugin.layerCount.tooltip.innerHTML = content;
+  layerCount.tooltip.innerHTML = content;
 
   return false;
 };
@@ -80,7 +81,7 @@ var setup = function() {
 
   var button = document.createElement("a");
   button.className = "leaflet-bar-part";
-  button.addEventListener("click", plugin.layerCount.onBtnClick, false);
+  button.addEventListener("click", layerCount.onBtnClick, false);
   button.title = 'Count nested fields';
 
   var tooltip = document.createElement("div");
@@ -92,7 +93,7 @@ var setup = function() {
   container.appendChild(button);
   parent.append(container);
 
-  plugin.layerCount.button = button;
-  plugin.layerCount.tooltip = tooltip;
-  plugin.layerCount.container = container;
+  layerCount.button = button;
+  layerCount.tooltip = tooltip;
+  layerCount.container = container;
 }

--- a/plugins/layer-count.js
+++ b/plugins/layer-count.js
@@ -56,33 +56,45 @@ function calculate (ev) {
 function setup () {
   $('<style>').prop('type', 'text/css').html('@include_string:layer-count.css@').appendTo('head');
 
-  var parent = $('.leaflet-top.leaflet-left', window.map.getContainer());
+  var LayerCount = L.Control.extend({
+    options: {
+      position: 'topleft'
+    },
 
-  var button = document.createElement('a');
-  button.className = 'leaflet-bar-part';
-  button.addEventListener('click', function () {
-    var btn = this;
-    if (btn.classList.contains('active')) {
-      window.map.off('click', calculate);
-      btn.classList.remove('active');
-    } else {
-      window.map.on('click', calculate);
-      btn.classList.add('active');
-      setTimeout(function () {
-        tooltip.textContent = 'Click on map';
-      }, 10);
+    onAdd: function (map) {
+      var button = document.createElement('a');
+      button.className = 'leaflet-bar-part';
+      button.addEventListener('click', function toggle () {
+        var btn = this;
+        if (btn.classList.contains('active')) {
+          map.off('click', calculate);
+          btn.classList.remove('active');
+        } else {
+          map.on('click', calculate);
+          btn.classList.add('active');
+          setTimeout(function () {
+            tooltip.textContent = 'Click on map';
+          }, 10);
+        }
+      }, false);
+      button.title = 'Count nested fields';
+
+      tooltip = document.createElement('div');
+      tooltip.className = 'leaflet-control-layer-count-tooltip';
+      button.appendChild(tooltip);
+
+      var container = document.createElement('div');
+      container.className = 'leaflet-control-layer-count leaflet-bar';
+      container.appendChild(button);
+      return container;
+    },
+
+    onRemove: function (map) {
+      map.off('click', calculate);
     }
-  }, false);
-  button.title = 'Count nested fields';
-
-  tooltip = document.createElement('div');
-  tooltip.className = 'leaflet-control-layer-count-tooltip';
-  button.appendChild(tooltip);
-
-  var container = document.createElement('div');
-  container.className = 'leaflet-control-layer-count leaflet-bar leaflet-control';
-  container.appendChild(button);
-  parent.append(container);
+  });
+  var ctrl = new LayerCount;
+  ctrl.addTo(window.map);
 }
 
 /* exported setup */

--- a/plugins/layer-count.js
+++ b/plugins/layer-count.js
@@ -9,90 +9,90 @@
 plugin.layerCount = {}
 
 plugin.layerCount.onBtnClick = function(ev) {
-	var btn = plugin.layerCount.button,
-		tooltip = plugin.layerCount.tooltip,
-		layer = plugin.layerCount.layer;
+  var btn = plugin.layerCount.button,
+    tooltip = plugin.layerCount.tooltip,
+    layer = plugin.layerCount.layer;
 
-	if(btn.classList.contains("active")) {
-		map.off("click", plugin.layerCount.calculate);
-		btn.classList.remove("active");
-	} else {
-		map.on("click", plugin.layerCount.calculate);
-		btn.classList.add("active");
-		setTimeout(function(){
-			tooltip.textContent = "Click on map";
-		}, 10);
-	}
+  if(btn.classList.contains("active")) {
+    map.off("click", plugin.layerCount.calculate);
+    btn.classList.remove("active");
+  } else {
+    map.on("click", plugin.layerCount.calculate);
+    btn.classList.add("active");
+    setTimeout(function(){
+      tooltip.textContent = "Click on map";
+    }, 10);
+  }
 };
 
 plugin.layerCount.latLngE6ToGooglePoint = function(point) {
-	return new google.maps.LatLng(point.latE6/1E6, point.lngE6/1E6);
+  return new google.maps.LatLng(point.latE6/1E6, point.lngE6/1E6);
 }
 
 plugin.layerCount.calculate = function(ev) {
-	var point = ev.layerPoint;
-	var fields = window.fields;
-	var layersRes = layersEnl = layersDrawn = 0;
+  var point = ev.layerPoint;
+  var fields = window.fields;
+  var layersRes = layersEnl = layersDrawn = 0;
 
-	for(var guid in fields) {
-		var field = fields[guid];
+  for(var guid in fields) {
+    var field = fields[guid];
 
-		// we don't need to check the field's bounds first. pnpoly is pretty simple math.
-		// Checking the bounds is about 50 times slower than just using pnpoly
-		if(field._rings && window.pnpoly(field._rings[0], point)) {
-			if(field.options.team == TEAM_ENL) {
-				layersEnl++;
-			} else if(field.options.team == TEAM_RES) {
-				layersRes++;
-			}
-		}
-	}
+    // we don't need to check the field's bounds first. pnpoly is pretty simple math.
+    // Checking the bounds is about 50 times slower than just using pnpoly
+    if(field._rings && window.pnpoly(field._rings[0], point)) {
+      if(field.options.team == TEAM_ENL) {
+        layersEnl++;
+      } else if(field.options.team == TEAM_RES) {
+        layersRes++;
+      }
+    }
+  }
 
-	if (window.plugin.drawTools) {
-		plugin.drawTools.drawnItems.eachLayer(function (layer) {
-			if (layer instanceof L.GeodesicPolygon && layer._rings && window.pnpoly(layer._rings[0], point)) {
-				layersDrawn++;
-			}
-		});
-	}
+  if (window.plugin.drawTools) {
+    plugin.drawTools.drawnItems.eachLayer(function (layer) {
+      if (layer instanceof L.GeodesicPolygon && layer._rings && window.pnpoly(layer._rings[0], point)) {
+        layersDrawn++;
+      }
+    });
+  }
 
-	if(layersRes != 0 && layersEnl != 0)
-		var content = "Res: " + layersRes + " + Enl: " + layersEnl + " = " + (layersRes + layersEnl) + " fields";
-	else if(layersRes != 0)
-		var content = "Res: " + layersRes + " field(s)";
-	else if(layersEnl != 0)
-		var content = "Enl: " + layersEnl + " field(s)";
-	else
-		var content = "No fields";
+  if(layersRes != 0 && layersEnl != 0)
+    var content = "Res: " + layersRes + " + Enl: " + layersEnl + " = " + (layersRes + layersEnl) + " fields";
+  else if(layersRes != 0)
+    var content = "Res: " + layersRes + " field(s)";
+  else if(layersEnl != 0)
+    var content = "Enl: " + layersEnl + " field(s)";
+  else
+    var content = "No fields";
 
-	if (layersDrawn != 0)
-		content += "; draw: " + layersDrawn + " polygon(s)";
+  if (layersDrawn != 0)
+    content += "; draw: " + layersDrawn + " polygon(s)";
 
-	plugin.layerCount.tooltip.innerHTML = content;
+  plugin.layerCount.tooltip.innerHTML = content;
 
-	return false;
+  return false;
 };
 
 var setup = function() {
-	$('<style>').prop('type', 'text/css').html('@include_string:layer-count.css@').appendTo('head');
+  $('<style>').prop('type', 'text/css').html('@include_string:layer-count.css@').appendTo('head');
 
-	var parent = $(".leaflet-top.leaflet-left", window.map.getContainer());
+  var parent = $(".leaflet-top.leaflet-left", window.map.getContainer());
 
-	var button = document.createElement("a");
-	button.className = "leaflet-bar-part";
-	button.addEventListener("click", plugin.layerCount.onBtnClick, false);
-	button.title = 'Count nested fields';
+  var button = document.createElement("a");
+  button.className = "leaflet-bar-part";
+  button.addEventListener("click", plugin.layerCount.onBtnClick, false);
+  button.title = 'Count nested fields';
 
-	var tooltip = document.createElement("div");
-	tooltip.className = "leaflet-control-layer-count-tooltip";
-	button.appendChild(tooltip);
+  var tooltip = document.createElement("div");
+  tooltip.className = "leaflet-control-layer-count-tooltip";
+  button.appendChild(tooltip);
 
-	var container = document.createElement("div");
-	container.className = "leaflet-control-layer-count leaflet-bar leaflet-control";
-	container.appendChild(button);
-	parent.append(container);
+  var container = document.createElement("div");
+  container.className = "leaflet-control-layer-count leaflet-bar leaflet-control";
+  container.appendChild(button);
+  parent.append(container);
 
-	plugin.layerCount.button = button;
-	plugin.layerCount.tooltip = tooltip;
-	plugin.layerCount.container = container;
+  plugin.layerCount.button = button;
+  plugin.layerCount.tooltip = tooltip;
+  plugin.layerCount.container = container;
 }

--- a/plugins/layer-count.js
+++ b/plugins/layer-count.js
@@ -9,72 +9,66 @@
 var layerCount = {};
 window.plugin.layerCount = layerCount;
 
-layerCount.onBtnClick = function(ev) {
+layerCount.onBtnClick = function () {
   var btn = layerCount.button,
-    tooltip = layerCount.tooltip,
-    layer = layerCount.layer;
+    tooltip = layerCount.tooltip;
 
-  if(btn.classList.contains('active')) {
-    map.off('click', layerCount.calculate);
+  if (btn.classList.contains('active')) {
+    window.map.off('click', layerCount.calculate);
     btn.classList.remove('active');
   } else {
-    map.on('click', layerCount.calculate);
+    window.map.on('click', layerCount.calculate);
     btn.classList.add('active');
-    setTimeout(function(){
+    setTimeout(function () {
       tooltip.textContent = 'Click on map';
     }, 10);
   }
 };
 
-layerCount.latLngE6ToGooglePoint = function(point) {
-  return new google.maps.LatLng(point.latE6/1E6, point.lngE6/1E6);
-}
-
-layerCount.calculate = function(ev) {
+layerCount.calculate = function (ev) {
   var point = ev.layerPoint;
   var fields = window.fields;
-  var layersRes = layersEnl = layersDrawn = 0;
+  var layersRes = 0, layersEnl = 0, layersDrawn = 0;
 
-  for(var guid in fields) {
+  for (var guid in fields) {
     var field = fields[guid];
 
     // we don't need to check the field's bounds first. pnpoly is pretty simple math.
     // Checking the bounds is about 50 times slower than just using pnpoly
-    if(field._rings && window.pnpoly(field._rings[0], point)) {
-      if(field.options.team === TEAM_ENL) {
+    if (field._rings && window.pnpoly(field._rings[0], point)) {
+      if (field.options.team === TEAM_ENL) {
         layersEnl++;
-      } else if(field.options.team === TEAM_RES) {
+      } else if (field.options.team === TEAM_RES) {
         layersRes++;
       }
     }
   }
 
   if (window.plugin.drawTools) {
-    plugin.drawTools.drawnItems.eachLayer(function (layer) {
+    window.plugin.drawTools.drawnItems.eachLayer(function (layer) {
       if (layer instanceof L.GeodesicPolygon && layer._rings && window.pnpoly(layer._rings[0], point)) {
         layersDrawn++;
       }
     });
   }
 
-  if(layersRes !== 0 && layersEnl !== 0)
-    var content = 'Res: ' + layersRes + ' + Enl: ' + layersEnl + ' = ' + (layersRes + layersEnl) + ' fields';
-  else if(layersRes !== 0)
-    var content = 'Res: ' + layersRes + ' field(s)';
-  else if(layersEnl !== 0)
-    var content = 'Enl: ' + layersEnl + ' field(s)';
-  else
-    var content = 'No fields';
-
-  if (layersDrawn !== 0)
+  var content;
+  if (layersRes !== 0 && layersEnl !== 0) {
+    content = 'Res: ' + layersRes + ' + Enl: ' + layersEnl + ' = ' + (layersRes + layersEnl) + ' fields';
+  } else if (layersRes !== 0) {
+    content = 'Res: ' + layersRes + ' field(s)';
+  } else if (layersEnl !== 0) {
+    content = 'Enl: ' + layersEnl + ' field(s)';
+  } else {
+    content = 'No fields';
+  }
+  if (layersDrawn !== 0) {
     content += '; draw: ' + layersDrawn + ' polygon(s)';
-
+  }
   layerCount.tooltip.innerHTML = content;
-
-  return false;
 };
 
-var setup = function() {
+function setup () {
   $('<style>').prop('type', 'text/css').html('@include_string:layer-count.css@').appendTo('head');
 
   var parent = $('.leaflet-top.leaflet-left', window.map.getContainer());
@@ -97,3 +91,5 @@ var setup = function() {
   layerCount.tooltip = tooltip;
   layerCount.container = container;
 }
+
+/* exported setup */

--- a/plugins/layer-count.js
+++ b/plugins/layer-count.js
@@ -9,23 +9,8 @@
 var layerCount = {};
 window.plugin.layerCount = layerCount;
 
-layerCount.onBtnClick = function () {
-  var btn = layerCount.button,
-    tooltip = layerCount.tooltip;
-
-  if (btn.classList.contains('active')) {
-    window.map.off('click', layerCount.calculate);
-    btn.classList.remove('active');
-  } else {
-    window.map.on('click', layerCount.calculate);
-    btn.classList.add('active');
-    setTimeout(function () {
-      tooltip.textContent = 'Click on map';
-    }, 10);
-  }
-};
-
-layerCount.calculate = function (ev) {
+var tooltip;
+function calculate (ev) {
   var point = ev.layerPoint;
   var fields = window.fields;
   var layersRes = 0, layersEnl = 0, layersDrawn = 0;
@@ -65,8 +50,8 @@ layerCount.calculate = function (ev) {
   if (layersDrawn !== 0) {
     content += '; draw: ' + layersDrawn + ' polygon(s)';
   }
-  layerCount.tooltip.innerHTML = content;
-};
+  tooltip.innerHTML = content;
+}
 
 function setup () {
   $('<style>').prop('type', 'text/css').html('@include_string:layer-count.css@').appendTo('head');
@@ -75,10 +60,22 @@ function setup () {
 
   var button = document.createElement('a');
   button.className = 'leaflet-bar-part';
-  button.addEventListener('click', layerCount.onBtnClick, false);
+  button.addEventListener('click', function () {
+    var btn = this;
+    if (btn.classList.contains('active')) {
+      window.map.off('click', calculate);
+      btn.classList.remove('active');
+    } else {
+      window.map.on('click', calculate);
+      btn.classList.add('active');
+      setTimeout(function () {
+        tooltip.textContent = 'Click on map';
+      }, 10);
+    }
+  }, false);
   button.title = 'Count nested fields';
 
-  var tooltip = document.createElement('div');
+  tooltip = document.createElement('div');
   tooltip.className = 'leaflet-control-layer-count-tooltip';
   button.appendChild(tooltip);
 
@@ -86,10 +83,6 @@ function setup () {
   container.className = 'leaflet-control-layer-count leaflet-bar leaflet-control';
   container.appendChild(button);
   parent.append(container);
-
-  layerCount.button = button;
-  layerCount.tooltip = tooltip;
-  layerCount.container = container;
 }
 
 /* exported setup */

--- a/plugins/layer-count.js
+++ b/plugins/layer-count.js
@@ -14,14 +14,14 @@ layerCount.onBtnClick = function(ev) {
     tooltip = layerCount.tooltip,
     layer = layerCount.layer;
 
-  if(btn.classList.contains("active")) {
-    map.off("click", layerCount.calculate);
-    btn.classList.remove("active");
+  if(btn.classList.contains('active')) {
+    map.off('click', layerCount.calculate);
+    btn.classList.remove('active');
   } else {
-    map.on("click", layerCount.calculate);
-    btn.classList.add("active");
+    map.on('click', layerCount.calculate);
+    btn.classList.add('active');
     setTimeout(function(){
-      tooltip.textContent = "Click on map";
+      tooltip.textContent = 'Click on map';
     }, 10);
   }
 };
@@ -58,16 +58,16 @@ layerCount.calculate = function(ev) {
   }
 
   if(layersRes != 0 && layersEnl != 0)
-    var content = "Res: " + layersRes + " + Enl: " + layersEnl + " = " + (layersRes + layersEnl) + " fields";
+    var content = 'Res: ' + layersRes + ' + Enl: ' + layersEnl + ' = ' + (layersRes + layersEnl) + ' fields';
   else if(layersRes != 0)
-    var content = "Res: " + layersRes + " field(s)";
+    var content = 'Res: ' + layersRes + ' field(s)';
   else if(layersEnl != 0)
-    var content = "Enl: " + layersEnl + " field(s)";
+    var content = 'Enl: ' + layersEnl + ' field(s)';
   else
-    var content = "No fields";
+    var content = 'No fields';
 
   if (layersDrawn != 0)
-    content += "; draw: " + layersDrawn + " polygon(s)";
+    content += '; draw: ' + layersDrawn + ' polygon(s)';
 
   layerCount.tooltip.innerHTML = content;
 
@@ -77,19 +77,19 @@ layerCount.calculate = function(ev) {
 var setup = function() {
   $('<style>').prop('type', 'text/css').html('@include_string:layer-count.css@').appendTo('head');
 
-  var parent = $(".leaflet-top.leaflet-left", window.map.getContainer());
+  var parent = $('.leaflet-top.leaflet-left', window.map.getContainer());
 
-  var button = document.createElement("a");
-  button.className = "leaflet-bar-part";
-  button.addEventListener("click", layerCount.onBtnClick, false);
+  var button = document.createElement('a');
+  button.className = 'leaflet-bar-part';
+  button.addEventListener('click', layerCount.onBtnClick, false);
   button.title = 'Count nested fields';
 
-  var tooltip = document.createElement("div");
-  tooltip.className = "leaflet-control-layer-count-tooltip";
+  var tooltip = document.createElement('div');
+  tooltip.className = 'leaflet-control-layer-count-tooltip';
   button.appendChild(tooltip);
 
-  var container = document.createElement("div");
-  container.className = "leaflet-control-layer-count leaflet-bar leaflet-control";
+  var container = document.createElement('div');
+  container.className = 'leaflet-control-layer-count leaflet-bar leaflet-control';
   container.appendChild(button);
   parent.append(container);
 

--- a/plugins/layer-count.js
+++ b/plugins/layer-count.js
@@ -41,9 +41,9 @@ layerCount.calculate = function(ev) {
     // we don't need to check the field's bounds first. pnpoly is pretty simple math.
     // Checking the bounds is about 50 times slower than just using pnpoly
     if(field._rings && window.pnpoly(field._rings[0], point)) {
-      if(field.options.team == TEAM_ENL) {
+      if(field.options.team === TEAM_ENL) {
         layersEnl++;
-      } else if(field.options.team == TEAM_RES) {
+      } else if(field.options.team === TEAM_RES) {
         layersRes++;
       }
     }
@@ -57,16 +57,16 @@ layerCount.calculate = function(ev) {
     });
   }
 
-  if(layersRes != 0 && layersEnl != 0)
+  if(layersRes !== 0 && layersEnl !== 0)
     var content = 'Res: ' + layersRes + ' + Enl: ' + layersEnl + ' = ' + (layersRes + layersEnl) + ' fields';
-  else if(layersRes != 0)
+  else if(layersRes !== 0)
     var content = 'Res: ' + layersRes + ' field(s)';
-  else if(layersEnl != 0)
+  else if(layersEnl !== 0)
     var content = 'Enl: ' + layersEnl + ' field(s)';
   else
     var content = 'No fields';
 
-  if (layersDrawn != 0)
+  if (layersDrawn !== 0)
     content += '; draw: ' + layersDrawn + ' polygon(s)';
 
   layerCount.tooltip.innerHTML = content;

--- a/plugins/tidy-links.js
+++ b/plugins/tidy-links.js
@@ -1,7 +1,7 @@
 // @author         boombuler
 // @name           Tidy Links
 // @category       Draw
-// @version        0.5.0
+// @version        0.6.0
 // @description    Calculate how to link the portals to create a reasonably tidy set of links/fields. Enable from the layer chooser. (former `Max Links`)
 
 
@@ -25,23 +25,39 @@ tidyLinks.STROKE_STYLE = { // https://leafletjs.com/reference-1.4.0.html#polylin
 var map;
 
 tidyLinks.getLocations = function (limit) {
-  var locations = [];
-  var bounds = map.getBounds();
-  for (var guid in window.portals) {
-    if (limit && locations.length > limit) { return; }
-    var ll = window.portals[guid].getLatLng();
-    if (bounds.contains(ll)) { locations.push(ll); }
+  var filters = plugin.drawTools && plugin.drawTools.getLocationFilters && plugin.drawTools.getLocationFilters();
+  // fallback to map bounds if no drawn polygon (or no drawtools)
+  if (!filters || !filters.length) {
+    var bounds = map.getBounds();
+    filters = [function (p) {
+      return bounds.contains(p.getLatLng());
+    }];
   }
-  return locations;
+
+  var locationsArray = [];
+  var counter = 0;
+  filters.forEach(function (filter) {
+    var points = [];
+    for (var guid in window.portals) {
+      if (limit) {
+        counter++;
+        if (counter > limit) { return; }
+      }
+      var location = window.portals[guid];
+      if (filter(location)) {
+        points.push(location);
+      }
+    }
+    if (!points.length) return;
+    locationsArray.push(points);
+  });
+  return locationsArray;
 };
 
 tidyLinks.draw = function (locations, layer) {
-  var triangles = tidyLinks.Delaunay.triangulate(locations.map(function (latlng) {
-    var point = map.project(latlng, tidyLinks.PROJECT_ZOOM);
-    return [point.x,point.y];
+  var triangles = tidyLinks.Delaunay.triangulate(locations.map(function(location) {
+    return [location._point.x, location._point.y];
   }));
-
-  layer.clearLayers();
 
   var drawnLinks = {};
 
@@ -56,7 +72,9 @@ tidyLinks.draw = function (locations, layer) {
 
     if (!(b in drawnLinks[a])) { // no line from a to b yet
       drawnLinks[a][b] = true;
-      L.polyline([locations[a], locations[b]], tidyLinks.STROKE_STYLE).addTo(layer);
+      var aLL = locations[a].getLatLng();
+      var bLL = locations[b].getLatLng();
+      L.polyline([aLL, bLL], tidyLinks.STROKE_STYLE).addTo(layer);
     }
   }
   for (var i = 0; i<triangles.length;) {
@@ -74,9 +92,14 @@ tidyLinks.setOverflow = function (isOveflowed) {
 };
 
 tidyLinks.update = function () {
-  var locations = tidyLinks.getLocations(tidyLinks.MAX_PORTALS_TO_LINK);
-  if (locations) { tidyLinks.draw(locations, tidyLinks.layer); }
-  tidyLinks.setOverflow(!locations);
+  var locationsArray = tidyLinks.getLocations();
+  if (locationsArray.length) {
+    tidyLinks.layer.clearLayers();
+    locationsArray.forEach(function (locations) {
+      tidyLinks.draw(locations, tidyLinks.layer);
+    });
+  }
+  tidyLinks.setOverflow(!locationsArray.length);
 };
 
 function setup () {
@@ -87,9 +110,15 @@ function setup () {
     .on('add', function () {
       tidyLinks.update();
       window.addHook('mapDataRefreshEnd', tidyLinks.update);
+      if (plugin.drawTools && plugin.drawTools.filterEvents) {
+        plugin.drawTools.filterEvents.on('changed', tidyLinks.update);
+      }
     })
     .on('remove', function () {
       window.removeHook('mapDataRefreshEnd', tidyLinks.update);
+      if (plugin.drawTools && plugin.drawTools.filterEvents) {
+        plugin.drawTools.filterEvents.off('changed', tidyLinks.update);
+      }
     })
     .bindTooltip('Tidy Links: too many portals!', {
       className: 'tidy-links-error',


### PR DESCRIPTION
* utils_misc.js: common function `window.pnpoly`.
  Applied to:
  - fix-china-map-offset
  - fly-links
  - layer-count

* draw-tools: implement _location filters api_.
  Includes entities inside of drawn polygons (every polygon separately).
  Portals with markers are excluded from filters.
  * `window.plugin.drawTools.getLocationFilters()`, returns array of functions:
    `filter(point:portal|Point|LatLng):Boolean`
  * `window.plugin.drawTools.filterEvents:Evented`, with single event "changed".
  Applied to:
    - fly-links
    - tidy-links

* Make use of already projected coords (current zoom), instead of reprojecting.
  Applied to:
  - fly-links
  - tidy-links
  - layer-count (before: used unprojected latlngs)
  - location filters api

  Note: fix-china-map-offset still uses unprojected latlngs in pnpoly, like upstream does.

* fly-links
  - fix working w/o draw-tools
  - fix working w/o drawn polygon (fall back to visible map bounds)
  - redraw on drawn polygon changed
  - on draw: use stored latlngs instead of unprojecting points

Fix #450, close #544 (supersedes)