### PR TITLE
fix: no library object reference for tidy-links

### DIFF
--- a/plugins/tidy-links.js
+++ b/plugins/tidy-links.js
@@ -183,6 +183,10 @@ function loadDelaunay() {
     // eslint-disable-next-line
     '@include_raw:external/delaunay.js@';
 
+    if (typeof window.Delaunay === 'undefined') {
+      window.Delaunay = Delaunay; // eslint-disable-line no-undef
+    }
+
     return window.Delaunay;
   } catch (e) {
     console.error('delaunay.js loading failed');


### PR DESCRIPTION
The external library used creates an object in the current scope but one in the window was needed.