### PR TITLE
Revert "Alphabetical sorting of all plugin links under the portal details panel"

### DIFF
--- a/core/code/boot.js
+++ b/core/code/boot.js
@@ -205,29 +205,6 @@ function prepPluginsToLoad () {
   };
 }
 
-function setupToolboxSort() {
-  var toolboxElement = $('#toolbox')[0];
-
-  function sortToolbox() {
-    var children = Array.prototype.slice.call(toolboxElement.children);
-    var sortedChildren = children.slice().sort(function (x, y) {
-      return x.innerText.localeCompare(y.innerText);
-    });
-    if (
-      sortedChildren.some(function (item, index) {
-        return item !== children[index];
-      })
-    ) {
-      sortedChildren.forEach(function (child) {
-        toolboxElement.removeChild(child);
-        toolboxElement.appendChild(child);
-      });
-    }
-  }
-  sortToolbox();
-  window.observeDOMChildren(toolboxElement, sortToolbox);
-}
-
 function boot() {
   log.log('loading done, booting. Built: '+'@build_date@');
   if (window.deviceID) {
@@ -267,8 +244,6 @@ function boot() {
 
   window.iitcLoaded = true;
   window.runHooks('iitcLoaded');
-
-  setupToolboxSort();
 }
 
 try {

--- a/core/code/utils_misc.js
+++ b/core/code/utils_misc.js
@@ -427,22 +427,3 @@ if (!Element.prototype.closest) {
     return null;
   };
 }
-
-var MutObserver = window.MutationObserver || window.WebKitMutationObserver;
-window.observeDOMChildren = function (obj, callback) {
-  if (!obj || obj.nodeType !== 1) return;
-
-  if (MutObserver) {
-    // define a new observer
-    var mutationObserver = new MutObserver(callback);
-
-    // have the observer observe for changes in children
-    mutationObserver.observe(obj, { childList: true, subtree: true });
-    return mutationObserver;
-  }
-
-  // browser support fallback
-  else if (window.addEventListener) {
-    obj.addEventListener('DOMNodeInserted', callback, false);
-  }
-};

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -8,6 +8,10 @@
 window.script_info = plugin_info;
 window.script_info.changelog = [
   {
+    version: '0.36.1',
+    changes: ['Revert sorted sidebar links'],
+  },
+  {
     version: '0.36.0',
     changes: [
       'Ability to define and display changelog',


### PR DESCRIPTION
This reverts commit 747f876e (PR https://github.com/IITC-CE/ingress-intel-total-conversion/pull/653)

There was a conflict with some of the plugins. Let's improve the implementation, add a possibility to disable and bring back this feature