### PR TITLE
Fix portal data synchronization between cache and hooks

### DIFF
--- a/core/code/portal_detail.js
+++ b/core/code/portal_detail.js
@@ -72,9 +72,6 @@ var handleResponse = function (deferred, guid, data, success) {
     var ent = [guid, data.result[13], data.result];
     var portal = window.mapDataRequest.render.createPortalEntity(ent, 'detailed');
 
-    // Update cache with from current map
-    cache.store(guid, portal.options.data);
-
     deferred.resolve(portal.options.data);
     window.runHooks('portalDetailLoaded', { guid: guid, success: success, details: portal.options.data, ent: ent, portal: portal });
   } else {

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -187,6 +187,9 @@ L.PortalMarker = L.CircleMarker.extend({
     L.setOptions(this, dataOptions);
 
     this.setSelected();
+    if (this.hasFullDetails()) {
+      window.portalDetail.store(this.options.guid, this._details);
+    }
   },
 
   getDetails: function () {


### PR DESCRIPTION
Fixed issue where plugins using window.portalDetail.get() could receive outdated data compared to portalDetailsUpdated hook data.
Centralized cache update logic in PortalMarker.updateDetails() to ensure cache and hook data are always in sync.