### PR TITLE
Proxy for chat and COMM API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,12 @@
 {
     "env": {
         "browser": true,
-        "es6": true,
+        "es2024": true,
         "jquery": true,
         "greasemonkey": true
+    },
+    "parserOptions": {
+        "sourceType": "module"
     },
     "extends": [
         "eslint:recommended",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Tests
+'on':
+  push:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  test:
+    name: 'Node.js v18'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '18'
+      - name: 'Cache node_modules'
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-18-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-18-
+      - name: Install Dependencies
+        run: npm install
+      - name: Run All Node.js Tests
+        run: npm run test

--- a/core/code/chat.js
+++ b/core/code/chat.js
@@ -1,7 +1,7 @@
 /**
  * @file Namespace for chat-related functionalities.
  *
- * @namespace chat
+ * @module chat
  */
 var chat = function () {};
 window.chat = chat;
@@ -85,7 +85,7 @@ window.chat = new Proxy(window.chat, {
 /**
  * Adds a nickname to the chat input.
  *
- * @function chat.addNickname
+ * @function addNickname
  * @param {string} nick - The nickname to add.
  */
 chat.addNickname = function (nick) {
@@ -97,7 +97,7 @@ chat.addNickname = function (nick) {
 /**
  * Handles click events on nicknames in the chat.
  *
- * @function chat.nicknameClicked
+ * @function nicknameClicked
  * @param {Event} event - The click event.
  * @param {string} nickname - The clicked nickname.
  * @returns {boolean} Always returns false.
@@ -131,31 +131,31 @@ chat.nicknameClicked = function (event, nickname) {
  * Hold channel description
  *
  * See comm.js for examples
- * @typedef {Object} chat.ChannelDescription
+ * @typedef {Object} ChannelDescription
  * @property {string} id - uniq id, matches 'tab' parameter for server requests
  * @property {string} name - visible name
  * @property {string} [inputPrompt] - (optional) string for the input prompt
  * @property {string} [inputClass] - (optional) class to apply to #chatinput
- * @property {chat.ChannelSendMessageFn} [sendMessage] - (optional) function to send the message
- * @property {chat.ChannelRequestFn} [request] - (optional) function to call to request new message
- * @property {chat.ChannelRenderFn} [render] - (optional) function to render channel content,, called on tab change
+ * @property {ChannelSendMessageFn} [sendMessage] - (optional) function to send the message
+ * @property {ChannelRequestFn} [request] - (optional) function to call to request new message
+ * @property {ChannelRenderFn} [render] - (optional) function to render channel content,, called on tab change
  * @property {boolean} [localBounds] - (optional) if true, reset on view change
  */
 /**
- * @callback chat.ChannelSendMessageFn
+ * @callback ChannelSendMessageFn
  * @param {string} id - channel id
  * @param {string} message - input message
  * @returns {void}
  */
 /**
- * @callback chat.ChannelRequestFn
+ * @callback ChannelRequestFn
  * @param {string} id - channel id
  * @param {boolean} getOlderMsgs - true if request data from a scroll to top
  * @param {boolean} isRetry
  * @returns {void}
  */
 /**
- * @callback chat.ChannelRenderFn
+ * @callback ChannelRenderFn
  * @param {string} id - channel id
  * @param {boolean} oldMsgsWereAdded - true if data has been added at the top (to preserve scroll position)
  * @returns {void}
@@ -164,14 +164,15 @@ chat.nicknameClicked = function (event, nickname) {
 /**
  * Holds channels infos.
  *
- * @type {chat.ChannelDescription[]}
+ * @type {ChannelDescription[]}
+ * @memberof module:chat
  */
 chat.channels = [];
 
 /**
  * Gets the name of the active chat tab.
  *
- * @function chat.getActive
+ * @function getActive
  * @returns {string} The name of the active chat tab.
  */
 chat.getActive = function () {
@@ -181,9 +182,9 @@ chat.getActive = function () {
 /**
  * Converts a chat tab name to its corresponding channel object.
  *
- * @function chat.getChannelDesc
+ * @function getChannelDesc
  * @param {string} tab - The name of the chat tab.
- * @returns {chat.ChannelDescription} The corresponding channel name ('faction', 'alerts', or 'all').
+ * @returns {ChannelDescription} The corresponding channel name ('faction', 'alerts', or 'all').
  */
 chat.getChannelDesc = function (tab) {
   var channelObject = null;
@@ -198,7 +199,7 @@ chat.getChannelDesc = function (tab) {
  * that need to process COMM data even when the user is not actively viewing the COMM channels.
  * It tracks the requested channels for each plugin instance and updates the global state accordingly.
  *
- * @function chat.backgroundChannelData
+ * @function backgroundChannelData
  * @param {string} instance - A unique identifier for the plugin or instance requesting background COMM data.
  * @param {string} channel - The name of the COMM channel ('all', 'faction', or 'alerts').
  * @param {boolean} flag - Set to true to request data for the specified channel, false to stop requesting.
@@ -226,7 +227,7 @@ chat.backgroundChannelData = function (instance, channel, flag) {
  * Requests chat messages for the currently active chat tab and background channels.
  * It calls the appropriate request function based on the active tab or background channels.
  *
- * @function chat.request
+ * @function request
  */
 chat.request = function () {
   var channel = chat.getActive();
@@ -241,7 +242,7 @@ chat.request = function () {
  * Checks if the currently selected chat tab needs more messages.
  * This function is triggered by scroll events and loads older messages when the user scrolls to the top.
  *
- * @function chat.needMoreMessages
+ * @function needMoreMessages
  */
 chat.needMoreMessages = function () {
   var activeTab = chat.getActive();
@@ -262,7 +263,7 @@ chat.needMoreMessages = function () {
  * Chooses and activates a specified chat tab.
  * Also triggers an early refresh of the chat data when switching tabs.
  *
- * @function chat.chooseTab
+ * @function chooseTab
  * @param {string} tab - The name of the chat tab to activate ('all', 'faction', or 'alerts').
  */
 chat.chooseTab = function (tab) {
@@ -318,7 +319,7 @@ chat.chooseTab = function (tab) {
  * When expanded, the chat window covers a larger area of the screen.
  * This function also ensures that the chat is scrolled to the bottom when collapsed.
  *
- * @function chat.toggle
+ * @function toggle
  */
 chat.toggle = function () {
   var c = $('#chat, #chatcontrols');
@@ -338,7 +339,7 @@ chat.toggle = function () {
 /**
  * Displays the chat interface and activates a specified chat tab.
  *
- * @function chat.show
+ * @function show
  * @param {string} name - The name of the chat tab to show and activate.
  */
 chat.show = function (name) {
@@ -357,7 +358,7 @@ chat.show = function (name) {
  * This function is triggered by a click event on the chat tab. It reads the tab name from the event target
  * and activates the corresponding chat tab.
  *
- * @function chat.chooser
+ * @function chooser
  * @param {Event} event - The event triggered by clicking a chat tab.
  */
 chat.chooser = function (event) {
@@ -371,7 +372,7 @@ chat.chooser = function (event) {
  * This function is designed to keep the scroll position fixed when old messages are loaded, and to automatically scroll
  * to the bottom when new messages are added if the user is already at the bottom of the chat.
  *
- * @function chat.keepScrollPosition
+ * @function keepScrollPosition
  * @param {jQuery} box - The jQuery object of the chat box.
  * @param {number} scrollBefore - The scroll position before new messages were added.
  * @param {boolean} isOldMsgs - Indicates if the added messages are older messages.
@@ -399,7 +400,7 @@ chat.keepScrollPosition = function (box, scrollBefore, isOldMsgs) {
  *
  * @function createChannelTab
  * @memberof chat
- * @param {chat.ChannelDescription} channelDesc - channel description
+ * @param {ChannelDescription} channelDesc - channel description
  * @static
  */
 function createChannelTab(channelDesc) {
@@ -434,8 +435,8 @@ var isTabsSetup = false;
  *
  * If tabs are already created, a tab is created for this channel as well
  *
- * @function chat.addChannel
- * @param {chat.ChannelDescription} channelDesc - channel description
+ * @function addChannel
+ * @param {ChannelDescription} channelDesc - channel description
  */
 chat.addChannel = function (channelDesc) {
   // deny reserved name
@@ -463,8 +464,8 @@ chat.addChannel = function (channelDesc) {
 /**
  * Sets up all channels starting from intel COMM
  *
- * @function chat.setupTabs
- * @param {chat.ChannelDescription} channelDesc - channel description
+ * @function setupTabs
+ * @param {ChannelDescription} channelDesc - channel description
  */
 chat.setupTabs = function () {
   isTabsSetup = true;
@@ -485,7 +486,7 @@ chat.setupTabs = function () {
   /**
    * Initiates a request for public chat data.
    *
-   * @function chat.requestPublic
+   * @function requestPublic
    * @param {boolean} getOlderMsgs - Whether to retrieve older messages.
    * @param {boolean} [isRetry=false] - Whether the request is a retry.
    */
@@ -496,7 +497,7 @@ chat.setupTabs = function () {
   /**
    * Requests faction chat messages.
    *
-   * @function chat.requestFaction
+   * @function requestFaction
    * @param {boolean} getOlderMsgs - Flag to determine if older messages are being requested.
    * @param {boolean} [isRetry=false] - Flag to indicate if this is a retry attempt.
    */
@@ -507,7 +508,7 @@ chat.setupTabs = function () {
   /**
    * Initiates a request for alerts chat data.
    *
-   * @function chat.requestAlerts
+   * @function requestAlerts
    * @param {boolean} getOlderMsgs - Whether to retrieve older messages.
    * @param {boolean} [isRetry=false] - Whether the request is a retry.
    */
@@ -518,7 +519,7 @@ chat.setupTabs = function () {
   /**
    * Renders public chat in the UI.
    *
-   * @function chat.renderPublic
+   * @function renderPublic
    * @param {boolean} oldMsgsWereAdded - Indicates if older messages were added to the chat.
    */
   chat.renderPublic = function (oldMsgsWereAdded) {
@@ -528,7 +529,7 @@ chat.setupTabs = function () {
   /**
    * Renders faction chat.
    *
-   * @function chat.renderFaction
+   * @function renderFaction
    * @param {boolean} oldMsgsWereAdded - Indicates if old messages were added in the current rendering.
    */
   chat.renderFaction = function (oldMsgsWereAdded) {
@@ -538,7 +539,7 @@ chat.setupTabs = function () {
   /**
    * Renders alerts chat in the UI.
    *
-   * @function chat.renderAlerts
+   * @function renderAlerts
    * @param {boolean} oldMsgsWereAdded - Indicates if older messages were added to the chat.
    */
   chat.renderAlerts = function (oldMsgsWereAdded) {
@@ -549,7 +550,7 @@ chat.setupTabs = function () {
 /**
  * Sets up the chat interface.
  *
- * @function chat.setup
+ * @function setup
  */
 chat.setup = function () {
   chat.setupTabs();
@@ -583,7 +584,7 @@ chat.setup = function () {
  * Sets up the time display in the chat input box.
  * This function updates the time displayed next to the chat input field every minute to reflect the current time.
  *
- * @function chat.setupTime
+ * @function setupTime
  */
 chat.setupTime = function () {
   var inputTime = $('#chatinput time');
@@ -609,7 +610,7 @@ chat.setupTime = function () {
 /**
  * Handles tab completion in chat input.
  *
- * @function chat.handleTabCompletion
+ * @function handleTabCompletion
  */
 chat.handleTabCompletion = function () {
   var el = $('#chatinput input');
@@ -650,7 +651,7 @@ chat.handleTabCompletion = function () {
 /**
  * Posts a chat message to the currently active chat tab.
  *
- * @function chat.postMsg
+ * @function postMsg
  */
 chat.postMsg = function () {
   var c = chat.getActive();
@@ -668,7 +669,7 @@ chat.postMsg = function () {
 /**
  * Sets up the chat message posting functionality.
  *
- * @function chat.setupPosting
+ * @function setupPosting
  */
 chat.setupPosting = function () {
   if (!window.isSmartphone()) {
@@ -701,7 +702,7 @@ chat.setupPosting = function () {
  * Legacy function for rendering chat messages. Used for backward compatibility with plugins.
  *
  * @deprecated
- * @function window.chat.renderMsg
+ * @function renderMsg
  * @param {string} msg - The chat message.
  * @param {string} nick - The nickname of the player who sent the message.
  * @param {number} time - The timestamp of the message.
@@ -741,7 +742,7 @@ chat.renderMsg = function (msg, nick, time, team, msgToPlayer, systemNarrowcast)
  * Used for backward compatibility with plugins.
  *
  * @deprecated
- * @function window.chat.tabToChannel
+ * @function tabToChannel
  * @param {string} tab - The name of the chat tab.
  * @returns {string} The corresponding channel name ('faction', 'alerts', or 'all').
  */

--- a/core/code/comm.js
+++ b/core/code/comm.js
@@ -107,6 +107,16 @@ let msgRowTemplate = '<tr data-guid="{{ guid }}" class="{{ class_names }}">{{ ti
 let dividerTemplate = '<tr class="divider"><td><hr></td><td>{{ text }}</td><td><hr></td></tr>';
 
 /**
+ * Returns the coordinates for the message to be sent, default is the center of the map.
+ *
+ * @function IITC.comm.getLatLngForSendingMessage
+ * @returns {L.LatLng}
+ */
+function getLatLngForSendingMessage() {
+  return map.getCenter();
+}
+
+/**
  * Updates the oldest and newest message timestamps and GUIDs in the chat storage.
  *
  * @function IITC.comm._updateOldNewHash
@@ -246,7 +256,7 @@ function _writeDataToHash(newData, storageHash, isOlderMsgs, isAscendingOrder) {
 function sendChatMessage(tab, msg) {
   if (tab !== 'all' && tab !== 'faction') return;
 
-  var latlng = map.getCenter();
+  const latlng = IITC.comm.getLatLngForSendingMessage();
 
   var data = {
     message: msg,
@@ -879,6 +889,7 @@ IITC.comm = {
   channels: _channels,
   sendChatMessage,
   parseMsgData,
+  getLatLngForSendingMessage,
   // List of transformations
   portalNameTransformations,
   messageTransformFunctions,

--- a/core/code/comm.js
+++ b/core/code/comm.js
@@ -74,7 +74,8 @@ function _initChannelData(id) {
  * @type {String}
  * @memberof IITC.comm
  */
-let portalTemplate = '<a onclick="window.selectPortalByLatLng({{ lat }}, {{ lng }});return false" title="{{ title }}" href="{{ url }}" class="help">{{ portal_name }}</a>';
+let portalTemplate =
+  '<a onclick="window.selectPortalByLatLng({{ lat }}, {{ lng }});return false" title="{{ title }}" href="{{ url }}" class="help">{{ portal_name }}</a>';
 /**
  * Template for time cell.
  * @type {String}
@@ -519,7 +520,7 @@ function getChatPortalName(markup) {
   // Use reduce to apply each transformation to the data
   const transformedData = portalNameTransformations.reduce((initialMarkup, transform) => {
     const updatedName = transform(initialMarkup);
-    return {...initialMarkup, name: updatedName};
+    return { ...initialMarkup, name: updatedName };
   }, markup);
 
   return transformedData.name;
@@ -539,11 +540,11 @@ function renderPortal(portal) {
   const portalName = IITC.comm.getChatPortalName(portal);
 
   return IITC.comm.portalTemplate
-    .replace("{{ lat }}", lat.toString())
-    .replace("{{ lng }}", lng.toString())
-    .replace("{{ title }}", portal.address)
-    .replace("{{ url }}", permalink)
-    .replace("{{ portal_name }}", portalName);
+    .replace('{{ lat }}', lat.toString())
+    .replace('{{ lng }}', lng.toString())
+    .replace('{{ title }}', portal.address)
+    .replace('{{ url }}', permalink)
+    .replace('{{ portal_name }}', portalName);
 }
 
 /**
@@ -712,7 +713,7 @@ const transformMessage = (data) => {
   // Use reduce to apply each transformation to the data
   const transformedData = messageTransformFunctions.reduce((data, transform) => {
     const updatedMarkup = transform(data);
-    return {...data, markup: updatedMarkup};
+    return { ...data, markup: updatedMarkup };
   }, initialData);
 
   return transformedData.markup;
@@ -731,14 +732,17 @@ function renderTimeCell(unixtime, classNames) {
   const time = window.unixTimeToHHmm(unixtime);
   const datetime = window.unixTimeToDateTimeString(unixtime, true);
   // add <small> tags around the milliseconds
-  const datetime_title = (datetime.slice(0, 19) + '<small class="milliseconds">' + datetime.slice(19) + '</small>').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  const datetime_title = (datetime.slice(0, 19) + '<small class="milliseconds">' + datetime.slice(19) + '</small>')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
 
   return IITC.comm.timeCellTemplate
-    .replace("{{ class_names }}", classNames)
-    .replace("{{ datetime }}", datetime)
-    .replace("{{ time_title }}", datetime_title)
-    .replace("{{ unixtime }}", unixtime.toString())
-    .replace("{{ time }}", time);
+    .replace('{{ class_names }}', classNames)
+    .replace('{{ datetime }}', datetime)
+    .replace('{{ time_title }}', datetime_title)
+    .replace('{{ unixtime }}', unixtime.toString())
+    .replace('{{ time }}', time);
 }
 
 /**
@@ -751,7 +755,7 @@ function renderTimeCell(unixtime, classNames) {
  * @returns {string} The HTML string representing a table cell with the player's nickname.
  */
 function renderNickCell(nick, classNames) {
-  return IITC.comm.nickCellTemplate.replace("{{ class_names }}", classNames).replace("{{ nick }}", nick);
+  return IITC.comm.nickCellTemplate.replace('{{ class_names }}', classNames).replace('{{ nick }}', nick);
 }
 
 /**
@@ -764,7 +768,7 @@ function renderNickCell(nick, classNames) {
  * @returns {string} The HTML string representing a table cell with the chat message.
  */
 function renderMsgCell(msg, classNames) {
-  return IITC.comm.msgCellTemplate.replace("{{ class_names }}", classNames).replace("{{ msg }}", msg);
+  return IITC.comm.msgCellTemplate.replace('{{ class_names }}', classNames).replace('{{ msg }}', msg);
 }
 
 /**
@@ -802,11 +806,11 @@ function renderMsgRow(data) {
   }
 
   return IITC.comm.msgRowTemplate
-    .replace("{{ class_names }}", className)
-    .replace("{{ guid }}", data.guid)
-    .replace("{{ time_cell }}", timeCell)
-    .replace("{{ nick_cell }}", nickCell)
-    .replace("{{ msg_cell }}", msgCell)
+    .replace('{{ class_names }}', className)
+    .replace('{{ guid }}', data.guid)
+    .replace('{{ time_cell }}', timeCell)
+    .replace('{{ nick_cell }}', nickCell)
+    .replace('{{ msg_cell }}', msgCell);
 }
 
 /**
@@ -817,7 +821,7 @@ function renderMsgRow(data) {
  * @returns {string} The HTML string representing a divider row in the chat table.
  */
 function renderDivider(text) {
-  return IITC.comm.dividerTemplate.replace("{{ text }}", text);
+  return IITC.comm.dividerTemplate.replace('{{ text }}', text);
 }
 
 /**

--- a/core/code/comm.js
+++ b/core/code/comm.js
@@ -435,19 +435,45 @@ function renderText(text) {
 }
 
 /**
+ * List of transformations for portal names used in chat.
+ * Each transformation function takes the portal markup object and returns a transformed name.
+ * If a transformation does not apply, the original name is returned.
+ *
+ * @const IITC.comm.portalNameTransformations
+ * @example
+ * // Adding a transformation that appends the portal location to its name
+ * portalNameTransformations.push((markup) => {
+ *   const latlng = `${markup.latE6 / 1E6},${markup.lngE6 / 1E6}`; // Convert E6 format to decimal
+ *   return `[${latlng}] ${markup.name}`;
+ * });
+ */
+const portalNameTransformations = [
+  // Transformation for 'US Post Office'
+  (markup) => {
+    if (markup.name === 'US Post Office') {
+      const address = markup.address.split(',');
+      return 'USPS: ' + address[0];
+    }
+    return markup.name;
+  },
+];
+
+/**
  * Overrides portal names used repeatedly in chat, such as 'US Post Office', with more specific names.
+ * Applies a series of transformations to the portal name based on the portal markup.
  *
  * @function IITC.comm.getChatPortalName
  * @param {Object} markup - An object containing portal markup, including the name and address.
  * @returns {string} The processed portal name.
  */
 function getChatPortalName(markup) {
-  var name = markup.name;
-  if (name === 'US Post Office') {
-    var address = markup.address.split(',');
-    name = 'USPS: ' + address[0];
-  }
-  return name;
+  // Use reduce to apply each transformation to the data
+  const transformedData = portalNameTransformations.reduce((initialMarkup, transform) => {
+    const updatedName = transform(initialMarkup);
+    return {...initialMarkup, name: updatedName};
+  }, markup);
+
+  return transformedData.name;
 }
 
 /**
@@ -761,6 +787,8 @@ IITC.comm = {
   channels: _channels,
   sendChatMessage,
   parseMsgData,
+  // List of transformations
+  portalNameTransformations,
   // Render primitive, may be override
   renderMsgRow,
   renderDivider,

--- a/core/code/comm.js
+++ b/core/code/comm.js
@@ -239,11 +239,15 @@ var _oldBBox = null;
  * @private
  * @param {string} channel - The chat channel.
  * @param {boolean} getOlderMsgs - Flag to determine if older messages are being requested.
+ * @param args=undefined - Used for backward compatibility when calling a function with three arguments.
  * @returns {Object} The generated post data.
  */
-function _genPostData(channel, getOlderMsgs) {
+function _genPostData(channel, getOlderMsgs, ...args) {
   if (typeof channel !== 'string') {
     throw new Error('API changed: isFaction flag now a channel string - all, faction, alerts');
+  }
+  if (args.length === 1) {
+    getOlderMsgs = args[0];
   }
 
   var b = window.clampLatLngBounds(map.getBounds());
@@ -776,6 +780,9 @@ IITC.comm = {
   renderChannel,
   renderData,
   _channelsData,
+  _genPostData,
+  _updateOldNewHash,
+  _writeDataToHash,
 };
 
 /* global log, map, chat, IITC */

--- a/core/code/comm.js
+++ b/core/code/comm.js
@@ -789,6 +789,7 @@ function renderData(data, element, likelyWereOldMsgs, sortedGuids) {
   var prevTime = null;
   vals.forEach(function (guid) {
     var msg = data[guid];
+    if (IITC.comm.declarativeMessageFilter.filterMessage(msg[4])) return;
     var nextTime = new Date(msg[0]).toLocaleDateString();
     if (prevTime && prevTime !== nextTime) {
       msgs += IITC.comm.renderDivider(nextTime);

--- a/core/code/comm_declarative_message_filter.js
+++ b/core/code/comm_declarative_message_filter.js
@@ -1,0 +1,150 @@
+/* global IITC */
+
+/**
+ * Declarative message filter for COMM API
+ *
+ * @memberof IITC.comm
+ * @namespace declarativeMessageFilter
+ */
+
+IITC.comm.declarativeMessageFilter = {
+  _rules: {},
+
+  /**
+   * Adds a new filtering rule with a given ID.
+   *
+   * @param {string} id The ID of the rule to add.
+   * @param {Object} rule The rule to add.
+   *
+   * @example
+   * // Hide all messages from Resistance team
+   * IITC.comm.declarativeMessageFilter.addRule({
+   *   id: "hideResistanceTeam1",
+   *   conditions: [
+   *     { field: "player.team", value: "Resistance" },
+   *   ]
+   * });
+   *
+   * @example
+   * // Hide all messages except those from the Resistance team using the inverted rule
+   * IITC.comm.declarativeMessageFilter.addRule({
+   *   id: "hideExceptResistanceTeam",
+   *   conditions: [
+   *     { field: "player.team", value: "Resistance", invert: true },
+   *   ]
+   * });
+   *
+   * @example
+   * // Hide messages that look like spam
+   * IITC.comm.declarativeMessageFilter.addRule({
+   *   id: "hideSpam",
+   *   conditions: [
+   *     { field: "markup[4][1].plain", condition: /ingress-(shop|store)|(store|shop)-ingress/i },
+   *   ]
+   * });
+   */
+  addRule: (id, rule) => {
+    if (IITC.comm.declarativeMessageFilter._rules[id]) {
+      console.warn(`Rule with ID '${id}' already exists. Overwriting.`);
+    }
+    IITC.comm.declarativeMessageFilter._rules[id] = rule;
+  },
+
+  /**
+   * Removes a filtering rule by its ID.
+   *
+   * @param {string} id The ID of the rule to remove.
+   */
+  removeRule: (id) => {
+    if (IITC.comm.declarativeMessageFilter._rules[id]) {
+      delete IITC.comm.declarativeMessageFilter._rules[id];
+    } else {
+      console.error(`No rule found with ID '${id}'.`);
+    }
+  },
+
+  /**
+   * Gets a rule by its ID.
+   *
+   * @param {string} id The ID of the rule to get.
+   * @returns {Object|null} The rule object, or null if not found.
+   */
+  getRuleById: (id) => {
+    return IITC.comm.declarativeMessageFilter._rules[id] || null;
+  },
+
+  /**
+   * Gets all current filtering rules.
+   *
+   * @returns {Object} The current set of filtering rules.
+   */
+  getAllRules: () => {
+    return IITC.comm.declarativeMessageFilter._rules;
+  },
+
+  /**
+   * Extracts the value from the message object by a given path.
+   *
+   * @param {Object} object The message object.
+   * @param {String} path Path to the property in dot notation.
+   * @returns {*} The value of the property at the specified path or undefined if the path is not valid.
+   */
+  getMessageValueByPath: (object, path) => {
+    const parts = path.replace(/\[(\w+)]/g, '.$1').split('.');
+    let current = object;
+
+    for (const part of parts) {
+      if (part in current) {
+        current = current[part];
+      } else {
+        return undefined; // Path is not valid
+      }
+    }
+    return current;
+  },
+
+  /**
+   * Checks if the message matches a single rule.
+   *
+   * @param {Object} message The message to check.
+   * @param {Object} rule The rule to match against.
+   * @returns {boolean} True if the message matches the rule, false otherwise.
+   */
+  matchesRule: (message, rule) => {
+    return rule.conditions.every((condition) => {
+      const messageValue = IITC.comm.declarativeMessageFilter.getMessageValueByPath(message, condition.field);
+      let result;
+
+      if ('value' in condition) {
+        result = messageValue === condition.value;
+      } else if ('pattern' in condition) {
+        const regex = new RegExp(condition.pattern);
+        result = regex.test(messageValue);
+      } else {
+        return false; // If the condition does not contain 'value' or 'pattern', we consider that the message does not match the rule
+      }
+
+      // Invert the result if the condition is inverted
+      if (condition.invert) {
+        return !result;
+      }
+      return result;
+    });
+  },
+
+  /**
+   * Checks if a message matches any of the current filtering rules.
+   *
+   * @param {Object} message The message to check.
+   * @returns {boolean} True if the message matches any rule, false otherwise.
+   */
+  filterMessage: (message) => {
+    const rules = IITC.comm.declarativeMessageFilter.getAllRules();
+    for (const ruleId in rules) {
+      if (IITC.comm.declarativeMessageFilter.matchesRule(message, rules[ruleId])) {
+        return true;
+      }
+    }
+    return false;
+  },
+};

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -120,13 +120,19 @@ if (!window.PLAYER || !PLAYER.nickname) {
 // remove complete page. We only wanted the user-data and the page’s
 // security context so we can access the API easily. Setup as much as
 // possible without requiring scripts.
-document.head.innerHTML = ''
-  + '<title>Ingress Intel Map</title>'
-  + '<style>'+'@include_string:style.css@'+'</style>'
-  + '<style>'+'@include_css:external/leaflet.css@'+'</style>'
-  + '<style>'+'@include_css:external/jquery-ui-1.12.1-resizable.css@'+'</style>'
+document.head.innerHTML =
+  '<title>Ingress Intel Map</title>' +
+  '<style>' +
+  '@include_string:style.css@' +
+  '</style>' +
+  '<style>' +
+  '@include_css:external/leaflet.css@' +
+  '</style>' +
+  '<style>' +
+  '@include_css:external/jquery-ui-1.12.1-resizable.css@' +
+  '</style>' +
 //note: smartphone.css injection moved into code/smartphone.js
-  + '<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:100,100italic,300,300italic,400,400italic,500,500italic,700,700italic&subset=latin,cyrillic-ext,greek-ext,greek,vietnamese,latin-ext,cyrillic"/>';
+  '<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:100,100italic,300,300italic,400,400italic,500,500italic,700,700italic&subset=latin,cyrillic-ext,greek-ext,greek,vietnamese,latin-ext,cyrillic"/>';
 
 // remove body element entirely to remove event listeners
 document.body = document.createElement('body');

--- a/package.json
+++ b/package.json
@@ -5,16 +5,20 @@
   "repository": "https://github.com/IITC-CE/ingress-intel-total-conversion.git",
   "license": "ISC",
   "private": true,
+  "type": "module",
   "devDependencies": {
+    "chai": "^4.3.6",
     "eslint": "^8.20.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "mocha": "^9.2.2",
     "prettier": "^2.7.1"
   },
   "scripts": {
     "build": "npm run build:local",
     "build:local": "./build.py local",
     "build:mobile": "./build.py mobile",
-    "fileserver": "./web_server_local.py local"
+    "fileserver": "./web_server_local.py local",
+    "test": "mocha --exit"
   }
 }

--- a/test/comm_declarative_message_filter.spec.js
+++ b/test/comm_declarative_message_filter.spec.js
@@ -1,5 +1,7 @@
-import { describe, it, before } from 'mocha';
+import { describe, it, beforeEach } from 'mocha';
 import { expect } from 'chai';
+
+/* eslint-disable no-unused-expressions */
 
 globalThis.IITC = { comm: {} };
 import('../core/code/comm_declarative_message_filter.js');
@@ -7,94 +9,97 @@ import('../core/code/comm_declarative_message_filter.js');
 // Define test messages
 const testMessages = [
   {
-    "guid":"3d.d",
-    "time":1709,
-    "public":false,
-    "secure":true,
-    "alert":false,
-    "msgToPlayer":false,
-    "type":"SYSTEM_BROADCAST",
-    "narrowcast":false,
-    "auto":true,
-    "team":2,
-    "player": {
-      "name":"Spedd",
-      "team":2
+    guid: '3d.d',
+    time: 1709,
+    public: false,
+    secure: true,
+    alert: false,
+    msgToPlayer: false,
+    type: 'SYSTEM_BROADCAST',
+    narrowcast: false,
+    auto: true,
+    team: 2,
+    player: {
+      name: 'Spedd',
+      team: 2,
     },
-    "markup":[
-      ["TEXT",{"plain":"Drone returned to Agent by "}],
-      ["PLAYER",{"plain":"Spedd","team":"ENLIGHTENED"}]
-    ]
+    markup: [
+      ['TEXT', { plain: 'Drone returned to Agent by ' }],
+      ['PLAYER', { plain: 'Spedd', team: 'ENLIGHTENED' }],
+    ],
   },
   {
-    "guid":"40.d",
-    "time":1709,
-    "public":false,
-    "secure":true,
-    "alert":false,
-    "msgToPlayer":false,
-    "type":"PLAYER_GENERATED",
-    "narrowcast":false,
-    "auto":false,
-    "team":2,
-    "player": {
-      "name":"43Bad",
-      "team":2
+    guid: '40.d',
+    time: 1709,
+    public: false,
+    secure: true,
+    alert: false,
+    msgToPlayer: false,
+    type: 'PLAYER_GENERATED',
+    narrowcast: false,
+    auto: false,
+    team: 2,
+    player: {
+      name: '43Bad',
+      team: 2,
     },
-    "markup":[
-      ["SECURE",{"plain":"[secure] "}],
-      ["SENDER",{"plain":"43Bad: ","team":"ENLIGHTENED"}],
-      ["TEXT",{"plain":""}],
-      ["AT_PLAYER",{"plain":"@RockDeckard","team":"ENLIGHTENED"}],
-      ["TEXT",{"plain":": HI!"}]
-    ]
+    markup: [
+      ['SECURE', { plain: '[secure] ' }],
+      ['SENDER', { plain: '43Bad: ', team: 'ENLIGHTENED' }],
+      ['TEXT', { plain: '' }],
+      ['AT_PLAYER', { plain: '@RockDeckard', team: 'ENLIGHTENED' }],
+      ['TEXT', { plain: ': HI!' }],
+    ],
   },
   {
-    "guid":"40.d",
-    "time":1709,
-    "public":true,
-    "secure":false,
-    "alert":false,
-    "msgToPlayer":false,
-    "type":"SYSTEM_BROADCAST",
-    "narrowcast":false,
-    "auto":true,
-    "team":0,
-    "player": {
-      "name":"b3387",
-      "team":2
+    guid: '40.d',
+    time: 1709,
+    public: true,
+    secure: false,
+    alert: false,
+    msgToPlayer: false,
+    type: 'SYSTEM_BROADCAST',
+    narrowcast: false,
+    auto: true,
+    team: 0,
+    player: {
+      name: 'b3387',
+      team: 2,
     },
-    "markup":[
-      ["TEXT",{"plain":"Agent "}],
-      ["PLAYER",{"plain":"b3387","team":"ENLIGHTENED"}],
-      ["TEXT",{"plain":" destroyed the "}],
-      ["FACTION",{"team":"NEUTRAL","plain":"Neutral"}],
-      ["TEXT",{"plain":" Link "}],
-      ["PORTAL",{"plain":"Turner Ave. (London N15 5DG, UK)","name":"Turner Ave","address":"London N15 5DG, UK","latE6":5000,"lngE6":-800,"team":"NEUTRAL"}],
-      ["TEXT",{"plain":" to "}],
-      ["PORTAL",{"plain":"Notice board (London N15 5DG, UK)","name":"Notice board","address":"London N15 5DG, UK","latE6":5001,"lngE6":-801,"team":"NEUTRAL"}]
-    ]
+    markup: [
+      ['TEXT', { plain: 'Agent ' }],
+      ['PLAYER', { plain: 'b3387', team: 'ENLIGHTENED' }],
+      ['TEXT', { plain: ' destroyed the ' }],
+      ['FACTION', { team: 'NEUTRAL', plain: 'Neutral' }],
+      ['TEXT', { plain: ' Link ' }],
+      ['PORTAL', { plain: 'Turner Ave. (London N15 5DG, UK)', name: 'Turner Ave', address: 'London N15 5DG, UK', latE6: 5000, lngE6: -800, team: 'NEUTRAL' }],
+      ['TEXT', { plain: ' to ' }],
+      [
+        'PORTAL',
+        { plain: 'Notice board (London N15 5DG, UK)', name: 'Notice board', address: 'London N15 5DG, UK', latE6: 5001, lngE6: -801, team: 'NEUTRAL' },
+      ],
+    ],
   },
   {
-    "guid":"ae.d",
-    "time":1709,
-    "public":true,
-    "secure":false,
-    "alert":false,
-    "msgToPlayer":false,
-    "type":"SYSTEM_BROADCAST",
-    "narrowcast":false,
-    "auto":true,
-    "team":1,
-    "player": {
-      "name":"Q77n",
-      "team":1
+    guid: 'ae.d',
+    time: 1709,
+    public: true,
+    secure: false,
+    alert: false,
+    msgToPlayer: false,
+    type: 'SYSTEM_BROADCAST',
+    narrowcast: false,
+    auto: true,
+    team: 1,
+    player: {
+      name: 'Q77n',
+      team: 1,
     },
-    "markup":[
-      ["PLAYER",{"plain":"Q77n","team":"RESISTANCE"}],
-      ["TEXT",{"plain":" captured "}],
-      ["PORTAL",{"plain":"Bridge (UK)","name":"Bridge","address":"UK","latE6":6000,"lngE6":-4000,"team":"RESISTANCE"}]
-    ]
+    markup: [
+      ['PLAYER', { plain: 'Q77n', team: 'RESISTANCE' }],
+      ['TEXT', { plain: ' captured ' }],
+      ['PORTAL', { plain: 'Bridge (UK)', name: 'Bridge', address: 'UK', latE6: 6000, lngE6: -4000, team: 'RESISTANCE' }],
+    ],
   },
 ];
 
@@ -198,3 +203,5 @@ describe('IITC Comm Declarative Message Filter', () => {
     expect(shouldNotMatch).to.be.false;
   });
 });
+
+/* global IITC */

--- a/test/comm_declarative_message_filter.spec.js
+++ b/test/comm_declarative_message_filter.spec.js
@@ -1,0 +1,200 @@
+import { describe, it, before } from 'mocha';
+import { expect } from 'chai';
+
+globalThis.IITC = { comm: {} };
+import('../core/code/comm_declarative_message_filter.js');
+
+// Define test messages
+const testMessages = [
+  {
+    "guid":"3d.d",
+    "time":1709,
+    "public":false,
+    "secure":true,
+    "alert":false,
+    "msgToPlayer":false,
+    "type":"SYSTEM_BROADCAST",
+    "narrowcast":false,
+    "auto":true,
+    "team":2,
+    "player": {
+      "name":"Spedd",
+      "team":2
+    },
+    "markup":[
+      ["TEXT",{"plain":"Drone returned to Agent by "}],
+      ["PLAYER",{"plain":"Spedd","team":"ENLIGHTENED"}]
+    ]
+  },
+  {
+    "guid":"40.d",
+    "time":1709,
+    "public":false,
+    "secure":true,
+    "alert":false,
+    "msgToPlayer":false,
+    "type":"PLAYER_GENERATED",
+    "narrowcast":false,
+    "auto":false,
+    "team":2,
+    "player": {
+      "name":"43Bad",
+      "team":2
+    },
+    "markup":[
+      ["SECURE",{"plain":"[secure] "}],
+      ["SENDER",{"plain":"43Bad: ","team":"ENLIGHTENED"}],
+      ["TEXT",{"plain":""}],
+      ["AT_PLAYER",{"plain":"@RockDeckard","team":"ENLIGHTENED"}],
+      ["TEXT",{"plain":": HI!"}]
+    ]
+  },
+  {
+    "guid":"40.d",
+    "time":1709,
+    "public":true,
+    "secure":false,
+    "alert":false,
+    "msgToPlayer":false,
+    "type":"SYSTEM_BROADCAST",
+    "narrowcast":false,
+    "auto":true,
+    "team":0,
+    "player": {
+      "name":"b3387",
+      "team":2
+    },
+    "markup":[
+      ["TEXT",{"plain":"Agent "}],
+      ["PLAYER",{"plain":"b3387","team":"ENLIGHTENED"}],
+      ["TEXT",{"plain":" destroyed the "}],
+      ["FACTION",{"team":"NEUTRAL","plain":"Neutral"}],
+      ["TEXT",{"plain":" Link "}],
+      ["PORTAL",{"plain":"Turner Ave. (London N15 5DG, UK)","name":"Turner Ave","address":"London N15 5DG, UK","latE6":5000,"lngE6":-800,"team":"NEUTRAL"}],
+      ["TEXT",{"plain":" to "}],
+      ["PORTAL",{"plain":"Notice board (London N15 5DG, UK)","name":"Notice board","address":"London N15 5DG, UK","latE6":5001,"lngE6":-801,"team":"NEUTRAL"}]
+    ]
+  },
+  {
+    "guid":"ae.d",
+    "time":1709,
+    "public":true,
+    "secure":false,
+    "alert":false,
+    "msgToPlayer":false,
+    "type":"SYSTEM_BROADCAST",
+    "narrowcast":false,
+    "auto":true,
+    "team":1,
+    "player": {
+      "name":"Q77n",
+      "team":1
+    },
+    "markup":[
+      ["PLAYER",{"plain":"Q77n","team":"RESISTANCE"}],
+      ["TEXT",{"plain":" captured "}],
+      ["PORTAL",{"plain":"Bridge (UK)","name":"Bridge","address":"UK","latE6":6000,"lngE6":-4000,"team":"RESISTANCE"}]
+    ]
+  },
+];
+
+describe('IITC Comm Declarative Message Filter', () => {
+  beforeEach(() => {
+    // Reset rules before each test
+    IITC.comm.declarativeMessageFilter._rules = {};
+  });
+
+  it('should add a new rule successfully', () => {
+    const ruleId = 'testRule';
+    const rule = {
+      conditions: [{ field: 'player.team', value: 1 }],
+    };
+
+    IITC.comm.declarativeMessageFilter.addRule(ruleId, rule);
+
+    const addedRule = IITC.comm.declarativeMessageFilter.getRuleById(ruleId);
+    expect(addedRule).to.deep.equal(rule);
+  });
+
+  it('should remove an existing rule by ID', () => {
+    const ruleId = 'testRule';
+    IITC.comm.declarativeMessageFilter.addRule(ruleId, { conditions: [] });
+    IITC.comm.declarativeMessageFilter.removeRule(ruleId);
+
+    const ruleAfterRemoval = IITC.comm.declarativeMessageFilter.getRuleById(ruleId);
+    expect(ruleAfterRemoval).to.be.null;
+  });
+
+  it('should return all current rules', () => {
+    const rules = {
+      rule1: { conditions: [{ field: 'player.team', value: 1 }] },
+      rule2: { conditions: [{ field: 'player.team', value: 2 }] },
+    };
+
+    for (const id in rules) {
+      IITC.comm.declarativeMessageFilter.addRule(id, rules[id]);
+    }
+
+    const allRules = IITC.comm.declarativeMessageFilter.getAllRules();
+    expect(allRules).to.deep.equal(rules);
+  });
+
+  // Example: Test matching a rule with a direct comparison
+  it('should correctly filter messages based on a direct comparison condition', () => {
+    const ruleId = 'directComparison';
+    const rule = {
+      conditions: [{ field: 'player.name', value: '43Bad' }],
+    };
+
+    IITC.comm.declarativeMessageFilter.addRule(ruleId, rule);
+
+    const shouldNotMatch1 = IITC.comm.declarativeMessageFilter.filterMessage(testMessages[0]);
+    const shouldMatch = IITC.comm.declarativeMessageFilter.filterMessage(testMessages[1]);
+    const shouldNotMatch2 = IITC.comm.declarativeMessageFilter.filterMessage(testMessages[2]);
+    const shouldNotMatch3 = IITC.comm.declarativeMessageFilter.filterMessage(testMessages[3]);
+
+    expect(shouldMatch).to.be.true;
+    expect(shouldNotMatch1).to.be.false;
+    expect(shouldNotMatch2).to.be.false;
+    expect(shouldNotMatch3).to.be.false;
+  });
+
+  // Example: Test matching a rule with a regex pattern
+  it('should correctly filter messages based on a regex pattern condition', () => {
+    const ruleId = 'regexPattern';
+    const rule = {
+      conditions: [{ field: 'markup[5][1].plain', pattern: /UK\)$/i }],
+    };
+
+    IITC.comm.declarativeMessageFilter.addRule(ruleId, rule);
+
+    const shouldNotMatch1 = IITC.comm.declarativeMessageFilter.filterMessage(testMessages[0]);
+    const shouldNotMatch2 = IITC.comm.declarativeMessageFilter.filterMessage(testMessages[1]);
+    const shouldMatch = IITC.comm.declarativeMessageFilter.filterMessage(testMessages[2]);
+    const shouldNotMatch3 = IITC.comm.declarativeMessageFilter.filterMessage(testMessages[3]);
+
+    expect(shouldMatch).to.be.true;
+    expect(shouldNotMatch1).to.be.false;
+    expect(shouldNotMatch2).to.be.false;
+    expect(shouldNotMatch3).to.be.false;
+  });
+
+  it('should correctly filter messages based on an inverted condition', () => {
+    const ruleId = 'invertCondition';
+    const rule = {
+      conditions: [{ field: 'player.team', value: 1, invert: true }],
+    };
+
+    IITC.comm.declarativeMessageFilter.addRule(ruleId, rule);
+
+    const shouldMatch1 = IITC.comm.declarativeMessageFilter.filterMessage(testMessages[0]);
+    const shouldMatch2 = IITC.comm.declarativeMessageFilter.filterMessage(testMessages[1]);
+    const shouldMatch3 = IITC.comm.declarativeMessageFilter.filterMessage(testMessages[2]);
+    const shouldNotMatch = IITC.comm.declarativeMessageFilter.filterMessage(testMessages[3]); // This message is from Resistance, so it should not match when inverted
+
+    expect(shouldMatch1).to.be.true;
+    expect(shouldMatch2).to.be.true;
+    expect(shouldMatch3).to.be.true;
+    expect(shouldNotMatch).to.be.false;
+  });
+});


### PR DESCRIPTION
On top of https://github.com/IITC-CE/ingress-intel-total-conversion/pull/447

**Problem**: legacy plugins overwrite window.chat functions, but the new code uses the COMM API and these plugin changes are not called. Also, before this PR, a lot of window.chat functions were removed, which could cause errors in the legacy plugins.

**Solution**: I created a proxy that calls the alternatives in the COMM API when calling the removed window.chat functions. It also overwrites COMM API methods when they are overwritten in window.chat by a legacy plugin.

I tested this solution with plugins from Commutity plugins and it looks like a working solution.

- [x] Analyze what causes plugins to overwrite functions and if necessary, extend API capabilities to make those capabilities available through API
- [x] [Write documentation on plugin migration](https://github.com/IITC-CE/ingress-intel-total-conversion/wiki/IITC-plugin-migration-guide#comm-api)