### PR TITLE
Apply a `filter` to `glob` results to verify a file exists.

### DIFF
--- a/build.py
+++ b/build.py
@@ -55,7 +55,7 @@ def iitc_build(source, outdir, deps_list=None):
     build_plugin.process_file(source / iitc_script, outdir, deps_list=deps_list)
 
     outdir.joinpath('plugins').mkdir(parents=True, exist_ok=True)
-    for filename in source.joinpath('plugins').glob('*.js'):
+    for filename in filter(lambda p: p.exists(), (source / 'plugins').glob('*.js')):
         build_plugin.process_file(
             filename,
             outdir / 'plugins',

--- a/build_plugin.py
+++ b/build_plugin.py
@@ -129,7 +129,7 @@ var log = ulog('{.stem}');
 
 
 def bundle_code(_, path=None):
-    files = (path / 'code').glob('*.js')
+    files = filter(lambda p: p.exists(), (path / 'code').glob('*.js'))
     return '\n'.join(map(wrap_iife, sorted(files)))
 
 


### PR DESCRIPTION
Also replace a `joinpath` with `/` for consistency.

Closes #788 .