### PR TITLE
Add favicon.ico

### DIFF
--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -122,6 +122,7 @@ if (!window.PLAYER || !PLAYER.nickname) {
 // possible without requiring scripts.
 document.head.innerHTML =
   '<title>Ingress Intel Map</title>' +
+  '<link rel="shortcut icon" href="/img/favicon.ico" />' +
   '<style>' +
   '@include_string:style.css@' +
   '</style>' +


### PR DESCRIPTION
In the original intel, there is `favicon.ico` in the head section.

![image](https://github.com/user-attachments/assets/fe7aba58-48ab-41f6-8f7a-5984016caa3e)

But after the IITC plugin, this line disappeared.