### PR TITLE
fixed range display for machina

### DIFF
--- a/core/code/portal_detail_display_tools.js
+++ b/core/code/portal_detail_display_tools.js
@@ -33,7 +33,7 @@ window.getRangeText = function(d) {
     '<a onclick="window.rangeLinkClick()"' +
       (range.isLinkable ? '' : ' style="text-decoration:line-through;"') +
       '>' +
-      (range.range > 1000 ? Math.floor(range.range / 100) / 10 + ' km' : Math.floor(range.range) + ' m') +
+      window.formatDistance(range.range) +
       '</a>',
     title,
   ];

--- a/core/code/portal_detail_display_tools.js
+++ b/core/code/portal_detail_display_tools.js
@@ -28,15 +28,15 @@ window.getRangeText = function(d) {
 
   if(!range.isLinkable) title += '\nPortal is missing resonators,\nno new links can be made';
 
-  return ['range',
-      '<a onclick="window.rangeLinkClick()"'
-    + (range.isLinkable ? '' : ' style="text-decoration:line-through;"')
-    + '>'
-    + (range.range > 1000
-      ? Math.floor(range.range/1000) + ' km'
-      : Math.floor(range.range)      + ' m')
-    + '</a>',
-    title];
+  return [
+    'range',
+    '<a onclick="window.rangeLinkClick()"' +
+      (range.isLinkable ? '' : ' style="text-decoration:line-through;"') +
+      '>' +
+      (range.range > 1000 ? Math.floor(range.range / 100) / 10 + ' km' : Math.floor(range.range) + ' m') +
+      '</a>',
+    title,
+  ];
 }
 
 

--- a/core/code/utils_misc.js
+++ b/core/code/utils_misc.js
@@ -104,6 +104,9 @@ window.formatInterval = function(seconds,maxTerms) {
   return terms.join(' ');
 }
 
+window.formatDistance = function (distance) {
+  return window.digits(distance > 10000 ? (distance / 1000).toFixed(2) + 'km' : Math.round(distance) + 'm');
+};
 
 window.rangeLinkClick = function() {
   if(window.portalRangeIndicator)

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -4,6 +4,8 @@
 // @version        0.4.2
 // @description    Save your favorite Maps and Portals and move the intel map with a click. Works with sync. Supports Multi-Project-Extension
 
+/* global L -- eslint */
+
 /* **********************************************************************
 
   HOOKS:
@@ -865,22 +867,20 @@ window.plugin.bookmarks.loadStorageBox = function() {
     var text = "You must select 2 or 3 portals!";
     var color = "red";
 
-    function formatDistance(distance) {
-      var text = digits(distance > 10000 ? (distance/1000).toFixed(2) + "km" : (Math.round(distance) + "m"));
-      return distance >= 200000
-        ? '<em title="Long distance link" class="help longdistance">'+text+'</em>'
-        : text;
-    }
+  function distanceElement(distance) {
+    var text = window.formatDistance(distance);
+    return distance >= 200000 ? '<em title="Long distance link" class="help longdistance">' + text + '</em>' : text;
+  }
 
     if(latlngs.length == 2) {
       var distance = L.latLng(latlngs[0]).distanceTo(latlngs[1]);
-      text = 'Distance between portals: ' + formatDistance(distance);
+    text = 'Distance between portals: ' + distanceElement(distance);
       color = "";
     } else if(latlngs.length == 3) {
       var longdistance = false;
       var distances = latlngs.map(function(ll1, i, latlngs) {
         var ll2 = latlngs[(i+1)%3];
-        return formatDistance(L.latLng(ll1).distanceTo(ll2));
+      return distanceElement(L.latLng(ll1).distanceTo(ll2));
       });
       text = 'Distances: ' + distances.join(", ");
       color = "";


### PR DESCRIPTION
Range display is now consistent with autodraw
Better precision for long links

display examples:
* links under 10000m (10km) - `160m`, `9 999m`
* links longer than 10km - `11.25km`, `6 881.28km`