### PR TITLE
Portal list and count for weird chars

### DIFF
--- a/plugins/portal-counts.js
+++ b/plugins/portal-counts.js
@@ -244,7 +244,13 @@ window.plugin.portalcounts.makeBar = function(portals, text, color, shift) {
   }
 
   $('<text>')
-    .html(text.substring(0, 3))
+    .html(
+      text
+        .replaceAll(/[^a-z]/gi, '')
+        .substring(0, 3)
+        .toLowerCase()
+        .capitalize()
+    )
     .attr({
       x: self.BAR_WIDTH * 0.5,
       y: self.BAR_TOP * 0.75,

--- a/plugins/portals-list.css
+++ b/plugins/portals-list.css
@@ -93,7 +93,7 @@
 #portalslist .filters .filterNeu,
 #portalslist .filters .filterEnl,
 #portalslist .filters .filterRes,
-#portalslist .filters .filterUnk {
+#portalslist .filters .filterMac {
   grid-row: 1;
 }
 
@@ -112,14 +112,14 @@
   #portalslist .filters .filterNeu.name,
   #portalslist .filters .filterRes.name,
   #portalslist .filters .filterEnl.name,
-  #portalslist .filters .filterUnk.name {
+  #portalslist .filters .filterMac.name {
     grid-column: 1;
   }
 
   #portalslist .filters .filterNeu.count,
   #portalslist .filters .filterRes.count,
   #portalslist .filters .filterEnl.count,
-  #portalslist .filters .filterUnk.count {
+  #portalslist .filters .filterMac.count {
     grid-column: 2;
   }
 
@@ -150,7 +150,7 @@
     grid-row: 3;
   }
 
-  #portalslist .filters .filterUnk {
+  #portalslist .filters .filterMac {
     grid-row: 4;
   }
 }
@@ -199,7 +199,7 @@
 }
 
 #portalslist table tr.mac td,
-#portalslist .filters .filterUnk {
+#portalslist .filters .filterMac {
   background-color: #a00;
 }
 

--- a/plugins/portals-list.js
+++ b/plugins/portals-list.js
@@ -4,25 +4,16 @@
 // @version        0.4.1
 // @description    Display a sortable list of all visible portals with full details about the team, resonators, links, etc.
 
+// use own namespace for plugin
+window.plugin.portalslist = function() {};
+
+
 function abbreviate(label) {
   return label
     .replaceAll(/[^a-z]/gi, '')
     .substring(0, 3)
-    .toLowerCase()
     .capitalize();
 }
-// use own namespace for plugin
-window.plugin.portalslist = function() {};
-
-window.plugin.portalslist.FACTION_FILTERS = window.TEAM_NAMES;
-window.plugin.portalslist.FACTION_ABBREVS = window.plugin.portalslist.FACTION_FILTERS.map(abbreviate);
-window.plugin.portalslist.ALL_FACTION_FILTERS = ['All', ...window.plugin.portalslist.FACTION_FILTERS];
-window.plugin.portalslist.HISTORY_FILTERS = ['Visited', 'Captured', 'Scout Controlled'];
-window.plugin.portalslist.FILTERS = [...window.plugin.portalslist.ALL_FACTION_FILTERS, ...window.plugin.portalslist.HISTORY_FILTERS];
-
-window.plugin.portalslist.listPortals = [];
-window.plugin.portalslist.sortBy = 1; // second column: level
-window.plugin.portalslist.sortOrder = -1;
 
 function zeroCounts() {
   return window.plugin.portalslist.FILTERS.reduce((prev, curr) => {
@@ -30,9 +21,6 @@ function zeroCounts() {
     return prev;
   }, {});
 }
-window.plugin.portalslist.counts = zeroCounts();
-
-window.plugin.portalslist.filter = 0;
 
 /*
  * plugins may add fields by appending their specifiation to the following list. The following members are supported:
@@ -455,6 +443,18 @@ window.plugin.portalslist.onPaneChanged = function(pane) {
 };
 
 var setup =  function() {
+  window.plugin.portalslist.FACTION_FILTERS = window.TEAM_NAMES;
+  window.plugin.portalslist.FACTION_ABBREVS = window.plugin.portalslist.FACTION_FILTERS.map(abbreviate);
+  window.plugin.portalslist.ALL_FACTION_FILTERS = ['All', ...window.plugin.portalslist.FACTION_FILTERS];
+  window.plugin.portalslist.HISTORY_FILTERS = ['Visited', 'Captured', 'Scout Controlled'];
+  window.plugin.portalslist.FILTERS = [...window.plugin.portalslist.ALL_FACTION_FILTERS, ...window.plugin.portalslist.HISTORY_FILTERS];
+
+  window.plugin.portalslist.listPortals = [];
+  window.plugin.portalslist.sortBy = 1; // second column: level
+  window.plugin.portalslist.sortOrder = -1;
+  window.plugin.portalslist.counts = zeroCounts();
+  window.plugin.portalslist.filter = 0;
+
   if (window.useAppPanes()) {
     app.addPane("plugin-portalslist", "Portals list", "ic_action_paste");
     addHook("paneChanged", window.plugin.portalslist.onPaneChanged);


### PR DESCRIPTION
Portal count and portals list use abbreviations of team names which were either hardcoded, or contained only the weird characters. 
This PR uses team names defined in core and automaticaly abbreviates them.

![image](https://github.com/IITC-CE/ingress-intel-total-conversion/assets/9021449/b37c4289-12ce-4033-9821-57a03af2ff20)

Now we'll be able to change/add faction names and portals list and portal count plugins will follow nicely.