### PR TITLE
IITCm: Add plugin by URL

### DIFF
--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_FileManager.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_FileManager.java
@@ -284,7 +284,8 @@ public class IITC_FileManager {
                     final String url = uri.toString();
                     InputStream is;
                     String fileName;
-                    if (uri.getScheme().contains("http")) {
+                    final String uriScheme = uri.getScheme();
+                    if (uriScheme != null && uriScheme.contains("http")) {
                         final URLConnection conn = new URL(url).openConnection();
                         is = conn.getInputStream();
                         fileName = uri.getLastPathSegment();

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/prefs/PluginPreferenceActivity.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/prefs/PluginPreferenceActivity.java
@@ -1,7 +1,9 @@
 package org.exarhteam.iitc_mobile.prefs;
 
+import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
@@ -9,6 +11,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceActivity;
+import android.text.InputType;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -16,6 +19,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
+import android.widget.EditText;
 import android.widget.ListAdapter;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -155,6 +159,34 @@ public class PluginPreferenceActivity extends PreferenceActivity {
                     } catch (final ActivityNotFoundException e) {
                         Toast.makeText(this, getString(R.string.file_browser_is_required), Toast.LENGTH_LONG).show();
                     }
+                }
+            case R.id.menu_plugins_add_url:
+                if (mFileManager.checkWriteStoragePermissionGranted()) {
+                    final AlertDialog.Builder builder = new AlertDialog.Builder(this);
+                    builder.setTitle(R.string.menu_plugins_add_url);
+
+                    final EditText input = new EditText(this);
+                    input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_URI);
+                    builder.setView(input);
+
+                    builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() { 
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            final String url = input.getText().toString();
+                            final Uri uri = Uri.parse(url);
+                            if (uri != null) {
+                                mFileManager.installPlugin(uri, true);
+                            }
+                        }
+                    });
+                    builder.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            dialog.cancel();
+                        }
+                    });
+
+                    builder.show();
                 }
             default:
                 return super.onOptionsItemSelected(item);

--- a/mobile/app/src/main/res/menu/plugins.xml
+++ b/mobile/app/src/main/res/menu/plugins.xml
@@ -9,4 +9,11 @@
         app:showAsAction="ifRoom|collapseActionView"
         android:title="@string/menu_plugins_add"/>
 
+    <item
+        android:id="@+id/menu_plugins_add_url"
+        android:icon="@drawable/ic_action_web_site"
+        android:orderInCategory="10"
+        app:showAsAction="ifRoom|collapseActionView"
+        android:title="@string/menu_plugins_add_url"/>
+
 </menu>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -146,6 +146,7 @@
     <string name="menu_debug">Debug</string>
     <string name="menu_send_screenshot">Send screenshot</string>
     <string name="menu_plugins_add">Add external plugins</string>
+    <string name="menu_plugins_add_url">Add plugins by URL</string>
     <string name="menu_copy">Copy</string>
     <string name="menu_delete">Delete</string>
     <string name="choose_account_to_login">Choose account to login</string>


### PR DESCRIPTION
Since loading a plugin directly from its url doesn't work as it used to be, this PR adds the capability to do it by hand from the Plugin activity.