### PR TITLE
[IITCm] Fix back button doesn't work go back

### DIFF
--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -917,7 +917,9 @@ public class IITC_Mobile extends AppCompatActivity
     public void dialogOpened(final String id, final boolean open) {
         if (open) {
             Log.d("Dialog " + id + " added");
-            mDialogStack.push(id);
+	    if (!mDialogStack.contains(id)) {
+                mDialogStack.push(id);
+	    }
         } else {
             Log.d("Dialog " + id + " closed");
             mDialogStack.remove(id);


### PR DESCRIPTION
jQuery dialog events lead to dialog id being added twice. This ensures unicity in the android dialog stack.