### PR TITLE
Update .prettierrc.json

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,6 @@
   "trailingComma": "es5",
   "tabWidth": 2,
   "semi": true,
-  "singleQuote": true
+  "singleQuote": true,
+  "endOfLine": "auto"
 }

--- a/EOL-Test-File.js
+++ b/EOL-Test-File.js
@@ -1,4 +1,0 @@
-// This is just a test file for EoL
-function test() {
-
-}

--- a/EOL-Test-File.js
+++ b/EOL-Test-File.js
@@ -1,0 +1,4 @@
+// This is just a test file for EoL
+function test() {
+
+}


### PR DESCRIPTION
GIT converts LineEndings to the locally used standard while downloading.
In windows this is CRLF.
Editors that suport linters/prettier complain about that for each line as the default for Prettier is LF.
by adding `"endOfLine": "auto"` to prettierrc.json, prettier will accept the OS's default.

Please check if the setting causes any problems in your environment (it should not, but maybe you tweaked all your windows tools to work with LF too?)

(Please avoid discussions on IDEs/Windows/Linux/LF/CRFL.)