### PR TITLE
fix: missing portal indicators (access+range)

### DIFF
--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -431,6 +431,9 @@ window.Render.prototype.createPortalEntity = function (ent, details) {
     window.portals[data.guid] = marker;
   }
 
+  if (guid === window.selectedPortal) {
+    window.setPortalIndicators(marker);
+  }
 
   window.ornaments.addPortal(marker);
 


### PR DESCRIPTION
this fix a regression from the portal marker factoring `setPortalIndicators` is called from `selectPortal` that was called by `renderPortalDetails`.

Now, the function is called:
 - on click
 - on portal added if selected

It's called twice on click when portal defail is not fresh

Fix #797 