### PR TITLE
Region-Score name search fix (closes #622)

### DIFF
--- a/plugins/external/s2geometry.js
+++ b/plugins/external/s2geometry.js
@@ -166,7 +166,7 @@ var IJToST = function(ij,order,offsets) {
 // note: rather then calculating the final integer hilbert position, we just return the list of quads
 // this ensures no precision issues whth large orders (S3 cell IDs use up to 30), and is more
 // convenient for pulling out the individual bits as needed later
-var pointToHilbertQuadList = function(x,y,order) {
+var pointToHilbertQuadList = function(face, x,y,order) {
   var hilbertMap = {
     'a': [ [0,'d'], [1,'a'], [3,'b'], [2,'a'] ],
     'b': [ [2,'b'], [1,'b'], [3,'a'], [0,'c'] ],
@@ -174,7 +174,7 @@ var pointToHilbertQuadList = function(x,y,order) {
     'd': [ [0,'a'], [3,'c'], [1,'d'], [2,'d'] ]  
   };
 
-  var currentSquare='a';
+  var currentSquare = face & 1 ? 'd' : 'a';
   var positions = [];
 
   for (var i=order-1; i>=0; i--) {
@@ -257,7 +257,7 @@ S2.S2Cell.prototype.getCornerLatLngs = function() {
 
 
 S2.S2Cell.prototype.getFaceAndQuads = function() {
-  var quads = pointToHilbertQuadList(this.ij[0], this.ij[1], this.level);
+  var quads = pointToHilbertQuadList(this.face, this.ij[0], this.ij[1], this.level);
 
   return [this.face,quads];
 };

--- a/plugins/external/s2geometry.js
+++ b/plugins/external/s2geometry.js
@@ -194,7 +194,34 @@ var pointToHilbertQuadList = function(face, x,y,order) {
   return positions;
 };
 
+  /**
+   * reverse of @see pointToHilbertQuadList
+   */
+  var hilbertQuadListToPoint = function (face, positions) {
+    const hilbertMapReverse = {
+      'a': [[0, 'd'], [1, 'a'], [3, 'a'], [2, 'b']],
+      'b': [[3, 'c'], [1, 'b'], [0, 'b'], [2, 'a']],
+      'c': [[3, 'b'], [2, 'c'], [0, 'c'], [1, 'd']],
+      'd': [[0, 'a'], [2, 'd'], [3, 'd'], [1, 'c']]
+    };
 
+    let currentSquare = face & 1 ? 'd' : 'a';
+    const level = positions.length;
+
+    let i = 0;
+    let j = 0;
+
+    positions.forEach(v => {
+      const t = hilbertMapReverse[currentSquare][v]
+      i <<= 1;
+      j <<= 1;
+      if (t[0] & 2) i |= 1;
+      if (t[0] & 1) j |= 1;
+      currentSquare = t[1];
+    });
+
+    return [i, j];
+  };
 
 
 // S2Cell class
@@ -223,6 +250,14 @@ S2.S2Cell.FromFaceIJ = function(face,ij,level) {
   return cell;
 };
 
+  /**
+     * Create cell by face and hilbertcurve position
+     * (this is like the original CellID construction)
+     */
+  S2.S2Cell.FromFacePosition = function (face, position) {
+    const ij = hilbertQuadListToPoint(face, position)
+    return S2.S2Cell.FromFaceIJ(face, ij, position.length);
+  };
 
 S2.S2Cell.prototype.toString = function() {
   return 'F'+this.face+'ij['+this.ij[0]+','+this.ij[1]+']@'+this.level;

--- a/plugins/regions.js
+++ b/plugins/regions.js
@@ -50,14 +50,7 @@ window.plugin.regions.CODE_WORDS = [
 window.plugin.regions.REGEXP = new RegExp('^(?:(?:(' + plugin.regions.FACE_NAMES.join('|') + ')-?)?((?:1[0-6])|(?:0?[1-9]))-?)?(' +
   plugin.regions.CODE_WORDS.join('|') + ')(?:-?((?:1[0-5])|(?:0?\\d)))?$', 'i');
 
-window.plugin.regions.regionName = function(cell) {
-  // ingress does some odd things with the naming. for some faces, the i and j coords are flipped when converting
-  // (and not only the names - but the full quad coords too!). easiest fix is to create a temporary cell with the coords
-  // swapped
-  if (cell.face == 1 || cell.face == 3 || cell.face == 5) {
-    cell = S2.S2Cell.FromFaceIJ ( cell.face, [cell.ij[1], cell.ij[0]], cell.level );
-  }
-
+window.plugin.regions.regionName = function (cell) {
   // first component of the name is the face
   var name = window.plugin.regions.FACE_NAMES[cell.face];
 
@@ -163,11 +156,7 @@ window.plugin.regions.getSearchResult = function(match) {
     regionJ = (regionJ << 2) + xy[1];
   }
 
-  // as in the name-construction above, for odd numbered faces, the I and J need swapping
-  var cell = (faceId % 2 == 1)
-    ? S2.S2Cell.FromFaceIJ(faceId, [regionJ,regionI], level)
-    : S2.S2Cell.FromFaceIJ(faceId, [regionI,regionJ], level);
-
+  var cell = S2.S2Cell.FromFaceIJ(faceId, [regionI, regionJ], level);
   var corners = cell.getCornerLatLngs();
 
   result.title = window.plugin.regions.regionName(cell);

--- a/plugins/regions.js
+++ b/plugins/regions.js
@@ -99,32 +99,7 @@ window.plugin.regions.search = function(query) {
   });
 }
 
-// rot and d2xy from Wikipedia
-window.plugin.regions.rot = function(n, x, y, rx, ry) {
-  if(ry == 0) {
-    if(rx == 1) {
-      x = n-1 - x;
-      y = n-1 - y;
-    }
-
-    return [y, x];
-  }
-  return [x, y];
-}
-window.plugin.regions.d2xy = function(n, d) {
-  var rx, ry, s, t = d, xy = [0, 0];
-  for(s=1; s<n; s*=2) {
-    rx = 1 & (t/2);
-    ry = 1 & (t ^ rx);
-    xy = window.plugin.regions.rot(s, xy[0], xy[1], rx, ry);
-    xy[0] += s * rx;
-    xy[1] += s * ry;
-    t /= 4;
-  }
-  return xy;
-}
-
-window.plugin.regions.getSearchResult = function(match) {
+window.plugin.regions.getSearchResult = function (match) {
   var faceId = window.plugin.regions.FACE_NAMES.indexOf(match[1]);
   var id1 = parseInt(match[2]);
   var codeWordId = window.plugin.regions.CODE_WORDS.indexOf(match[3]);
@@ -137,26 +112,22 @@ window.plugin.regions.getSearchResult = function(match) {
   // face is used as-is
 
   // id1 is the region 'i' value (first 4 bits), codeword is the 'j' value (first 4 bits)
-  var regionI = id1-1;
-  var regionJ = codeWordId;
+  var cell = S2.S2Cell.FromFaceIJ(faceId, [id1 - 1, codeWordId], 4);
 
-  var result = {}, level;
+  var result = {};
 
-  if(id2 === undefined) {
+  if (id2 === undefined) {
     result.description = 'Regional score cells (cluster of 16 cells)';
-    result.icon = 'data:image/svg+xml;base64,'+btoa('@include_string:images/icon-cell.svg@'.replace(/orange/, 'gold'));
-    level = 4;
+    result.icon = 'data:image/svg+xml;base64,' + btoa('@include_string:images/icon-cell.svg@'.replace(/orange/, 'gold'));
   } else {
     result.description = 'Regional score cell';
-    result.icon = 'data:image/svg+xml;base64,'+btoa('@include_string:images/icon-cell.svg@');
-    level = 6;
+    result.icon = 'data:image/svg+xml;base64,' + btoa('@include_string:images/icon-cell.svg@');
 
-    var xy = window.plugin.regions.d2xy(4, id2);
-    regionI = (regionI << 2) + xy[0];
-    regionJ = (regionJ << 2) + xy[1];
+    const [_, positions] = cell.getFaceAndQuads();
+    positions.push(Math.floor(id2 / 4), id2 % 4);
+    cell = S2.S2Cell.FromFacePosition(faceId, positions);
   }
 
-  var cell = S2.S2Cell.FromFaceIJ(faceId, [regionI, regionJ], level);
   var corners = cell.getCornerLatLngs();
 
   result.title = window.plugin.regions.regionName(cell);

--- a/plugins/regions.js
+++ b/plugins/regions.js
@@ -4,6 +4,8 @@
 // @version        0.2.1
 // @description    Show the regional scoring cells grid on the map
 
+/* global S2 */
+
 
 // use own namespace for plugin
 window.plugin.regions = function() {};
@@ -123,6 +125,7 @@ window.plugin.regions.getSearchResult = function (match) {
     result.description = 'Regional score cell';
     result.icon = 'data:image/svg+xml;base64,' + btoa('@include_string:images/icon-cell.svg@');
 
+    // eslint-disable-next-line no-unused-vars
     const [_, positions] = cell.getFaceAndQuads();
     positions.push(Math.floor(id2 / 4), id2 % 4);
     cell = S2.S2Cell.FromFacePosition(faceId, positions);


### PR DESCRIPTION
this includes 2 things in S2geomety + region-plugin:

- a fix in the hilbercurve calculation
Rotate the hilbercurve on some faces. (like the original google-lib does)
This way the 'workaround' in region-name generation is no longer needed

- fix region-search by enhance the cell-id ..
instead of the custom calculation which resulted in the wrong values