### PR TITLE
Disable RTL for Portalnames

### DIFF
--- a/core/code/comm.js
+++ b/core/code/comm.js
@@ -75,7 +75,7 @@ function _initChannelData(id) {
  * @memberof IITC.comm
  */
 let portalTemplate =
-  '<a onclick="window.selectPortalByLatLng({{ lat }}, {{ lng }});return false" title="{{ title }}" href="{{ url }}" class="help" style="unicode-bidi: isolate;">{{ portal_name }}</a>';
+  '<a onclick="window.selectPortalByLatLng({{ lat }}, {{ lng }});return false" title="{{ title }}" href="{{ url }}" class="bidi-isolate help">{{ portal_name }}</a>';
 /**
  * Template for time cell.
  * @type {String}

--- a/core/code/comm.js
+++ b/core/code/comm.js
@@ -75,7 +75,7 @@ function _initChannelData(id) {
  * @memberof IITC.comm
  */
 let portalTemplate =
-  '<a onclick="window.selectPortalByLatLng({{ lat }}, {{ lng }});return false" title="{{ title }}" href="{{ url }}" class="help">{{ portal_name }}</a>';
+  '<a onclick="window.selectPortalByLatLng({{ lat }}, {{ lng }});return false" title="{{ title }}" href="{{ url }}" class="help" style="unicode-bidi: isolate;">{{ portal_name }}</a>';
 /**
  * Template for time cell.
  * @type {String}

--- a/core/style.css
+++ b/core/style.css
@@ -439,6 +439,9 @@ summary {
   padding:3px 4px 1px 4px;
 }
 
+.bidi-isolate {
+    unicode-bidi: isolate;
+}
 
 
 /* sidebar ************************************************************/


### PR DESCRIPTION
in right-to-left languages some message are screwed up.

like:` x created field @11+ portal mus`
instead of:` x created field @portal  +11 mus`


... not sure if this should be applied to player names too?!?
or better moved to an extra css class?!?