### PR TITLE
Fixing CI/CD for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
       - master
     tags:
       - '*'
-  pull_request:
 
 jobs:
   build:
@@ -29,16 +28,12 @@ jobs:
 
       - name: Set env BUILD_TYPE and ARCHIVE_DIR (optional)
         run: |
-          if [[ $GITHUB_EVENT_NAME == 'push' ]]; then
-            if [[ $BRANCH == 'master' ]]; then
-                echo "BUILD_TYPE=beta" >> "$GITHUB_ENV"
-                echo "ARCHIVE_DIR=beta_archive" >> "$GITHUB_ENV"
-            else
-                echo "BUILD_TYPE=release" >> "$GITHUB_ENV"
-                echo "ARCHIVE_DIR=release_archive" >> "$GITHUB_ENV"
-            fi
+          if [[ $BRANCH == 'master' ]]; then
+              echo "BUILD_TYPE=beta" >> "$GITHUB_ENV"
+              echo "ARCHIVE_DIR=beta_archive" >> "$GITHUB_ENV"
           else
-              echo "BUILD_TYPE=test" >> "$GITHUB_ENV"
+              echo "BUILD_TYPE=release" >> "$GITHUB_ENV"
+              echo "ARCHIVE_DIR=release_archive" >> "$GITHUB_ENV"
           fi
 
       - name: Download localbuildsettings.py
@@ -56,17 +51,6 @@ jobs:
           echo "ARTIFACT_IITC_MOBILE=$( ls -d ./build/${{ env.BUILD_TYPE }}/* | grep '.apk' )" >> "$GITHUB_ENV"
           echo "ARTIFACT_IITC_ZIP=$( ls -d ./build/${{ env.BUILD_TYPE }}/* | grep '.zip' )" >> "$GITHUB_ENV"
 
-      - name: Push artifacts to PR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: gavv/pull-request-artifacts@v1.0.0
-        with:
-          commit: ${{ github.event.pull_request.head.sha }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts-branch: artifacts
-          artifacts: |
-            ${{ env.ARTIFACT_IITC_MOBILE }}
-            ${{ env.ARTIFACT_IITC_ZIP }}
-
       - name: Set env BUILDSTAMP
         run: |
           echo "BUILDSTAMP=$(date -u +'%Y-%m-%d_%H-%M' -d"$(stat -c %y ./build/${{ env.BUILD_TYPE }}/total-conversion-build.user.js)")" >> "$GITHUB_ENV"
@@ -75,7 +59,7 @@ jobs:
         env:
           WEBSITE_REPO: ${{ secrets.WEBSITE_REPO }}
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-        if: ${{ github.event_name == 'push' && env.WEBSITE_REPO != '' }}
+        if: ${{ env.WEBSITE_REPO != '' }}
         uses: dmnemec/copy_file_to_another_repo_action@main
         with:
           source_file: "./build/${{ env.BUILD_TYPE }}/."
@@ -99,7 +83,7 @@ jobs:
         env:
           TG_BOT_TOKEN: ${{ secrets.TG_BOT_TOKEN }}
           TG_CHAT_ID: ${{ secrets.TG_CHAT_ID }}
-        if: ${{ github.event_name == 'push' && env.TG_BOT_TOKEN != ''}}
+        if: ${{ env.TG_BOT_TOKEN != ''}}
         run: |
           TEXT="🤖 *New IITC Mobile ${{ env.BUILD_TYPE }} build: *[${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
           APIPARAMS="-F parse_mode=MarkdownV2 -F disable_notification=true -F chat_id=${{ env.TG_CHAT_ID }} https://api.telegram.org/bot${{ env.TG_BOT_TOKEN }}/sendDocument"

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -1,0 +1,51 @@
+name: Build PR
+
+# read-only repo token
+# no access to secrets
+on:
+  pull_request:
+    paths-ignore:
+      - '!.github/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'gradle'
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Set env BUILD_TYPE
+        run: |
+            echo "BUILD_TYPE=test" >> "$GITHUB_ENV"
+
+      - name: Download localbuildsettings.py
+        run: wget https://iitc.app/deploy/localbuildsettings.py
+
+      - name: Run build.py
+        run: ./build.py $BUILD_TYPE
+
+      - name: Save PR metadata
+        run: |
+          mv ./build/${{ env.BUILD_TYPE }} ./build/build
+          mkdir -p ./build/.metadata
+          echo ${{ github.event.number }} > ./build/.metadata/number
+          echo ${{ github.event.pull_request.head.sha }} > ./build/.metadata/commit
+          echo $( ls ./build/build/ | grep '.apk' ) > ./build/.metadata/apk_filename
+          echo $( ls ./build/build/ | grep '.zip' ) > ./build/.metadata/zip_filename
+          echo $(date -u +'%Y-%m-%d_%H-%M' -d"$(stat -c %y ./build/build/total-conversion-build.user.js)") > ./build/.metadata/buildstamp
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: |
+            ./build/.metadata/
+            ./build/build/

--- a/.github/workflows/upload_pr.yml
+++ b/.github/workflows/upload_pr.yml
@@ -1,0 +1,78 @@
+name: Upload PR
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: ["Build PR"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "build"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/build.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip build.zip
+
+      - name: Set env
+        run: |
+          echo "PR_NUMBER=$(cat ./.metadata/number)" >> "$GITHUB_ENV"
+          echo "COMMIT_HASH=$(cat ./.metadata/commit)" >> "$GITHUB_ENV"
+          echo "BUILD_APK_FILENAME=$(cat ./.metadata/apk_filename)" >> "$GITHUB_ENV"
+          echo "BUILD_ZIP_FILENAME=$(cat ./.metadata/zip_filename)" >> "$GITHUB_ENV"
+          echo "BUILDSTAMP=$(cat ./.metadata/buildstamp)" >> "$GITHUB_ENV"
+
+      - name: Push build artifacts to website
+        env:
+          WEBSITE_REPO: ${{ secrets.WEBSITE_REPO }}
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        if: ${{ env.WEBSITE_REPO != '' }}
+        uses: dmnemec/copy_file_to_another_repo_action@main
+        with:
+          source_file: "./build/."
+          destination_repo: ${{ secrets.WEBSITE_REPO }}
+          destination_branch: master
+          destination_folder: 'static/build/artifact/PR${{ env.PR_NUMBER }}/'
+          user_email: 'example@email.com'
+          user_name: 'IITC Updates'
+          commit_message: '🤖 New IITC test build from https://github.com/${{ github.repository }}/commit/${{ github.sha }}'
+
+      - name: Comment with build url
+        if: ${{ env.WEBSITE_REPO != '' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr_release
+          number: ${{ env.PR_NUMBER }}
+          message: |
+            ## 🤖 Pull request artifacts
+            | file | commit |
+            | ---- | ------ |
+            | [`${{ env.BUILD_APK_FILENAME }}`](https://github.com/${{ secrets.WEBSITE_REPO }}/raw/master/static/build/artifact/PR${{ env.PR_NUMBER }}/${{ env.BUILD_APK_FILENAME }}) | ${{ env.COMMIT_HASH }} |
+            | [`${{ env.BUILD_ZIP_FILENAME }}`](https://github.com/${{ secrets.WEBSITE_REPO }}/raw/master/static/build/artifact/PR${{ env.PR_NUMBER }}/${{ env.BUILD_ZIP_FILENAME }}) | ${{ env.COMMIT_HASH }} |
+            See build on website](https://iitc.app/build/artifact/PR${{ env.PR_NUMBER }}/)
+


### PR DESCRIPTION
PR builds are now run in a separate action, and artifacts are published in the context of the main repository to access repository secrets.

Thanks to @le-jeu for the example.