### PR TITLE
Add conditional check for `String.prototype.capitalize` polyfill

### DIFF
--- a/core/code/utils_misc.js
+++ b/core/code/utils_misc.js
@@ -533,11 +533,13 @@ window.makePermalink = function (latlng, options) {
   return url + '?' + args.join('&');
 };
 
-Object.defineProperty(String.prototype, 'capitalize', {
-  value: function() {
-    return this.charAt(0).toUpperCase() + this.slice(1).toLowerCase();
-  }
-});
+if (!String.prototype.capitalize) {
+  Object.defineProperty(String.prototype, 'capitalize', {
+    value: function () {
+      return this.charAt(0).toUpperCase() + this.slice(1).toLowerCase();
+    },
+  });
+}
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith#polyfill
 if (!String.prototype.startsWith) {


### PR DESCRIPTION
Only define the capitalize method on String.prototype if it is not already defined, avoiding overrides.