### PR TITLE
Chat: Format neutrals (machina)

### DIFF
--- a/core/code/comm.js
+++ b/core/code/comm.js
@@ -783,9 +783,10 @@ function renderMsgRow(data) {
   var timeCell = IITC.comm.renderTimeCell(data.time, timeClass);
 
   var nickClasses = ['nickname'];
-  if (data.player.team === window.TEAM_ENL || data.player.team === window.TEAM_RES) {
+  if (window.TEAM_TO_CSS[data.player.team]) {
     nickClasses.push(window.TEAM_TO_CSS[data.player.team]);
   }
+
   // highlight things said/done by the player in a unique colour
   // (similar to @player mentions from others in the chat text itself)
   if (data.player.name === window.PLAYER.nickname) {


### PR DESCRIPTION
chat refactor removed neutral css class
from old code

23edee74dd5b32c704799ba97f43ecadbedaef66

this resulted in a black text color for machina messages.
this PR reverts the line to the old code (TEAM_NONE - White - for machina messages)