### PR TITLE
enhance unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "build:local": "./build.py local",
     "build:mobile": "./build.py mobile",
     "fileserver": "./web_server_local.py local",
-    "test": "mocha --exit"
+    "test": "mocha -r test/_mocks.js --exit"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jsdoc": "^4.0.4",
     "mocha": "^10.1.0",
     "prettier": "^3.3.3",
+    "sinon": "^21.0.0",
     "taffydb": "^2.7.3",
     "tui-jsdoc-template": "^1.2.2"
   },

--- a/test/_mocks.js
+++ b/test/_mocks.js
@@ -1,0 +1,53 @@
+/* global L */
+class Map {
+  addTo() {}
+  addLayer() {}
+  removeLayer() {}
+  setView() {}
+}
+
+// global objects
+globalThis.document = {};
+globalThis.window = {
+  location: {},
+  map: new Map(),
+  runHooks: () => {},
+  isSmartphone: () => false,
+  TEAM_SHORTNAMES: { NEUTRAL: 'NEU', ENLIGHTENED: 'ENL' },
+  COLORS: { NEUTRAL: '#CCC', ENLIGHTENED: '#008000' },
+  teamStringToId: (team) => (team === 'ENLIGHTENED' ? 'ENLIGHTENED' : 'NEUTRAL'),
+};
+
+// leaflet
+globalThis.L = {
+  LatLng: class {},
+  latLng: (lat, lng) => new L.LatLng(lat, lng),
+  LayerGroup: class {
+    addTo() {}
+  },
+  layerGroup: () => new L.LayerGroup(),
+  Marker: class {
+    addTo() {}
+  },
+  marker: () => new L.Marker(),
+  DivIcon: {
+    ColoredSvg: class {},
+  },
+};
+
+// iitc
+globalThis.IITC = {
+  search: {
+    Query: {},
+  },
+  comm: {},
+  utils: {},
+};
+
+globalThis.IITC.search.QueryResultsView = class {
+  constructor(term, confirmed) {
+    this.term = term;
+    this.confirmed = confirmed;
+  }
+  renderResults() {}
+};

--- a/test/_mocks.js
+++ b/test/_mocks.js
@@ -7,7 +7,7 @@ class Map {
 }
 
 // global objects
-globalThis.document = {};
+globalThis.document = { createElement: () => {} };
 globalThis.window = {
   location: {},
   map: new Map(),
@@ -32,6 +32,9 @@ globalThis.L = {
   marker: () => new L.Marker(),
   DivIcon: {
     ColoredSvg: class {},
+  },
+  divIcon: {
+    coloredSvg: () => new L.DivIcon.ColoredSvg(),
   },
 };
 

--- a/test/comm_declarative_message_filter.spec.js
+++ b/test/comm_declarative_message_filter.spec.js
@@ -4,8 +4,6 @@ import { expect } from 'chai';
 /* global IITC */
 /* eslint-disable no-unused-expressions */
 
-if (!globalThis.IITC) globalThis.IITC = {};
-globalThis.IITC.comm = {};
 import('../core/code/comm_declarative_message_filter.js');
 
 // Define test messages

--- a/test/search_query.spec.js
+++ b/test/search_query.spec.js
@@ -4,57 +4,12 @@ import { expect } from 'chai';
 /* global IITC, L */
 /* eslint-disable no-unused-expressions */
 
-if (!globalThis.window) globalThis.window = {};
-if (!globalThis.L) globalThis.L = {};
-if (!globalThis.IITC) globalThis.IITC = {};
-if (!globalThis.IITC.search) globalThis.IITC.search = {};
-globalThis.IITC.search.Query = {};
 import('../core/code/search_query.js');
 
 describe('IITC.search.Query', () => {
   let query;
-  let fakeMap;
 
   beforeEach(() => {
-    // Mock objects and methods
-    fakeMap = {
-      addTo: () => {},
-      addLayer: () => {},
-    };
-
-    globalThis.window = {
-      ...globalThis.window,
-      ...{
-        map: fakeMap,
-        runHooks: () => {},
-        isSmartphone: () => false,
-        TEAM_SHORTNAMES: { NEUTRAL: 'NEU', ENLIGHTENED: 'ENL' },
-        COLORS: { NEUTRAL: '#CCC', ENLIGHTENED: '#008000' },
-        teamStringToId: (team) => (team === 'ENLIGHTENED' ? 'ENLIGHTENED' : 'NEUTRAL'),
-      },
-    };
-
-    globalThis.L = {
-      ...globalThis.L,
-      ...{
-        LatLng: class {},
-        latLng: (lat, lng) => new L.LatLng(lat, lng),
-        layerGroup: () => fakeMap,
-        marker: () => fakeMap,
-        divIcon: {
-          coloredSvg: () => {},
-        },
-      },
-    };
-
-    globalThis.IITC.search.QueryResultsView = class {
-      constructor(term, confirmed) {
-        this.term = term;
-        this.confirmed = confirmed;
-      }
-      renderResults() {}
-    };
-
     query = new IITC.search.Query('test', true);
   });
 
@@ -110,7 +65,7 @@ describe('IITC.search.Query', () => {
     const mockResult = { title: 'Hover Result', layer: null, position: new L.LatLng(0, 0) };
     let layerAdded = false;
 
-    fakeMap.addLayer = () => {
+    window.map.addLayer = () => {
       layerAdded = true;
     };
     query.onResultHoverStart(mockResult);
@@ -132,11 +87,11 @@ describe('IITC.search.Query', () => {
   });
 
   it('should remove hover interaction layer from map', () => {
-    const mockResult = { layer: fakeMap };
+    const mockResult = { layer: window.map };
     let layerRemoved = false;
 
     query.hoverResult = mockResult;
-    fakeMap.removeLayer = () => {
+    window.map.removeLayer = () => {
       layerRemoved = true;
     };
 
@@ -153,7 +108,7 @@ describe('IITC.search.Query', () => {
     };
     let viewSet = false;
 
-    fakeMap.setView = () => {
+    window.map.setView = () => {
       viewSet = true;
     };
     query.onResultSelected(mockResult, { type: 'click' });
@@ -166,7 +121,7 @@ describe('IITC.search.Query', () => {
     const mockResult = { title: 'Selected Result', onSelected: () => true };
     let viewSet = false;
 
-    fakeMap.setView = () => {
+    window.map.setView = () => {
       viewSet = true;
     };
     query.onResultSelected(mockResult, { type: 'click' });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -4,11 +4,6 @@ import { expect } from 'chai';
 /* global IITC */
 /* eslint-disable no-unused-expressions */
 
-if (!globalThis.document) globalThis.document = {};
-if (!globalThis.window) globalThis.window = {};
-globalThis.window.location = {};
-if (!globalThis.IITC) globalThis.IITC = {};
-globalThis.IITC.utils = {};
 import('../core/code/utils.js');
 
 describe('IITC.utils.getURLParam', () => {


### PR DESCRIPTION
- moved mocked functions to extra file `_mocks.js`
- use 'Sinon' to spy/mock functions call

I was not able to import Leaflet, JQuery or jsDom to have a complete the base function setup.
The different environments makes it real hard (node, browser, modul, commonjs,... whatever)

In other projects I (tried jest and then) switched to vitest but I can't say if it would be a solution here too.