### PR TITLE
Fix: player tracker reports wrong player team and/or wrong location

### DIFF
--- a/core/code/chat.js
+++ b/core/code/chat.js
@@ -371,16 +371,19 @@ window.chat.parseMsgData = function (data) {
 
   var markup = data[2].plext.markup;
 
-  var nick = '';
+  var player = {
+    name: '',
+    team: team,
+  };
   markup.forEach(function(ent) {
     switch (ent[0]) {
       case 'SENDER': // user generated messages
-        nick = ent[1].plain.replace(/: $/, ''); // cut “: ” at end
+        player.name = ent[1].plain.replace(/: $/, ''); // cut “: ” at end
         break;
 
       case 'PLAYER': // automatically generated messages
-        nick = ent[1].plain;
-        team = window.teamStringToId(ent[1].team);
+        player.name = ent[1].plain;
+        player.team = window.teamStringToId(ent[1].team);
         break;
 
       default:
@@ -398,10 +401,8 @@ window.chat.parseMsgData = function (data) {
     type: data[2].plext.plextType,
     narrowcast: systemNarrowcast,
     auto: auto,
-    player: {
-      name: nick,
-      team: team,
-    },
+    team: team,
+    player: player,
     markup: markup,
   };
 };

--- a/plugins/player-activity-tracker.js
+++ b/plugins/player-activity-tracker.js
@@ -153,6 +153,8 @@ window.plugin.playerTracker.processNewData = function(data) {
         // portal the player is at, so ignore it.
         if(markup[1].plain.indexOf('destroyed the Link') !== -1
           || markup[1].plain.indexOf('destroyed a Control Field') !== -1
+          // COMM messages changed a bit, keep old rules ↑ in case of rollback
+          || markup[1].plain.indexOf('destroyed the') !== -1
           || markup[1].plain.indexOf('Your Link') !== -1) {
           skipThisMessage = true;
           return false;

--- a/plugins/player-activity-tracker.js
+++ b/plugins/player-activity-tracker.js
@@ -186,7 +186,7 @@ window.plugin.playerTracker.processNewData = function(data) {
     });
 
     // skip unusable events
-    if (!plrname || !lat || !lng || !id || skipThisMessage || ![window.TEAM_RES, window.TEAM_ENL].includes(plrteam)) {
+    if (!plrname || !lat || !lng || !id || skipThisMessage || ![window.TEAM_RES, window.TEAM_ENL].includes(window.teamStringToId(plrteam))) {
       return true;
     }
 

--- a/plugins/player-activity-tracker.js
+++ b/plugins/player-activity-tracker.js
@@ -153,23 +153,25 @@ window.plugin.playerTracker.processNewData = function(data) {
     var skipThisMessage = false;
     $.each(json[2].plext.markup, function(ind, markup) {
       switch(markup[0]) {
-      case 'TEXT':
-        // Destroy link and field messages depend on where the link or
-        // field was originally created. Therefore it’s not clear which
-        // portal the player is at, so ignore it.
-        if(markup[1].plain.indexOf('destroyed the Link') !== -1
-          || markup[1].plain.indexOf('destroyed a Control Field') !== -1
-          // COMM messages changed a bit, keep old rules ↑ in case of rollback
-          || markup[1].plain.indexOf('destroyed the') !== -1
-          || markup[1].plain.indexOf('Your Link') !== -1) {
-          skipThisMessage = true;
-          return false;
-        }
-        break;
-      case 'PLAYER':
-        plrname = markup[1].plain;
-        plrteam = markup[1].team;
-        break;
+        case 'TEXT':
+          // Destroy link and field messages depend on where the link or
+          // field was originally created. Therefore it’s not clear which
+          // portal the player is at, so ignore it.
+          if (
+            markup[1].plain.indexOf('destroyed the Link') !== -1 ||
+            markup[1].plain.indexOf('destroyed a Control Field') !== -1 ||
+            // COMM messages changed a bit, keep old rules ↑ in case of rollback
+            markup[1].plain.indexOf('destroyed the') !== -1 ||
+            markup[1].plain.indexOf('Your Link') !== -1
+          ) {
+            skipThisMessage = true;
+            return false;
+          }
+          break;
+        case 'PLAYER':
+          plrname = markup[1].plain;
+          plrteam = markup[1].team;
+          break;
       case 'PORTAL':
         // link messages are “player linked X to Y” and the player is at
         // X.

--- a/plugins/player-activity-tracker.js
+++ b/plugins/player-activity-tracker.js
@@ -143,7 +143,13 @@ window.plugin.playerTracker.processNewData = function(data) {
     if(json[1] < limit) return true;
 
     // find player and portal information
-    var plrname, lat, lng, id=null, name, address;
+    var plrname,
+      plrteam,
+      lat,
+      lng,
+      id = null,
+      name,
+      address;
     var skipThisMessage = false;
     $.each(json[2].plext.markup, function(ind, markup) {
       switch(markup[0]) {
@@ -162,6 +168,7 @@ window.plugin.playerTracker.processNewData = function(data) {
         break;
       case 'PLAYER':
         plrname = markup[1].plain;
+        plrteam = markup[1].team;
         break;
       case 'PORTAL':
         // link messages are “player linked X to Y” and the player is at
@@ -179,7 +186,7 @@ window.plugin.playerTracker.processNewData = function(data) {
     });
 
     // skip unusable events
-    if (!plrname || !lat || !lng || !id || skipThisMessage || ![window.TEAM_RES, window.TEAM_ENL].includes(window.teamStringToId(json[2].plext.team))) {
+    if (!plrname || !lat || !lng || !id || skipThisMessage || ![window.TEAM_RES, window.TEAM_ENL].includes(plrteam)) {
       return true;
     }
 
@@ -197,7 +204,7 @@ window.plugin.playerTracker.processNewData = function(data) {
     if(!playerData || playerData.events.length === 0) {
       plugin.playerTracker.stored[plrname] = {
         nick: plrname,
-        team: json[2].plext.team,
+        team: plrteam,
         events: [newEvent]
       };
       return true;


### PR DESCRIPTION
Following recent changes in the COMM data, the player activity tracker no longer ignore destroyed link/field messages, therefor players may be displayed at wrong locations. 

This is due to comm message having reporting inconsistent data.
Each log message has a `team` field, and each player tag in a message has a `team` field too.
Usually, the message `team` is the same as the player `team`, but it differs on destroyed link message (at least). It looks like the link `team` is used instead.

The PR uses the player `team` instead of the message `team` to determine the faction of a player.

```json
[
    "f58d75500e1f4ae099912d6664f26066.d",
    1697053409760,
    {
      "plext": {
        "text": "Agent jorodfr destroyed the Enlightened Link Colonne Publi (2 Avenue de la Porte Chaumont, 75019 Paris, France) to Stade Marcel Cerdan (170 Avenue Jean Jaurès, 93500 Pantin, France)",
        "team": "ENLIGHTENED",
        "markup": [
          [
            "TEXT",
            {
              "plain": "Agent "
            }
          ],
          [
            "PLAYER",
            {
              "plain": "jorodfr",
              "team": "RESISTANCE"
            }
          ],
         ...
 ```