### PR TITLE
Modified MODs‘ display colors

### DIFF
--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -313,12 +313,12 @@ window.COLORS_LVL = ['#000', '#FECE5A', '#FFA630', '#FF7315', '#E40000', '#FD299
 /**
  * Colour values for displaying mods, consistent with Ingress. Very Rare also used for AXA shields and Ultra Links.
  * @type {object}
- * @property {string} VERY_RARE=#b08cff
- * @property {string} RARE=#73a8ff
- * @property {string} COMMON=#8cffbf
+ * @property {string} VERY_RARE=#F781FF
+ * @property {string} RARE=#B68BFF
+ * @property {string} COMMON=#49EBC3
  * @memberof config_options
  */
-window.COLORS_MOD = { VERY_RARE: '#b08cff', RARE: '#73a8ff', COMMON: '#8cffbf' };
+window.COLORS_MOD = { VERY_RARE: '#F781FF', RARE: '#B68BFF', COMMON: '#49EBC3' };
 
 /**
  * What colour should the hacking range circle be (the small circle that appears around a selected portal,


### PR DESCRIPTION
Based on the colors shown in the Ingress Prime client, adjust the display colors of MODs by rarity to better align with the visual effects.
Before：
![image](https://github.com/user-attachments/assets/b40382b4-4892-4b84-bba2-53a34b102960)

After：
![image](https://github.com/user-attachments/assets/14db4b41-7b50-4cc9-8992-d376723717ab)
