### PR TITLE
Added controls to use the mobile version of IITC without an app

### DIFF
--- a/core/code/chat.js
+++ b/core/code/chat.js
@@ -364,7 +364,12 @@ chat.show = function (name) {
 chat.chooser = function (event) {
   var t = $(event.target);
   var tab = t.data('channel');
-  chat.chooseTab(tab);
+
+  if (window.isSmartphone() && !window.useAppPanes()) {
+    window.show(tab);
+  } else {
+    chat.chooseTab(tab);
+  }
 };
 
 /**

--- a/core/code/smartphone.js
+++ b/core/code/smartphone.js
@@ -68,20 +68,26 @@ window.runOnSmartphonesBeforeBoot = function () {
   };
 
   window.smartphone.mapButton = $('<a>map</a>').click(function () {
+    window.show('map');
     $('#map').css({ visibility: 'visible', opacity: '1' });
     $('#updatestatus').show();
-    $('#chatcontrols a .active').removeClass('active');
+    $('#chatcontrols a.active').removeClass('active');
     $("#chatcontrols a:contains('map')").addClass('active');
   });
 
   window.smartphone.sideButton = $('<a>info</a>').click(function () {
+    window.show('info');
     $('#scrollwrapper').show();
     window.resetScrollOnNewPortal();
-    $('.active').removeClass('active');
+    $('#chatcontrols a.active').removeClass('active');
     $("#chatcontrols a:contains('info')").addClass('active');
   });
 
   $('#chatcontrols').append(window.smartphone.mapButton).append(window.smartphone.sideButton);
+
+  if (!window.useAppPanes()) {
+    document.body.classList.add('show_controls');
+  }
 
   window.addHook('portalDetailsUpdated', function () {
     var x = $('.imgpreview img').removeClass('hide');
@@ -104,9 +110,10 @@ window.runOnSmartphonesBeforeBoot = function () {
  * This function is hooked to the 'portalSelected' event and is specific to the smartphone layout.
  *
  * @function smartphoneInfo
+ * @param {Object} selectedPortalData - The object containing details about the selected portal.
  */
-window.smartphoneInfo = function () {
-  var guid = data.selectedPortalGuid;
+window.smartphoneInfo = function (selectedPortalData) {
+  var guid = selectedPortalData.selectedPortalGuid;
   if (!window.portals[guid]) return;
 
   var data = window.portals[window.selectedPortal].options.data;
@@ -196,8 +203,4 @@ window.runOnSmartphonesAfterBoot = function () {
         $('#sidebar').animate({ scrollTop: newTop }, 200);
       }
     });
-
-  // make buttons in action bar flexible
-  var l = $('#chatcontrols a:visible');
-  l.css('width', 100 / l.length + '%');
 };

--- a/core/smartphone.css
+++ b/core/smartphone.css
@@ -125,10 +125,6 @@ body {
   margin-left: 4px;
 }
 
-#sidebar, #chatcontrols, #chat, #chatinput {
-  background: transparent !important;
-}
-
 .leaflet-top .leaflet-control {
   margin-top: 5px !important;
   margin-left: 5px !important;
@@ -257,3 +253,34 @@ body {
    https://github.com/IITC-CE/ingress-intel-total-conversion/issues/89
 */
 .leaflet-bottom { bottom: 5px; }
+
+/* Controls for mobile view without an app */
+:root {
+  --top-controls-height: 38px;
+}
+
+body.show_controls #chatcontrols {
+  display: flex !important;
+  top: 0;
+  overflow-x: auto;
+  width: calc(100% - 1px);
+}
+
+body.show_controls #chatcontrols a {
+  flex: 1;
+  min-width: fit-content;
+  padding: 0 5px;
+}
+
+body.show_controls #map {
+  height: calc(100vh - var(--top-controls-height) - 25px);
+  margin-top: var(--top-controls-height);
+}
+
+body.show_controls #scrollwrapper {
+  margin-top: var(--top-controls-height)
+}
+
+body.show_controls #chat {
+  top: var(--top-controls-height) !important;
+}


### PR DESCRIPTION
Judging by the code and commits, this was once planned to be done but was not implemented.
The PR adds control buttons, this allows you to use IITC in the mobile version without using an app (like the IITC Button on Firefox for Android).
This PR does not affect the desktop version or IITC when using the app.

![example](https://github.com/user-attachments/assets/881a8065-00f0-4b3f-949a-81f145f13b06)
