### PR TITLE
Expand `makePrimeLink()` into the component parts.

### DIFF
--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -380,6 +380,9 @@ window.rangeLinkClick = function () {
 /**
  * Creates a link to open a specific portal in Ingress Prime.
  *
+ * It is using Firebase's Dynamic Links feature.
+ * https://firebase.google.com/docs/dynamic-links/create-manually
+ *
  * @function makePrimeLink
  * @param {string} guid - The globally unique identifier of the portal.
  * @param {number} lat - The latitude of the portal.
@@ -387,7 +390,26 @@ window.rangeLinkClick = function () {
  * @returns {string} The Ingress Prime link for the portal
  */
 window.makePrimeLink = function (guid, lat, lng) {
-  return `https://link.ingress.com/?link=https%3A%2F%2Fintel.ingress.com%2Fportal%2F${guid}&apn=com.nianticproject.ingress&isi=576505181&ibi=com.google.ingress&ifl=https%3A%2F%2Fapps.apple.com%2Fapp%2Fingress%2Fid576505181&ofl=https%3A%2F%2Fintel.ingress.com%2Fintel%3Fpll%3D${lat}%2C${lng}`;
+  const base = 'https://link.ingress.com/';
+  const link = {
+    'link': `https://intel.ingress.com/portal/${guid}`,
+  };
+  const android = {
+    'apn': 'com.nianticproject.ingress',
+  };
+  const ios = {
+    'isi': '576505181',
+    'ibi': 'com.google.ingress',
+    'ifl': 'https://apps.apple.com/app/ingress/id576505181',
+  };
+  const other = {
+    'ofl': `https://intel.ingress.com/intel?pll=${lat},${lng}`,
+  };
+  const url = new URL(base);
+  for (const [key, value] of Object.entries({...link, ...android, ...ios, ...other})) {
+    url.searchParams.set(key, value);
+  }
+  return url.toString();
 };
 
 /**


### PR DESCRIPTION
There is no functional difference with this change; it just builds the URL on the fly.

Firebase is sunsetting this feature:
https://firebase.google.com/support/dynamic-links-faq

It is unknown if link.ingress.com still uses Firebase, or has implemented its own work-alike.  But by documenting it this way, it may help any future changes that come along.

Also, it opens up the possibility to customize links.  For example, I use a similar breakdown in a Python to create deep links that leaves off the `ios` portion, since I personally do not need them, and they are much shorter.