### PR TITLE
Fix template error for homepage URL and TG channel replacement.

### DIFF
--- a/core/code/dialog_about.js
+++ b/core/code/dialog_about.js
@@ -17,8 +17,8 @@ function createDialogContent() {
               <div>Ingress Intel Total Conversion</div>
               <hr>
               <div>
-               <a href="@url_homepage@" target="_blank">IITC Homepage</a> |
-               <a href="@url_tg@" target="_blank">Telegram channel</a><br />
+               <a href="${'@url_homepage@'}" target="_blank">IITC Homepage</a> |
+               <a href="${'@url_tg@'}" target="_blank">Telegram channel</a><br />
                On the script’s homepage you can:
                <ul>
                  <li>Find Updates</li>


### PR DESCRIPTION
The previous code had a template string with the wrong type of quotes around the placeholder '@url_homepage@' and '@url_tg@', which caused issues with the templating engine. This commit addresses the problem by using the correct syntax with '${...}'