### PR TITLE
Skip unreadable files during build

### DIFF
--- a/build_plugin.py
+++ b/build_plugin.py
@@ -176,6 +176,10 @@ def process_file(source, out_dir, dist_path=None, deps_list=None):
         meta, script = readtext(source).split('\n\n', 1)
     except ValueError:
         raise Exception(f'{source}: wrong input: empty line expected after metablock')
+    except (OSError, IOError) as e:
+        print(f"{source}: {type(e).__name__}: {e}")
+        return
+
     plugin_name = source.stem
     meta, is_main = fill_meta(meta, plugin_name, dist_path)
     settings.plugin_id = plugin_name


### PR DESCRIPTION
I propose this solution with skipping files that could not be read. It is less specific and can be useful not only for bypassing emacs links

replaces #789
closes #789 #788