### PR TITLE
Expose cache.store() via window.portalDetail

### DIFF
--- a/core/code/portal_detail.js
+++ b/core/code/portal_detail.js
@@ -21,7 +21,7 @@ window.portalDetail.get = function(guid) {
   return cache.get(guid);
 }
 
-window.portalDetail.store = function(guid, dict, freshtime) {
+window.portalDetail.store = function (guid, dict, freshtime) {
   return cache.store(guid, dict, freshtime);
 };
 

--- a/core/code/portal_detail.js
+++ b/core/code/portal_detail.js
@@ -23,7 +23,7 @@ window.portalDetail.get = function(guid) {
 
 window.portalDetail.store = function(guid, dict, freshtime) {
   return cache.store(guid, dict, freshtime);
-}
+};
 
 window.portalDetail.isFresh = function(guid) {
   return cache.isFresh(guid);

--- a/core/code/portal_detail.js
+++ b/core/code/portal_detail.js
@@ -21,6 +21,10 @@ window.portalDetail.get = function(guid) {
   return cache.get(guid);
 }
 
+window.portalDetail.store = function(guid, dict, freshtime) {
+  return cache.store(guid, dict, freshtime);
+}
+
 window.portalDetail.isFresh = function(guid) {
   return cache.isFresh(guid);
 }


### PR DESCRIPTION
This introduces a new method that allows data to be written into the portalDetail cache.