### PR TITLE
Fix/cache render details

### DIFF
--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -401,8 +401,15 @@ window.Render.prototype.createPortalEntity = function (ent, details) {
   if (oldPortal) {
     // update marker style/highlight and layer
     marker = window.portals[data.guid];
-
     marker.updateDetails(data);
+
+    if (window.portalDetail.isFresh(guid)) {
+      var oldDetails = window.portalDetail.get(guid);
+      if (data.timestamp > oldDetails.timestamp) {
+        // data is more recent than the cached details so we remove them from the cache
+        window.portalDetail.remove(guid);
+      }
+    }
 
     window.runHooks('portalAdded', { portal: marker, previousData: previousData });
   } else {

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -209,8 +209,6 @@ window.Render.prototype.endRenderPass = function () {
 
   // reorder portals to be after links/fields
   this.bringPortalsToFront();
-
-  this.isRendering = false;
 };
 
 /**
@@ -424,11 +422,8 @@ window.Render.prototype.createPortalEntity = function (ent, details) {
     window.runHooks('portalAdded', { portal: marker });
 
     window.portals[data.guid] = marker;
-
-    if (window.selectedPortal === data.guid) {
-      marker.renderDetails();
-    }
   }
+
 
   window.ornaments.addPortal(marker);
 

--- a/core/code/portal_detail.js
+++ b/core/code/portal_detail.js
@@ -64,14 +64,19 @@ var handleResponse = function (deferred, guid, data, success) {
   }
 
   if (success) {
+    // Parse portal details
+    var dict = window.decodeArray.portal(data.result, 'detailed');
+    cache.store(guid, dict);
+
     // entity format, as used in map data
     var ent = [guid, data.result[13], data.result];
     var portal = window.mapDataRequest.render.createPortalEntity(ent, 'detailed');
 
+    // Update cache with from current map
     cache.store(guid, portal.options.data);
 
     deferred.resolve(portal.options.data);
-    window.runHooks('portalDetailLoaded', { guid: guid, success: success, details: portal.options.data, ent: ent });
+    window.runHooks('portalDetailLoaded', { guid: guid, success: success, details: portal.options.data, ent: ent, portal: portal });
   } else {
     if (data && data.error === 'RETRY') {
       // server asked us to try again

--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -65,7 +65,7 @@ window.renderPortalUrl = function (lat, lng, title, guid) {
 };
 
 /**
- * Renders the details of a portal in the sidebar.
+ * Selects a portal, refresh its data and renders the details of the portal in the sidebar.
  *
  * @function renderPortalDetails
  * @param {string|null} guid - The globally unique identifier of the portal to display details for.
@@ -73,8 +73,9 @@ window.renderPortalUrl = function (lat, lng, title, guid) {
  */
 window.renderPortalDetails = function (guid, forceSelect) {
   if (forceSelect || window.selectedPortal !== guid) {
-    window.selectPortal(window.portals[guid] ? guid : null, 'renderPortalDetails');
+    window.selectPortal(guid && window.portals[guid] ? guid : null, 'renderPortalDetails');
   }
+
   if ($('#sidebar').is(':visible')) {
     window.resetScrollOnNewPortal();
     window.renderPortalDetails.lastVisible = guid;
@@ -84,10 +85,7 @@ window.renderPortalDetails = function (guid, forceSelect) {
     window.portalDetail.request(guid);
   }
 
-  // TODO? handle the case where we request data for a particular portal GUID, but it *isn't* in
-  // window.portals....
-
-  if (!window.portals[guid]) {
+  if (!guid || !window.portals[guid]) {
     window.urlPortal = guid;
     $('#portaldetails').html('');
     if (window.isSmartphone()) {
@@ -97,7 +95,17 @@ window.renderPortalDetails = function (guid, forceSelect) {
     return;
   }
 
-  var portal = window.portals[guid];
+  window.renderPortalToSideBar(window.portals[guid]);
+};
+
+/**
+ * Renders the details of a portal in the sidebar.
+ *
+ * @function renderPortalToSideBar
+ * @param {L.PortalMarker} portal - The portal marker object holding portal details.
+ */
+window.renderPortalToSideBar = function (portal) {
+  var guid = portal.options.guid;
   var details = portal.getDetails();
   var hasFullDetails = portal.hasFullDetails();
   var historyDetails = window.getPortalHistoryDetails(details);

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -186,19 +186,7 @@ L.PortalMarker = L.CircleMarker.extend({
     };
     L.setOptions(this, dataOptions);
 
-    if (this._selected) {
-      this.renderDetails();
-    }
-
     this.setSelected();
-  },
-
-  renderDetails() {
-    if (!this._rendering) {
-      this._rendering = true;
-      window.renderPortalDetails(this._details.guid);
-      this._rendering = false;
-    }
   },
 
   getDetails: function () {

--- a/core/code/sidebar.js
+++ b/core/code/sidebar.js
@@ -18,6 +18,9 @@ window.setupSidebar = function () {
   setupLargeImagePreview();
   setupAddons();
   $('#sidebar').show();
+  // setup portal detail display update
+  window.addHook('portalAdded', sidebarOnPortalAdded);
+  window.addHook('portalDetailLoaded', sidebarOnPortalDetailLoaded);
 };
 
 /**
@@ -211,4 +214,24 @@ function setupAddons() {
   window.artifact.setup();
 
   window.RegionScoreboardSetup();
+}
+
+/**
+ *
+ * @function sidebarOnPortalAdded
+ */
+function sidebarOnPortalAdded(data) {
+  if (data.portal.guid === window.selectedPortal) {
+    window.renderPortalToSideBar(data.portal);
+  }
+}
+
+/**
+ *
+ * @function sidebarOnPortalDetailLoaded
+ */
+function sidebarOnPortalDetailLoaded(data) {
+  if (data.success && data.guid === window.selectedPortal) {
+    window.renderPortalDetails(window.selectedPortal);
+  }
 }

--- a/core/code/sidebar.js
+++ b/core/code/sidebar.js
@@ -217,21 +217,23 @@ function setupAddons() {
 }
 
 /**
+ * portalAdded callback to update the sidebar
  *
  * @function sidebarOnPortalAdded
  */
 function sidebarOnPortalAdded(data) {
-  if (data.portal.guid === window.selectedPortal) {
-    window.renderPortalToSideBar(data.portal);
+  if (data.portal.options.guid === window.selectedPortal) {
+    window.renderPortalDetails(window.selectedPortal);
   }
 }
 
 /**
+ * portalDetailLoaded callback to update the sidebar
  *
  * @function sidebarOnPortalDetailLoaded
  */
 function sidebarOnPortalDetailLoaded(data) {
   if (data.success && data.guid === window.selectedPortal) {
-    window.renderPortalDetails(window.selectedPortal);
+    window.renderPortalToSideBar(data.portal);
   }
 }

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -1438,6 +1438,7 @@ var setup = function () {
   }
 
   window.addHook('portalSelected', window.plugin.bookmarks.onPortalSelected);
+  window.addHook('portalDetailsUpdated', window.plugin.bookmarks.onPortalSelected);
   window.addHook('search', window.plugin.bookmarks.onSearch);
 
   // Sync

--- a/plugins/machina-tools.js
+++ b/plugins/machina-tools.js
@@ -359,13 +359,13 @@ function createInfoLink(text, title, clickCallback) {
   return aside;
 }
 
-machinaTools.onPortalDetailsUpdated = function () {
+machinaTools.onPortalDetailsUpdated = function (data) {
   var portalData;
 
   // If the portal was cleared then exit.
   if (window.selectedPortal === null) return;
 
-  portalData = window.portalDetail.get(window.selectedPortal);
+  portalData = data.portalData;
 
   if (portalData.team === window.TEAM_CODE_MAC) {
     var linkdetails = $('.linkdetails');

--- a/plugins/uniques.js
+++ b/plugins/uniques.js
@@ -45,14 +45,14 @@ window.plugin.uniques.contentHTML = null;
 
 window.plugin.uniques.isHighlightActive = false;
 
-window.plugin.uniques.onPortalDetailsUpdated = function () {
+window.plugin.uniques.onPortalDetailsUpdated = function (data) {
   if (typeof Storage === 'undefined') {
     $('#portaldetails > .imgpreview').after(window.plugin.uniques.disabledMessage);
     return;
   }
 
   var guid = window.selectedPortal,
-    details = window.portalDetail.get(guid),
+    details = data.portalDetails,
     nickname = window.PLAYER.nickname;
   if (details) {
     if (details.owner === nickname) {


### PR DESCRIPTION
Clarify `renderPortalDetails` : its selects, refresh and render portal details.
Split it in a select/refresh part and render part.

Revert part of fa3dddd66914537b9db748bec480bbb4cfd9d225

Invalidate cache entry if map data is inconsistent with portal details. (from map_data_render)

Hook portal details rendering on `portalAdded` and `portalDetailLoaded` event

Use hook data in unique/machina-tools plugins instead of using `portalDetail.get`.

I'm not satisfied with the data flow I've made for the permanent portal markers, as data is store in two places (portal marker and cache) and `createPortalEntity` is used to parse data for map data and portal details.
This fix a bit this issue by parsing portal details twice but it feels wrong to me.