### PR TITLE
remove unused css style 'summary'

### DIFF
--- a/core/style.css
+++ b/core/style.css
@@ -444,17 +444,6 @@ mark {
   color: transparent;
 }
 
-/* divider */
-summary {
-  color: #bbb;
-  display: inline-block;
-  height: 16px;
-  overflow: hidden;
-  padding: 0 2px;
-  white-space: nowrap;
-  width: 100%;
-}
-
 #chatinput {
   position: absolute;
   bottom: 0;


### PR DESCRIPTION
summary is not used by IITC-CE anymore.
it was used in Chat->RenderDivider and was replaced.

Also it overwrites default HTML5 style. which is nice to use for foldable stuff (see: summary/details tag)