### PR TITLE
Rescale Ornaments

### DIFF
--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -588,6 +588,8 @@ window.Render.prototype.rescalePortalMarkers = function () {
     // NOTE: we're not calling this because it resets highlights - we're calling it as it
     // resets the style (inc size) of all portal markers, applying the new scale
     window.resetHighlightedPortals();
+
+    window.ornaments.reload();    
   }
 };
 


### PR DESCRIPTION
At certain zoom levels portal marker will change scale. Ornaments never rescale. 

They are destroyed and created in correlation with the portal-marker.

But now portal markers only got recreated if data has changed and so ornamets keep their first style on every map-zoom level.