### PR TITLE
Xm amount spacer and cell search fix 

### DIFF
--- a/core/code/sidebar.js
+++ b/core/code/sidebar.js
@@ -63,9 +63,9 @@ window.setupPlayerStat = function () {
 
 
   var t = 'Level:\t' + level + '\n'
-        + 'XM:\t' + PLAYER.energy + ' / ' + xmMax + '\n'
+        + 'XM:\t' + digits(PLAYER.energy) + ' / ' + digits(xmMax) + '\n'
         + 'AP:\t' + digits(ap) + '\n'
-        + (nextLvlAp > 0 ? 'level up in:\t' + lvlUpAp + ' AP' : 'Maximum level reached(!)')
+        + (nextLvlAp > 0 ? 'Level up in:\t' + lvlUpAp + ' AP' : 'Maximum level reached(!)')
         + '\nInvites:\t'+PLAYER.available_invites
         + '\n\nNote: your player stats can only be updated by a full reload (F5)';
 


### PR DESCRIPTION
Changes to agent stats:
XM spacers
Uppercase for text



Fixed search results:

on L6 cells search result are completely wrong in most cases

 for example "NR02-JULIET-12" returns NR02-JULIET-14 and etc.

Used part of code from 2015, src: https://github.com/IITC-CE/ingress-intel-total-conversion/blob/a98809ccd51c223735553faa6e4d09ac2d44718c/plugins/regions.user.js
