### PR TITLE
Disabling translations for the debug info dialog

### DIFF
--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -277,7 +277,7 @@
     <string name="ok">OK</string>
     <string name="pref_enabled">enabled</string>
     <string name="pref_disabled">disabled</string>
-    <string name="debug_info_dialog_text">
+    <string name="debug_info_dialog_text" translatable="false">
         <![CDATA[
         <b>Manufacturer:</b> %s<br/>
         <b>Model:</b> %s<br/>


### PR DESCRIPTION
Translations are disabled in the debug info dialog to preserve the English language for clarity and ease of understanding for developers who may need the information in this dialog