### PR TITLE
fix dialogs on iitc boot

### DIFF
--- a/core/code/boot.js
+++ b/core/code/boot.js
@@ -255,11 +255,11 @@ function boot() {
   var loadPlugins = prepPluginsToLoad();
   loadPlugins('boot');
 
+  window.setupDialogs();
   checkingIntelURL();
   setupIngressMarkers();
   window.extractFromStock();
   window.setupIdle();
-  window.setupDialogs();
   window.setupDataTileParams();
   window.setupMap();
   window.setupOMS();


### PR DESCRIPTION
DIALOGS is not initialized
when "checkingIntelURL" or "extractFromStock" function fails and tries to open a dialog.

example:
error"can't access property "dialog-anon-0", window.DIALOGS is undefined" when not using "intel.ingress.com"