### PR TITLE
Positioning Leaflet elements using CSS Grid

### DIFF
--- a/core/code/map.js
+++ b/core/code/map.js
@@ -316,6 +316,32 @@ window.setupMap = function () {
 
   map.attributionControl.setPrefix('');
 
+  /**
+   * Override default Google Maps attribution to use Leaflet's native attribution control
+   * instead of creating separate DOM elements. Extracts text content from Google's
+   * attribution container and adds it to Leaflet's control.
+   */
+  L.GridLayer.GoogleMutant.prototype._setupAttribution = function (ev) {
+    if (!this._map?.attributionControl) {
+      return;
+    }
+    // eslint-disable-next-line
+    const pos = google.maps.ControlPosition;
+    const container = ev.positions.get(pos.BOTTOM_RIGHT);
+    const attribution = container?.querySelector('span')?.textContent;
+    if (attribution) {
+      this._attributionText = attribution; // Сохраняем текст атрибуции
+      this._map.attributionControl.addAttribution(attribution);
+    }
+  };
+  const originalGoogleMutantOnRemove = L.GridLayer.GoogleMutant.prototype.onRemove;
+  L.GridLayer.GoogleMutant.prototype.onRemove = function (map) {
+    originalGoogleMutantOnRemove.call(this, map);
+    if (this._attributionText && map.attributionControl) {
+      map.attributionControl.removeAttribution(this._attributionText);
+    }
+  };
+
   window.map = map;
 
   map.on('moveend', function () {

--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -163,9 +163,6 @@ window.renderPortalDetails = function (guid) {
         .text('X')
         .click(function () {
           window.renderPortalDetails(null);
-          if (window.isSmartphone()) {
-            window.show('map');
-          }
         }),
 
       // help cursor via ".imgpreview img"

--- a/core/code/portal_highlighter.js
+++ b/core/code/portal_highlighter.js
@@ -61,12 +61,10 @@ window.updatePortalHighlighterControl = function () {
 
   if (window._highlighters !== null) {
     if ($('#portal_highlight_select').length === 0) {
-      $('body').append("<select id='portal_highlight_select'></select>");
+      $('.leaflet-top.leaflet-left').first().append("<select id='portal_highlight_select' class='leaflet-control'></select>");
       $('#portal_highlight_select').change(function () {
         window.changePortalHighlights($(this).val());
       });
-      $('.leaflet-top.leaflet-left').css('padding-top', '20px');
-      $('.leaflet-control-scale-line').css('margin-top', '25px');
     }
     $('#portal_highlight_select').html('');
     $('#portal_highlight_select').append($('<option>').attr('value', window._no_highlighter).text(window._no_highlighter));

--- a/core/smartphone.css
+++ b/core/smartphone.css
@@ -125,11 +125,6 @@ body {
   margin-left: 4px;
 }
 
-.leaflet-top .leaflet-control {
-  margin-top: 5px !important;
-  margin-left: 5px !important;
-}
-
 #searchwrapper .ui-accordion-header {
   padding: 0.3em 0;
 }

--- a/core/style.css
+++ b/core/style.css
@@ -161,6 +161,35 @@ a:hover {
   margin-left: 720px;
 }
 
+/* leaflet controls */
+.leaflet-left, .leaflet-right {
+  display: grid;
+  grid-gap: 10px;
+  justify-items: baseline;
+}
+
+.leaflet-right {
+  justify-items: end;
+}
+
+.leaflet-left .leaflet-control,
+.leaflet-right .leaflet-control {
+  margin: 0;
+}
+
+.leaflet-top {
+  top: 10px;
+}
+.leaflet-right {
+  right: 10px;
+}
+.leaflet-bottom {
+  bottom: 10px;
+}
+.leaflet-left {
+  left: 10px;
+}
+
 .help {
   cursor: help;
 }

--- a/core/style.css
+++ b/core/style.css
@@ -1250,16 +1250,21 @@ td + td {
 }
 
 #portal_highlight_select {
-  position: absolute;
-  top:5px;
-  left:10px;
   z-index: 2500;
   font-size:11px;
   background-color:#0E3C46;
   color:#ffce00;
-
+  order: -100;
 }
 
+.leaflet-control-scale {
+  order: -90;
+}
+
+.leaflet-bar {
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  box-shadow: none;
+}
 
 
 .portal_details th, .portal_details td {

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -143,13 +143,13 @@ document.head.innerHTML =
   '<title>Ingress Intel Map</title>' +
   '<link rel="shortcut icon" href="/img/favicon.ico" />' +
   '<style>' +
-  '@include_string:style.css@' +
+  '@include_css:external/jquery-ui-1.12.1-resizable.css@' +
   '</style>' +
   '<style>' +
   '@include_css:external/leaflet.css@' +
   '</style>' +
   '<style>' +
-  '@include_css:external/jquery-ui-1.12.1-resizable.css@' +
+  '@include_string:style.css@' +
   '</style>' +
   // note: smartphone.css injection moved into code/smartphone.js
   '<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:100,100italic,300,300italic,400,400italic,500,500italic,700,700italic&subset=latin,cyrillic-ext,greek-ext,greek,vietnamese,latin-ext,cyrillic"/>';

--- a/plugins/pan-control.css
+++ b/plugins/pan-control.css
@@ -1,0 +1,17 @@
+.leaflet-left.has-leaflet-pan-control .leaflet-bar {
+	left: 24.5px;
+}
+
+.leaflet-touch .leaflet-left.has-leaflet-pan-control .leaflet-bar {
+  left: 34px
+}
+
+.leaflet-control-pan {
+    order: -50;
+}
+
+.leaflet-control-pan div {
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  box-shadow: none;
+  border-radius: 4px;
+}

--- a/plugins/pan-control.js
+++ b/plugins/pan-control.js
@@ -40,28 +40,8 @@ function setup() {
   if (!panControl.options.position) {
     // default: 'topleft'
     // to be above all controls
-    $('.leaflet-top.leaflet-left .leaflet-control').first().before(panControl.control.getContainer());
+    $('.leaflet-top.leaflet-left').first().append(panControl.control.getContainer());
   }
-
-  // L.Control.Pan.css tries to align zoom control with the pan control, but the result sucks
-  // so here is our attempt to make it better
-  // (adapted from https://github.com/kartena/Leaflet.Pancontrol/pull/20)
-  $('<style>')
-    .html(
-      '\
-    .leaflet-left.has-leaflet-pan-control .leaflet-control-zoom,\
-    .leaflet-left.has-leaflet-pan-control .leaflet-control-zoomslider { left: unset; }\
-    .leaflet-left.has-leaflet-pan-control .leaflet-control-scale { left: -24.5px; }\
-    .leaflet-left.has-leaflet-pan-control { left: 24.5px; }\
-    .leaflet-left .leaflet-control-pan { left: -24.5px; }\
-    .leaflet-control-pan { width: 75px; height: 75px; }\
-    .leaflet-touch .leaflet-left.has-leaflet-pan-control { left: 26px; }\
-    .leaflet-touch .leaflet-left .leaflet-control-pan { left: -26px; }\
-    .leaflet-touch .leaflet-control-pan { width: 86px; height: 114px; }\
-    .leaflet-touch .leaflet-left .leaflet-control-pan { margin-left: 10px; }\
-  '
-    )
-    .appendTo('head');
 }
 setup.priority = 'low';
 
@@ -71,6 +51,7 @@ function loadLeafletPancontrol() {
     // eslint-disable-next-line
     '@include_raw:external/L.Control.Pan.js@';
     $('<style>').html('@include_css:external/L.Control.Pan.css@').appendTo('head');
+    $('<style>').html('@include_css:pan-control.css@').appendTo('head');
   } catch (e) {
     console.error('L.Control.Pan.js loading failed');
     throw e;

--- a/plugins/scale-bar.js
+++ b/plugins/scale-bar.js
@@ -29,30 +29,20 @@ window.plugin.scaleBar = scaleBar;
 // Before you ask: yes, I explicitely turned off imperial units. Imperial units
 // are worse than Internet Explorer 6 whirring fans combined. Upgrade to the metric
 // system already.
-scaleBar.options = { imperial: false };
-
-scaleBar.mobileOptions = { position: 'bottomright', maxWidth: 100 };
-
-scaleBar.desktopOptions = { position: 'topleft', maxWidth: 200 };
-
-function moveToEdge(ctrl) {
-  var $el = $(ctrl.getContainer());
-  var $corner = $el.parent();
-  var pos = ctrl.getPosition();
-  if (pos.indexOf('top') !== -1) {
-    $corner.prepend($el);
-  } else if (pos.indexOf('bottom') !== -1) {
-    $corner.append($el);
-    $corner.find('.leaflet-control-attribution').appendTo($corner); // make sure that attribution control is on very bottom
-  }
-}
+scaleBar.options = {
+  imperial: false,
+  position: 'bottomright',
+};
 
 function setup() {
-  var options = L.extend({}, window.isSmartphone() ? scaleBar.mobileOptions : scaleBar.desktopOptions, scaleBar.options);
+  var options = L.extend(
+    {},
+    {
+      maxWidth: window.isSmartphone() ? 100 : 200,
+    },
+    scaleBar.options
+  );
+
   scaleBar.control = L.control.scale(options).addTo(window.map);
-  // wait other controls to initialize (should be initialized last)
-  setTimeout(function () {
-    moveToEdge(scaleBar.control);
-  });
 }
 setup.priority = 'low';

--- a/plugins/zoom-slider.css
+++ b/plugins/zoom-slider.css
@@ -1,0 +1,5 @@
+.leaflet-container .leaflet-control-zoomslider {
+    margin-left: 0;
+    margin-top: 0;
+    order: -40;
+}

--- a/plugins/zoom-slider.js
+++ b/plugins/zoom-slider.js
@@ -42,12 +42,6 @@ function setup() {
     map.zoomControl.remove();
   }
   zoomSlider.control = L.control.zoomslider(zoomSlider.options).addTo(map);
-
-  // L.Control.Zoomslider.css defines non-standard border for `.leaflet-control-zoomslider`
-  // which makes zoomslider not aligning with other leaflet controls
-  // Here we are trying to unset it (make the same as general `.leaflet-control`)
-  // (adapted from https://github.com/kartena/Leaflet.zoomslider/pull/74)
-  $('<style>').html('.leaflet-touch .leaflet-control-zoomslider { border: 2px solid rgba(0,0,0,0.2) }').appendTo('head');
 }
 
 function loadLeafletZoomslider() {
@@ -56,6 +50,7 @@ function loadLeafletZoomslider() {
     // eslint-disable-next-line
     '@include_raw:external/L.Control.Zoomslider.js@';
     $('<style>').html('@include_string:external/L.Control.Zoomslider.css@').appendTo('head');
+    $('<style>').html('@include_string:zoom-slider.css@').appendTo('head');
   } catch (e) {
     console.error('L.Control.Zoomslider.js loading failed');
     throw e;


### PR DESCRIPTION
- The element for selecting highlighting has been moved to `leaflet-control-container`. This allowed to apply the same indentation for all elements. For example, this fixes accessing the element on smartphones without using the app https://github.com/IITC-CE/ingress-intel-total-conversion/issues/781#issuecomment-2467247554 close #781
- Leaflet controls now use CSS Grid instead of complex indentation calculations
- Use Leaflet's native attribution control for Google Maps layer
- Always position scale bar in bottom right corner
-  Disabled closing the Info panel when closing the portal in the mobile version
