### PR TITLE
basemap-kartverket: Update to new WMTS server

### DIFF
--- a/plugins/basemap-kartverket.js
+++ b/plugins/basemap-kartverket.js
@@ -1,7 +1,7 @@
 ﻿// @author         johnd0e
 // @name           Kartverket.no maps (Norway)
 // @category       Map Tiles
-// @version        0.2.3
+// @version        0.3.0
 // @description    Add Kartverket.no map layers.
 
 /* exported setup, changelog --eslint */

--- a/plugins/basemap-kartverket.js
+++ b/plugins/basemap-kartverket.js
@@ -9,6 +9,10 @@
 
 var changelog = [
   {
+    version: '0.3.0',
+    changes: ['Migrated to new WMTS server due to deprecation of Statkart opencache'],
+  },
+  {
     version: '0.2.3',
     changes: ['Version upgrade due to a change in the wrapper: added plugin icon'],
   },
@@ -21,38 +25,40 @@ mapKartverket.setup = function () {
 
   L.TileLayer.Kartverket = L.TileLayer.extend({
 
-    baseUrl: 'https://opencache{s}.statkart.no/gatekeeper/gk/gk.open_gmaps?'
-           + 'layers={layer}&zoom={z}&x={x}&y={y}',
+    baseUrl: 'https://cache.kartverket.no/v1/wmts/1.0.0/'
+           + '{layer}/default/webmercator/{z}/{y}/{x}.png',
 
     options: {
       maxNativeZoom: 18,
-      attribution: '&copy; <a href="http://kartverket.no">Kartverket</a>',
-      subdomains: ['', '2', '3']
+      attribution: '&copy; <a href="http://kartverket.no">Kartverket</a>'
     },
 
     mappings: {
-      kartdata2: 'topo4',
-      matrikkel_bakgrunn: 'matrikkel_bakgrunn2',
-      norgeskart_bakgrunn: 'topo4',
-      sjo_hovedkart2: 'sjokartraster',
-      toporaster: 'toporaster3',
-      topo2: 'topo4',
-      topo2graatone: 'topo4graatone'
+      bakgrunnskart_forenklet: 'topograatone',
+      egk: 'topo', // *1
+      europa: 'topo', // *1
+      havbunn_grunnkart: 'topo', // *1
+      kartdata2: 'topo',
+      matrikkel_bakgrunn: 'topo',
+      matrikkel_bakgrunn2: 'topo',
+      norges_grunnkart: 'topo',
+      norges_grunnkart_graatone: 'topograatone',
+      norgeskart_bakgrunn: 'topo',
+      sjo_hovedkart2: 'topo', // *1
+      sjokartraster: 'topo', // *1
+      terreng_norgeskart: 'topo',
+      toporaster3: 'toporaster',
+      topo2: 'topo',
+      topo4: 'topo',
+      topo2graatone: 'topograatone',
+      topo4graatone: 'topograatone',
+      // *1 = This layer is not provided on cache.kartverket.no.
     },
 
     layers: {
-      matrikkel_bakgrunn2:'Matrikkel bakgrunn',
-      topo4:              'Topografisk norgeskart',
-      topo4graatone:      'Topografisk norgeskart gråtone',
-      europa:             'Europakart',
-      toporaster3:        'Topografisk norgeskart, raster',
-      sjokartraster:      'Sjøkart hovedkartserien',
-      norges_grunnkart:   'Norges Grunnkart',
-      norges_grunnkart_graatone: 'Norges grunnkart gråtone',
-      egk:                'Europeiske grunnkart',
-      terreng_norgeskart: 'Terreng',
-      havbunn_grunnkart:  'Havbunn grunnkart',
-      bakgrunnskart_forenklet: null
+        topo: 'Kartverket Topo (farger)',
+        topograatone: 'Kartverket Topo (gråtone)',
+        toporaster: 'Kartverket Topo (raster)',
     },
 
     initialize: function (layer, options) {

--- a/plugins/basemap-kartverket.js
+++ b/plugins/basemap-kartverket.js
@@ -25,12 +25,11 @@ mapKartverket.setup = function () {
 
   L.TileLayer.Kartverket = L.TileLayer.extend({
 
-    baseUrl: 'https://cache.kartverket.no/v1/wmts/1.0.0/'
-           + '{layer}/default/webmercator/{z}/{y}/{x}.png',
+    baseUrl: 'https://cache.kartverket.no/v1/wmts/1.0.0/' + '{layer}/default/webmercator/{z}/{y}/{x}.png',
 
     options: {
       maxNativeZoom: 18,
-      attribution: '&copy; <a href="http://kartverket.no">Kartverket</a>'
+      attribution: '&copy; <a href="http://kartverket.no">Kartverket</a>',
     },
 
     mappings: {
@@ -56,9 +55,9 @@ mapKartverket.setup = function () {
     },
 
     layers: {
-        topo: 'Kartverket Topo (farger)',
-        topograatone: 'Kartverket Topo (gråtone)',
-        toporaster: 'Kartverket Topo (raster)',
+      topo: 'Kartverket Topo (farger)',
+      topograatone: 'Kartverket Topo (gråtone)',
+      toporaster: 'Kartverket Topo (raster)',
     },
 
     initialize: function (layer, options) {


### PR DESCRIPTION
Statkart's opencache server is deprecated and will be phased out. It is already experiencing performance issues that makes it more or less useless as a basemap tileserver. The plugin is updated to use the new (and much faster) WMTS cache from Kartverket, as described here: https://kartverket.no/om-kartverket/nyheter/alle/2024/juli/treghet-pa-opencache.statkart.no

Many of the map layers that were available on opencache are not present on the new cache, and reasonable mappings have been set to try to mitigate this.

close https://github.com/IITC-CE/ingress-intel-total-conversion/issues/749