### PR TITLE
fix: RegionScore tooltip rendering by adding selective escaping

### DIFF
--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -453,6 +453,26 @@ describe('IITC.utils.escapeHtml', () => {
     const result = IITC.utils.escapeHtml('No special chars');
     expect(result).to.equal('No special chars');
   });
+
+  it('should preserve allowed tags when provided', () => {
+    const result = IITC.utils.escapeHtml('<b>Bold</b> and <script>alert("XSS")</script>', ['b']);
+    expect(result).to.equal('<b>Bold</b> and &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;');
+  });
+
+  it('should preserve multiple allowed tags', () => {
+    const result = IITC.utils.escapeHtml('<b>Bold</b>, <i>Italic</i>, and <script>alert("XSS")</script>', ['b', 'i']);
+    expect(result).to.equal('<b>Bold</b>, <i>Italic</i>, and &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;');
+  });
+
+  it('should preserve self-closing tags like <hr>', () => {
+    const result = IITC.utils.escapeHtml('Text <hr> and <script>alert("XSS")</script>', ['hr']);
+    expect(result).to.equal('Text <hr> and &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;');
+  });
+
+  it('should preserve closing tags correctly', () => {
+    const result = IITC.utils.escapeHtml('<strong>Strong</strong> and <div>unsafe</div>', ['strong']);
+    expect(result).to.equal('<strong>Strong</strong> and &lt;div&gt;unsafe&lt;/div&gt;');
+  });
 });
 
 describe('IITC.utils.prettyEnergy', () => {


### PR DESCRIPTION
  - Fix RegionScore tooltip showing `<hr>` as text instead of HTML divider
  - Extend `escapeHtml` function to support selective HTML escaping with `allowedTags` parameter
  - Update `textToTable` to allow safe HTML tags: `hr`, `br`, `b`, `i`, `strong`, `em`
  - Add tests for new functionality

fix #844 