### PR TITLE
drawtools: add delete confirmation dialog

### DIFF
--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -1008,6 +1008,9 @@ function loadExternals() {
     // eslint-disable-next-line
     '@include_raw:external/leaflet.draw-geodesic.js@';
 
+    // eslint-disable-next-line
+    '@include_raw:external/leaflet.draw-confirm.js@';
+
     // support Leaflet >= 1
     // https://github.com/Leaflet/Leaflet.draw/pull/911
     L.Draw.Polyline.prototype.options.shapeOptions.interactive = true;

--- a/plugins/external/leaflet.draw-confirm.js
+++ b/plugins/external/leaflet.draw-confirm.js
@@ -1,0 +1,13 @@
+
+(function (removeAllLayers) {
+    L.EditToolbar.Delete.include({
+        removeAllLayers: function () {
+            if (confirm('Are you sure?')) {
+                removeAllLayers.call(this);
+            }
+        },
+        removeAllLayersDirect: function () {
+            removeAllLayers.call(this);
+        }
+    });
+})(L.EditToolbar.Delete.prototype.removeAllLayers);


### PR DESCRIPTION
show a classic "are you sure" before erasing all of your work

in other words: 
if you hit the "clear all" button in the drawtool bin button sub menu it will raise a confirmation dialog before removing all your drawings
