### PR TITLE
fix: sync user-location plugin state with location settings

### DIFF
--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_MigrationHelper.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_MigrationHelper.java
@@ -60,6 +60,18 @@ public class IITC_MigrationHelper {
             }
         }
 
+        // Sync user-location plugin with location settings
+        // This ensures that when user-location becomes a standard plugin,
+        // it matches the user's location preference setting
+        String locationMode = prefs.getString("pref_user_location_mode", "0");
+        boolean locationEnabled = !locationMode.equals("0");
+        boolean userLocationPluginEnabled = prefs.getBoolean("user-location.user.js", false);
+        
+        if (locationEnabled && !userLocationPluginEnabled) {
+            Log.d("Migration", "Enabling user-location plugin to match location settings");
+            editor.putBoolean("user-location.user.js", true);
+        }
+
         editor.putBoolean("saf_plugins_migrated", true);
         editor.apply();
 


### PR DESCRIPTION
Users updating from older versions may experience desync between location settings and user-location plugin state. If location was enabled (`pref_user_location_mode != "0"`) but the plugin defaults to disabled, location functionality breaks until manually toggled.

This fix targets release users who will receive both SAF migration and user-location plugin changes simultaneously, as beta users have already experienced this issue and likely resolved it manually by toggling location settings or the plugin checkbox.