### PR TITLE
Range display isn't updated on detail load

### DIFF
--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -190,11 +190,12 @@ window.renderPortalToSideBar = function (portal) {
 
   window.renderPortalUrl(lat, lng, title, guid);
 
-  // compatibility
-  var data = hasFullDetails ? window.getPortalSummaryData(details) : details;
   // only run the hooks when we have a portalDetails object - most plugins rely on the extended data
   // TODO? another hook to call always, for any plugins that can work with less data?
   if (hasFullDetails) {
+    // compatibility
+    var data = window.getPortalSummaryData(details);
+
     window.runHooks('portalDetailsUpdated', { guid: guid, portal: portal, portalDetails: details, portalData: data });
 
     window.setPortalIndicators(portal);

--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -192,11 +192,12 @@ window.renderPortalToSideBar = function (portal) {
 
   // compatibility
   var data = hasFullDetails ? window.getPortalSummaryData(details) : details;
-
   // only run the hooks when we have a portalDetails object - most plugins rely on the extended data
   // TODO? another hook to call always, for any plugins that can work with less data?
   if (hasFullDetails) {
     window.runHooks('portalDetailsUpdated', { guid: guid, portal: portal, portalDetails: details, portalData: data });
+
+    window.setPortalIndicators(portal);
   }
 };
 


### PR DESCRIPTION
When selecting a portal, the link range is only displayed when details are already loaded.
But it obviously loads afterward.

This updates the circles when the details are loading:

