### PR TITLE
Fix：Hack Cooldown Time in Portal info panel enhanced

### DIFF
--- a/core/code/portal_info.js
+++ b/core/code/portal_info.js
@@ -349,7 +349,8 @@ window.getPortalHackDetails = function (d) {
   // first mod of type is fully effective, the others are only 50% effective
   var effectivenessReduction = [1, 0.5, 0.5, 0.5];
 
-  var cooldownTime = window.BASE_HACK_COOLDOWN;
+  var isFriendly = window.teamStringToId(d.team) === window.teamStringToId(window.PLAYER.team); 
+  var cooldownTime = isFriendly ? FACTION_HACK_COOLDOWN : window.BASE_HACK_COOLDOWN; 
 
   $.each(heatsinks, function (index, mod) {
     var hackSpeed = parseInt(mod.stats.HACK_SPEED) / 1000000;

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -490,6 +490,7 @@ window.MAX_RESO_PER_PLAYER = [0, 8, 4, 4, 4, 2, 2, 1, 1];
  * @memberof ingress_constants
  */
 window.BASE_HACK_COOLDOWN = 300; // 5 mins - 300 seconds
+window.FACTION_HACK_COOLDOWN = 180; // 3 min - 180 seconds
 
 /**
  * Base value, how many times at most you can hack the portal.


### PR DESCRIPTION
According to "https://ingress.com/news/q4-2022-tempchanges/":
> The following temporary change will return to its original value, effective starting Friday, September 30:
> Portal cooldown between hacks will be reverted to its original value of 300 seconds on neutral Portals and Portals aligned to the opposite Faction, up from 90 seconds.
> Portal cooldown between hacks will be 180 seconds on Portals aligned to the Agents’ Faction, up from 90 seconds

Modify the basic calculation value of the relevant information in the Portal info panel

Fix: #534  