### PR TITLE
fix: update time format test locale for legacy Node.js compatibility

### DIFF
--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -183,7 +183,7 @@ describe('IITC.utils.unixTimeToString', () => {
     const timestamp = now.getTime();
     const timeString = IITC.utils.unixTimeToString(timestamp);
 
-    const timeFormatter = new Intl.DateTimeFormat('en-US', {
+    const timeFormatter = new Intl.DateTimeFormat('sv-SE', {
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',


### PR DESCRIPTION
Change test locale from en-US to sv-SE to match the implementation and avoid Node.js ICU bug where en-US displays midnight as "24:00:xx" instead of "00:00:xx" in Node.js v14-v18. Issue was fixed in v22+.

Ref: https://github.com/nodejs/node/issues/33089

fix https://github.com/IITC-CE/ingress-intel-total-conversion/issues/840