### PR TITLE
Update intel link to match stock.

### DIFF
--- a/core/code/utils_misc.js
+++ b/core/code/utils_misc.js
@@ -529,7 +529,7 @@ window.makePermalink = function (latlng, options) {
   if (options.fullURL) {
     url += new URL(document.baseURI).origin;
   }
-  url += '/';
+  url += '/intel';
   return url + '?' + args.join('&');
 };
 


### PR DESCRIPTION
It looks like when `/intel` was removed with e5fe5d8fe, stock was not adding the string to the URL.  Currently it does in both the web and scanner apps.

Closes #684.