### PR TITLE
DrawTools: fix snap by creating a new object (closes #818)

### DIFF
--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -659,7 +659,7 @@ window.plugin.drawTools.snapToPortals = function () {
     if (minGuid) {
       var pll = window.portals[minGuid].getLatLng();
       if (pll.lat !== latlng.lat || pll.lng !== latlng.lng) {
-        return L.latLng(pll);
+        return new L.LatLng(pll.lat, pll.lng);
       }
     }
   };


### PR DESCRIPTION
find snap point return the coordination object instead of a new L.LatLng object

leaflets L.latLng(A) will return A if A is a L.LatLng object itself