### PR TITLE
Add deep links support with permission management

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -36,6 +36,14 @@
             <data android:scheme="geo" />
         </intent>
 
+        <!-- Intel Map links for default handler checking -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" android:host="intel.ingress.com" />
+        </intent>
+
         <!-- Ingress Prime -->
         <package android:name="com.nianticproject.ingress" />
     </queries>

--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -107,6 +107,16 @@
                 <data android:scheme="geo"/>
             </intent-filter>
 
+            <!-- Handles iitc:// deep links -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+
+                <data android:scheme="iitc"/>
+            </intent-filter>
+
             <!-- Points to searchable meta data. -->
             <meta-data
                 android:name="android.app.searchable"

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_DeepLinkHandler.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_DeepLinkHandler.java
@@ -1,0 +1,95 @@
+package org.exarhteam.iitc_mobile;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.Settings;
+
+/**
+ * Helper class for managing deep link permissions and default handler status
+ */
+public class IITC_DeepLinkHandler {
+    private final Activity mActivity;
+    
+    public IITC_DeepLinkHandler(Activity activity) {
+        mActivity = activity;
+    }
+    
+    /**
+     * Check if the app is the default handler for Intel Map deep links
+     * @return true if app is default handler, false if not, null if can't check or not supported
+     */
+    public Boolean isDefaultDeepLinkHandler() {
+        if (mActivity == null) return null;
+        
+        // Only show deep link permission button on Android 12+ where system can reset the setting
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return null; // Hide button on older Android - system doesn't reset deep link settings
+        }
+        
+        try {
+            PackageManager packageManager = mActivity.getPackageManager();
+            String currentPackageName = mActivity.getPackageName();
+            
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(IITC_Mobile.getIntelUrl()));
+            
+            ResolveInfo resolveInfo = packageManager.resolveActivity(
+                intent, 
+                PackageManager.MATCH_DEFAULT_ONLY
+            );
+            
+            if (resolveInfo == null || resolveInfo.activityInfo == null) {
+                return false;
+            }
+            
+            return currentPackageName.equals(resolveInfo.activityInfo.packageName);
+        } catch (Exception e) {
+            Log.w("Error checking default deep link handler: " + e.getMessage());
+            return null;
+        }
+    }
+    
+    /**
+     * Open app deep link settings for the current app
+     * @return true if settings opened successfully
+     */
+    public boolean openDeepLinkSettings() {
+        if (mActivity == null) return false;
+        
+        try {
+            String packageName = mActivity.getPackageName();
+            Intent intent = new Intent(Settings.ACTION_APP_OPEN_BY_DEFAULT_SETTINGS);
+            intent.setData(Uri.parse("package:" + packageName));
+            
+            mActivity.startActivity(intent);
+            return true;
+        } catch (Exception e) {
+            Log.w("Error opening deep link settings: " + e.getMessage());
+            return false;
+        }
+    }
+    
+    /**
+     * Show dialog asking user to enable IITC Mobile as default deep link handler
+     */
+    public void showDeepLinkPermissionDialog() {
+        if (mActivity == null) return;
+        
+        new AlertDialog.Builder(mActivity)
+            .setTitle(R.string.deep_link_permission_dialog_title)
+            .setMessage(R.string.deep_link_permission_dialog_message)
+            .setPositiveButton(R.string.deep_link_permission_dialog_enable, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    openDeepLinkSettings();
+                }
+            })
+            .setNegativeButton(R.string.deep_link_permission_dialog_skip, null)
+            .show();
+    }
+}

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -453,6 +453,14 @@ public class IITC_Mobile extends AppCompatActivity
                     return;
                 }
             }
+            
+            if (uri.getScheme().equals("iitc")) {
+                // Convert iitc:// scheme to https://intel.ingress.com/ URL
+                String convertedUrl = mIntelUrl + uri.getSchemeSpecificPart();
+                Log.d("loading iitc deep link: " + uri.toString() + " -> " + convertedUrl);
+                loadUrl(convertedUrl);
+                return;
+            }
 
             if (uri.getScheme().equals("geo")) {
                 try {

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -1285,7 +1285,7 @@ public class IITC_Mobile extends AppCompatActivity
         return mUserLocation;
     }
 
-    public String getIntelUrl() {
+    public static String getIntelUrl() {
         return mIntelUrl;
     }
 

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/TileHttpHelper.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/TileHttpHelper.java
@@ -33,7 +33,7 @@ public class TileHttpHelper {
             userAgent = iitc.getDefaultUserAgent();
         }
         
-        String referer = iitc.getIntelUrl();
+        String referer = IITC_Mobile.getIntelUrl();
         
         // Set headers
         conn.setRequestProperty("User-Agent", userAgent);

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/fragments/MainSettings.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/fragments/MainSettings.java
@@ -18,6 +18,7 @@ import org.exarhteam.iitc_mobile.IntroActivity;
 import org.exarhteam.iitc_mobile.Log;
 import org.exarhteam.iitc_mobile.R;
 import org.exarhteam.iitc_mobile.prefs.AboutDialogPreference;
+import org.exarhteam.iitc_mobile.prefs.DeepLinkPermissionPreference;
 import org.exarhteam.iitc_mobile.prefs.ShareDebugInfoPreference;
 
 public class MainSettings extends PreferenceFragment {
@@ -78,6 +79,18 @@ public class MainSettings extends PreferenceFragment {
             Preference updateCheckPref = findPreference("pref_check_for_updates");
             PreferenceCategory mCategory = (PreferenceCategory) findPreference("pref_mics");
             mCategory.removePreference(updateCheckPref);
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        
+        // Notify deep link preference about activity resume
+        DeepLinkPermissionPreference deepLinkPref = 
+            (DeepLinkPermissionPreference) findPreference("pref_deep_link_permission");
+        if (deepLinkPref != null) {
+            deepLinkPref.onActivityResumed();
         }
     }
 

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/prefs/DeepLinkPermissionPreference.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/prefs/DeepLinkPermissionPreference.java
@@ -1,0 +1,112 @@
+package org.exarhteam.iitc_mobile.prefs;
+
+import android.app.Activity;
+import android.content.Context;
+import android.preference.Preference;
+import android.preference.PreferenceCategory;
+import android.preference.PreferenceManager;
+import android.util.AttributeSet;
+
+import org.exarhteam.iitc_mobile.IITC_DeepLinkHandler;
+
+/**
+ * Smart preference that manages deep link permissions and controls its own visibility
+ */
+public class DeepLinkPermissionPreference extends Preference {
+    
+    private IITC_DeepLinkHandler mDeepLinkHandler;
+    private PreferenceCategory mParentCategory;
+    private boolean mIsAttached = false;
+    
+    public DeepLinkPermissionPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+    
+    public DeepLinkPermissionPreference(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        init();
+    }
+    
+    private void init() {
+        // Initialize deep link handler when we have context
+        Context context = getContext();
+        if (context instanceof Activity) {
+            mDeepLinkHandler = new IITC_DeepLinkHandler((Activity) context);
+        }
+    }
+    
+    @Override
+    protected void onAttachedToHierarchy(PreferenceManager preferenceManager) {
+        super.onAttachedToHierarchy(preferenceManager);
+        mIsAttached = true;
+        
+        // Find parent category
+        if (getParent() instanceof PreferenceCategory) {
+            mParentCategory = (PreferenceCategory) getParent();
+        }
+        
+        // Update visibility after attachment
+        updateVisibility();
+    }
+    
+    @Override
+    protected void onAttachedToActivity() {
+        super.onAttachedToActivity();
+        
+        // Reinitialize handler with activity context
+        Context context = getContext();
+        if (context instanceof Activity) {
+            mDeepLinkHandler = new IITC_DeepLinkHandler((Activity) context);
+        }
+        
+        // Check visibility when activity becomes available
+        updateVisibility();
+    }
+    
+    /**
+     * Call this method when returning from system settings to update visibility
+     */
+    public void onActivityResumed() {
+        updateVisibility();
+    }
+    
+    @Override
+    protected void onClick() {
+        super.onClick();
+        
+        if (mDeepLinkHandler != null) {
+            mDeepLinkHandler.showDeepLinkPermissionDialog();
+        }
+    }
+    
+    /**
+     * Update preference visibility based on current deep link handler status
+     */
+    private void updateVisibility() {
+        if (!mIsAttached || mDeepLinkHandler == null) {
+            return;
+        }
+        
+        // Try to find parent category if we don't have it yet
+        if (mParentCategory == null && getParent() instanceof PreferenceCategory) {
+            mParentCategory = (PreferenceCategory) getParent();
+        }
+        
+        if (mParentCategory == null) {
+            return;
+        }
+        
+        Boolean isDefaultHandler = mDeepLinkHandler.isDefaultDeepLinkHandler();
+        
+        if (isDefaultHandler != null && isDefaultHandler) {
+            // Hide preference if app is already default handler
+            mParentCategory.removePreference(this);
+        } else {
+            // Show preference if app is not default handler
+            if (mParentCategory.findPreference(getKey()) == null) {
+                mParentCategory.addPreference(this);
+            }
+        }
+    }
+}

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -303,4 +303,12 @@
     <string name="migration_saf_message">IITC Mobile has been updated to use a more secure folder access system. Instead of accessing your entire storage, the app now only requests access to the IITC_Mobile folder.\n\nSince you have user plugins enabled, please grant access to the IITC_Mobile folder to continue using them.</string>
     <string name="migration_saf_button_grant">Grant Access</string>
     <string name="migration_saf_button_later">Later</string>
+
+    <!-- Deep link permission strings -->
+    <string name="pref_deep_link_permission">Open Intel links in IITC Mobile</string>
+    <string name="pref_deep_link_permission_summary">Configure IITC Mobile to handle Intel Map links</string>
+    <string name="deep_link_permission_dialog_title">Open links in IITC Mobile?</string>
+    <string name="deep_link_permission_dialog_message">You can set IITC Mobile to automatically open Intel Map links instead of using a browser</string>
+    <string name="deep_link_permission_dialog_enable">Enable</string>
+    <string name="deep_link_permission_dialog_skip">Skip</string>
 </resources>

--- a/mobile/app/src/main/res/xml/preferences.xml
+++ b/mobile/app/src/main/res/xml/preferences.xml
@@ -79,6 +79,10 @@
             android:key="pref_persistent_zoom"
             android:summary="@string/pref_persistent_zoom_sum"
             android:title="@string/pref_persistent_zoom"/>
+        <org.exarhteam.iitc_mobile.prefs.DeepLinkPermissionPreference
+            android:key="pref_deep_link_permission"
+            android:title="@string/pref_deep_link_permission"
+            android:summary="@string/pref_deep_link_permission_summary"/>
     </PreferenceCategory>
     <PreferenceCategory
         android:key="pref_mics"


### PR DESCRIPTION
This PR adds support for iitc:// custom scheme deep links and Intel Map link permission management.

- Added support for `iitc://` scheme URLs that automatically convert to `https://intel.ingress.com/` format
- Added smart permission button in Settings > Tweaks that shows only when app is not the default handler for Intel Map links, with dialog to open system link settings
- Button automatically hides on Android versions below API 31 where system doesn't reset deep link permissions