### PR TITLE
makePermalink: Use `document.location.pathname` instead of `/`.

### DIFF
--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -444,6 +444,6 @@ window.makePermalink = function (latlng, options) {
   if (options.fullURL) {
     url += new URL(document.baseURI).origin;
   }
-  url += '/';
+  url += document.location.pathname;
   return url + '?' + args.join('&');
 };


### PR DESCRIPTION
When using https://intel.ingress.com, there will be no change.  When using https://intel.ingress.com/intel, it will use `/intel'.

Tested with all core features that use it as well as some pluging like player-activity-tracker, draw-tools, and portals-list.

Closes #684.