### PR TITLE
Preparing Leaflet v2 - remove factory function calls

### DIFF
--- a/core/code/_deprecated.js
+++ b/core/code/_deprecated.js
@@ -211,16 +211,3 @@ window.renderUpdateStatus = function () {
 window.smartphoneInfo = function (selectedPortalData) {
   return IITC.statusbar.portal.update(selectedPortalData);
 };
-
-/**
- * Leaflet v2 backwards compability
- */
-/** @deprecated use: d = new L.DivIcon() */
-L.divIcon = function (options) {
-  return new L.DivIcon(options);
-};
-
-/** @deprecated use: d = new L.DivIcon.ColoredSvg() */
-L.divIcon.coloredSvg = function (color, options) {
-  return new L.DivIcon.ColoredSvg(color, options);
-};

--- a/core/code/_deprecated.js
+++ b/core/code/_deprecated.js
@@ -134,7 +134,7 @@ window.findPortalLatLng = function (guid) {
   // not found in portals - try the cached (and possibly stale) details - good enough for location
   var details = window.portalDetail.get(guid);
   if (details) {
-    return L.latLng(details.latE6 / 1e6, details.lngE6 / 1e6);
+    return new L.LatLng(details.latE6 / 1e6, details.lngE6 / 1e6);
   }
 
   // now try searching through fields
@@ -143,7 +143,7 @@ window.findPortalLatLng = function (guid) {
 
     for (var i in f.points) {
       if (f.points[i].guid === guid) {
-        return L.latLng(f.points[i].latE6 / 1e6, f.points[i].lngE6 / 1e6);
+        return new L.LatLng(f.points[i].latE6 / 1e6, f.points[i].lngE6 / 1e6);
       }
     }
   }
@@ -152,10 +152,10 @@ window.findPortalLatLng = function (guid) {
   for (var lguid in window.links) {
     var l = window.links[lguid].options.data;
     if (l.oGuid === guid) {
-      return L.latLng(l.oLatE6 / 1e6, l.oLngE6 / 1e6);
+      return new L.LatLng(l.oLatE6 / 1e6, l.oLngE6 / 1e6);
     }
     if (l.dGuid === guid) {
-      return L.latLng(l.dLatE6 / 1e6, l.dLngE6 / 1e6);
+      return new L.LatLng(l.dLatE6 / 1e6, l.dLngE6 / 1e6);
     }
   }
 

--- a/core/code/_deprecated.js
+++ b/core/code/_deprecated.js
@@ -211,3 +211,16 @@ window.renderUpdateStatus = function () {
 window.smartphoneInfo = function (selectedPortalData) {
   return IITC.statusbar.portal.update(selectedPortalData);
 };
+
+/**
+ * Leaflet v2 backwards compability
+ */
+/** @deprecated use: d = new L.DivIcon() */
+L.divIcon = function (options) {
+  return new L.DivIcon(options);
+};
+
+/** @deprecated use: d = new L.DivIcon.ColoredSvg() */
+L.divIcon.coloredSvg = function (color, options) {
+  return new L.DivIcon.ColoredSvg(color, options);
+};

--- a/core/code/artifact.js
+++ b/core/code/artifact.js
@@ -271,7 +271,7 @@ window.artifact.updateLayer = function () {
           iconAnchor: [iconSize / 2, iconSize / 2],
         });
 
-        const marker = L.marker(latlng, { icon: icon, interactive: false, keyboard: false, opacity: opacity });
+        const marker = new L.Marker(latlng, { icon: icon, interactive: false, keyboard: false, opacity: opacity });
 
         window.artifact._layer.addLayer(marker);
       } else if (data[type].fragments) {
@@ -287,7 +287,7 @@ window.artifact.updateLayer = function () {
           iconAnchor: [iconSize / 2, iconSize / 2],
         });
 
-        const marker = L.marker(latlng, { icon: icon, interactive: false, keyboard: false, opacity: opacity });
+        const marker = new L.Marker(latlng, { icon: icon, interactive: false, keyboard: false, opacity: opacity });
 
         window.artifact._layer.addLayer(marker);
       }

--- a/core/code/artifact.js
+++ b/core/code/artifact.js
@@ -253,7 +253,7 @@ window.artifact.updateLayer = function () {
   window.artifact._layer.clearLayers();
 
   $.each(window.artifact.portalInfo, function (guid, data) {
-    var latlng = L.latLng([data._data.latE6 / 1e6, data._data.lngE6 / 1e6]);
+    var latlng = new L.LatLng([data._data.latE6 / 1e6, data._data.lngE6 / 1e6]);
 
     $.each(data, function (type) {
       // we'll construct the URL form the type - stock seems to do that now

--- a/core/code/artifact.js
+++ b/core/code/artifact.js
@@ -265,7 +265,7 @@ window.artifact.updateLayer = function () {
         iconSize = 100 / 2;
         opacity = 1.0;
 
-        const icon = L.icon({
+        const icon = new L.Icon({
           iconUrl: iconUrl,
           iconSize: [iconSize, iconSize],
           iconAnchor: [iconSize / 2, iconSize / 2],
@@ -281,7 +281,7 @@ window.artifact.updateLayer = function () {
         iconSize = 60 / 2;
         opacity = 0.6;
 
-        const icon = L.icon({
+        const icon = new L.Icon({
           iconUrl: iconUrl,
           iconSize: [iconSize, iconSize],
           iconAnchor: [iconSize / 2, iconSize / 2],

--- a/core/code/boot.js
+++ b/core/code/boot.js
@@ -79,7 +79,7 @@ function setupIngressMarkers() {
       // ^ (as it's inappropriately styled)
       svgTemplate: '<svg style="fill: {color}"><use xlink:href="#marker-icon"/></svg>',
       color: '#a24ac3', // for draw-tools:
-      // L.divIcon does not use the option `color`, but we store it here to
+      // L.DivIcon does not use the option `color`, but we store it here to
       // be able to simply retrieve the color for serializing markers
     },
     initialize: function (color, options) {
@@ -90,9 +90,6 @@ function setupIngressMarkers() {
       this.options.html = L.Util.template(this.options.svgTemplate, { color: this.options.color });
     },
   });
-  L.divIcon.coloredSvg = function (color, options) {
-    return new L.DivIcon.ColoredSvg(color, options);
-  };
 }
 
 /**

--- a/core/code/boot.js
+++ b/core/code/boot.js
@@ -90,6 +90,17 @@ function setupIngressMarkers() {
       this.options.html = L.Util.template(this.options.svgTemplate, { color: this.options.color });
     },
   });
+
+  // Leaflet v2 backwards compability
+  /** @deprecated use: d = new L.DivIcon() */
+  L.divIcon = function (options) {
+    return new L.DivIcon(options);
+  };
+
+  /** @deprecated use: d = new L.DivIcon.ColoredSvg() */
+  L.divIcon.coloredSvg = function (color, options) {
+    return new L.DivIcon.ColoredSvg(color, options);
+  };
 }
 
 /**

--- a/core/code/map.js
+++ b/core/code/map.js
@@ -120,7 +120,7 @@ function createDefaultBaseMapLayers() {
   baseLayers['CartoDB Positron'] = L.tileLayer(cartoUrl, { attribution: cartoAttr, theme: 'light_all' });
 
   // Google Maps - including ingress default (using the stock-intel API-key)
-  baseLayers['Google Default Ingress Map'] = L.gridLayer.googleMutant({
+  baseLayers['Google Default Ingress Map'] = new L.GridLayer.GoogleMutant({
     type: 'roadmap',
     backgroundColor: '#0e3d4e',
     styles: [
@@ -131,16 +131,16 @@ function createDefaultBaseMapLayers() {
       { featureType: 'road', elementType: 'labels.icon', stylers: [{ invert_lightness: !0 }] },
     ],
   });
-  baseLayers['Google Roads'] = L.gridLayer.googleMutant({ type: 'roadmap' });
-  var trafficMutant = L.gridLayer.googleMutant({ type: 'roadmap' });
+  baseLayers['Google Roads'] = new L.GridLayer.GoogleMutant({ type: 'roadmap' });
+  var trafficMutant = new L.GridLayer.GoogleMutant({ type: 'roadmap' });
   trafficMutant.addGoogleLayer('TrafficLayer');
   baseLayers['Google Roads + Traffic'] = trafficMutant;
-  var transitMutant = L.gridLayer.googleMutant({ type: 'roadmap' });
+  var transitMutant = new L.GridLayer.GoogleMutant({ type: 'roadmap' });
   transitMutant.addGoogleLayer('TransitLayer');
   baseLayers['Google Roads + Transit'] = transitMutant;
-  baseLayers['Google Satellite'] = L.gridLayer.googleMutant({ type: 'satellite' });
-  baseLayers['Google Hybrid'] = L.gridLayer.googleMutant({ type: 'hybrid' });
-  baseLayers['Google Terrain'] = L.gridLayer.googleMutant({ type: 'terrain' });
+  baseLayers['Google Satellite'] = new L.GridLayer.GoogleMutant({ type: 'satellite' });
+  baseLayers['Google Hybrid'] = new L.GridLayer.GoogleMutant({ type: 'hybrid' });
+  baseLayers['Google Terrain'] = new L.GridLayer.GoogleMutant({ type: 'terrain' });
 
   return baseLayers;
 }

--- a/core/code/map_data_debug.js
+++ b/core/code/map_data_debug.js
@@ -8,7 +8,7 @@ window.RenderDebugTiles = function () {
   this.CLEAR_CHECK_TIME = 0.1;
   this.FADE_TIME = 1.0;
 
-  this.debugTileLayer = L.layerGroup();
+  this.debugTileLayer = new L.LayerGroup();
   window.layerChooser.addOverlay(this.debugTileLayer, 'DEBUG Data Tiles', { default: false });
 
   this.debugTileToRectangle = {};

--- a/core/code/map_data_debug.js
+++ b/core/code/map_data_debug.js
@@ -41,7 +41,7 @@ window.RenderDebugTiles.prototype.create = function (id, bounds) {
   bounds = new L.LatLngBounds(bounds);
   bounds = bounds.pad(-0.02);
 
-  var l = L.rectangle(bounds, s);
+  var l = new L.Rectangle(bounds, s);
   this.debugTileToRectangle[id] = l;
   this.debugTileLayer.addLayer(l);
   if (window.map.hasLayer(this.debugTileLayer)) {

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -67,7 +67,7 @@ window.Render.prototype.clearLinksOutsideBounds = function (bounds) {
     // NOTE: our geodesic lines can have lots of intermediate points. the bounds calculation hasn't been optimised for this
     // so can be particularly slow. a simple bounds check based on start+end point will be good enough for this check
     var lls = l.getLatLngs();
-    var linkBounds = L.latLngBounds(lls);
+    var linkBounds = new L.LatLngBounds(lls);
 
     if (!bounds.intersects(linkBounds)) {
       this.deleteLinkEntity(guid);
@@ -89,7 +89,7 @@ window.Render.prototype.clearFieldsOutsideBounds = function (bounds) {
     // NOTE: our geodesic polys can have lots of intermediate points. the bounds calculation hasn't been optimised for this
     // so can be particularly slow. a simple bounds check based on corner points will be good enough for this check
     var lls = f.getLatLngs();
-    var fieldBounds = L.latLngBounds([lls[0], lls[1]]).extend(lls[2]);
+    var fieldBounds = new L.LatLngBounds([lls[0], lls[1]]).extend(lls[2]);
 
     if (!bounds.intersects(fieldBounds)) {
       this.deleteFieldEntity(guid);
@@ -378,7 +378,7 @@ window.Render.prototype.createPortalEntity = function (ent, details) {
     previousData = $.extend(true, {}, p.getDetails());
   }
 
-  var latlng = L.latLng(data.latE6 / 1e6, data.lngE6 / 1e6);
+  var latlng = new L.LatLng(data.latE6 / 1e6, data.lngE6 / 1e6);
 
   window.pushPortalGuidPositionCache(data.guid, data.latE6, data.lngE6);
 
@@ -481,9 +481,9 @@ window.Render.prototype.createFieldEntity = function (ent) {
 
   var team = window.teamStringToId(ent[2][1]);
   var latlngs = [
-    L.latLng(data.points[0].latE6 / 1e6, data.points[0].lngE6 / 1e6),
-    L.latLng(data.points[1].latE6 / 1e6, data.points[1].lngE6 / 1e6),
-    L.latLng(data.points[2].latE6 / 1e6, data.points[2].lngE6 / 1e6),
+    new L.LatLng(data.points[0].latE6 / 1e6, data.points[0].lngE6 / 1e6),
+    new L.LatLng(data.points[1].latE6 / 1e6, data.points[1].lngE6 / 1e6),
+    new L.LatLng(data.points[2].latE6 / 1e6, data.points[2].lngE6 / 1e6),
   ];
 
   var poly = L.geodesicPolygon(latlngs, {
@@ -552,7 +552,7 @@ window.Render.prototype.createLinkEntity = function (ent) {
   }
 
   var team = window.teamStringToId(ent[2][1]);
-  var latlngs = [L.latLng(data.oLatE6 / 1e6, data.oLngE6 / 1e6), L.latLng(data.dLatE6 / 1e6, data.dLngE6 / 1e6)];
+  var latlngs = [new L.LatLng(data.oLatE6 / 1e6, data.oLngE6 / 1e6), new L.LatLng(data.dLatE6 / 1e6, data.dLngE6 / 1e6)];
   var poly = L.geodesicPolyline(latlngs, {
     color: window.COLORS[team],
     opacity: 1,
@@ -589,7 +589,7 @@ window.Render.prototype.rescalePortalMarkers = function () {
     // resets the style (inc size) of all portal markers, applying the new scale
     window.resetHighlightedPortals();
 
-    window.ornaments.reload();    
+    window.ornaments.reload();
   }
 };
 

--- a/core/code/map_data_request.js
+++ b/core/code/map_data_request.js
@@ -257,7 +257,7 @@ window.MapDataRequest.prototype.refresh = function () {
   // DEBUG: resize the bounds so we only retrieve some data
   // bounds = bounds.pad(-0.4);
 
-  // var debugrect = L.rectangle(bounds,{color: 'red', fill: false, weight: 4, opacity: 0.8}).addTo(map);
+  // var debugrect = new L.Rectangle(bounds,{color: 'red', fill: false, weight: 4, opacity: 0.8}).addTo(map);
   // setTimeout (function(){ map.removeLayer(debugrect); }, 10*1000);
 
   var x1 = window.lngToTile(bounds.getWest(), tileParams);
@@ -270,7 +270,7 @@ window.MapDataRequest.prototype.refresh = function () {
     [window.tileToLat(y2 + 1, tileParams), window.tileToLng(x1, tileParams)],
     [window.tileToLat(y1, tileParams), window.tileToLng(x2 + 1, tileParams)],
   ]);
-  // var debugrect2 = L.rectangle(dataBounds,{color: 'magenta', fill: false, weight: 4, opacity: 0.8}).addTo(map);
+  // var debugrect2 = new L.Rectangle(dataBounds,{color: 'magenta', fill: false, weight: 4, opacity: 0.8}).addTo(map);
   // setTimeout (function(){ map.removeLayer(debugrect2); }, 10*1000);
 
   // store the parameters used for fetching the data. used to prevent unneeded refreshes after move/zoom

--- a/core/code/map_data_request.js
+++ b/core/code/map_data_request.js
@@ -266,7 +266,7 @@ window.MapDataRequest.prototype.refresh = function () {
   var y2 = window.latToTile(bounds.getSouth(), tileParams);
 
   // calculate the full bounds for the data - including the part of the tiles off the screen edge
-  var dataBounds = L.latLngBounds([
+  var dataBounds = new L.LatLngBounds([
     [window.tileToLat(y2 + 1, tileParams), window.tileToLng(x1, tileParams)],
     [window.tileToLat(y1, tileParams), window.tileToLng(x2 + 1, tileParams)],
   ]);
@@ -325,7 +325,7 @@ window.MapDataRequest.prototype.refresh = function () {
 
         var latCenter = (latNorth + latSouth) / 2;
         var lngCenter = (lngEast + lngWest) / 2;
-        var tileLatLng = L.latLng(latCenter, lngCenter);
+        var tileLatLng = new L.LatLng(latCenter, lngCenter);
 
         var tilePoint = window.map.project(tileLatLng, mapZoom);
 

--- a/core/code/ornaments.js
+++ b/core/code/ornaments.js
@@ -171,7 +171,7 @@ window.ornaments = {
           layer = this.layers['Excluded ornaments'];
         }
 
-        return L.marker(portal.getLatLng(), {
+        return new L.Marker(portal.getLatLng(), {
           icon: new L.Icon({
             iconUrl: iconUrl,
             iconSize: [size, size],

--- a/core/code/ornaments.js
+++ b/core/code/ornaments.js
@@ -83,7 +83,7 @@ window.ornaments = {
    */
   setup: function () {
     this._portals = {};
-    this.layerGroup = L.layerGroup;
+    this.layerGroup = () => new L.LayerGroup();
     if (window.map.options.preferCanvas && L.Browser.canvas && !window.DISABLE_CANVASICONLAYER) {
       this.layerGroup = L.canvasIconLayer;
       L.CanvasIconLayer.mergeOptions({ padding: L.Canvas.prototype.options.padding });

--- a/core/code/ornaments.js
+++ b/core/code/ornaments.js
@@ -172,7 +172,7 @@ window.ornaments = {
         }
 
         return L.marker(portal.getLatLng(), {
-          icon: L.icon({
+          icon: new L.Icon({
             iconUrl: iconUrl,
             iconSize: [size, size],
             iconAnchor: anchor, // https://github.com/IITC-CE/Leaflet.Canvas-Markers/issues/4

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -106,7 +106,7 @@ L.PortalMarker = L.CircleMarker.extend({
     if (this._details) {
       // portal has been moved
       if (this._details.latE6 !== details.latE6 || this._details.lngE6 !== details.lngE6) {
-        this.setLatLng(L.latLng(details.latE6 / 1e6, details.lngE6 / 1e6));
+        this.setLatLng(new L.LatLng(details.latE6 / 1e6, details.lngE6 / 1e6));
       }
 
       // core data from a placeholder

--- a/core/code/search.js
+++ b/core/code/search.js
@@ -11,7 +11,7 @@
  * window.addHook('search', function(query) {
  *   query.addResult({
  *     title: 'My Result',
- *     position: L.latLng(0, 0)
+ *     position: new L.LatLng(0, 0)
  *   });
  * });
  *

--- a/core/code/search_hooks.js
+++ b/core/code/search_hooks.js
@@ -150,7 +150,7 @@ window.addHook('search', async (query) => {
             fill: false,
             pointToLayer: (featureData, latLng) =>
               L.marker(latLng, {
-                icon: L.divIcon.coloredSvg('red'),
+                icon: new L.DivIcon.ColoredSvg('red'),
                 title: item.display_name,
               }),
           });

--- a/core/code/search_hooks.js
+++ b/core/code/search_hooks.js
@@ -59,7 +59,7 @@ window.addHook('search', (query) => {
     query.addResult({
       title: latLngString,
       description: 'geo coordinates',
-      position: L.latLng(lat, lng),
+      position: new L.LatLng(lat, lng),
       onSelected: (result) => {
         for (const [guid, portal] of Object.entries(window.portals)) {
           const { lat: pLat, lng: pLng } = portal.getLatLng();
@@ -137,7 +137,7 @@ window.addHook('search', async (query) => {
         const result = {
           title: item.display_name,
           description: `Type: ${item.type}`,
-          position: L.latLng(parseFloat(item.lat), parseFloat(item.lon)),
+          position: new L.LatLng(parseFloat(item.lat), parseFloat(item.lon)),
           icon: item.icon,
         };
 
@@ -158,7 +158,7 @@ window.addHook('search', async (query) => {
 
         if (item.boundingbox) {
           const [south, north, west, east] = item.boundingbox;
-          result.bounds = new L.LatLngBounds(L.latLng(parseFloat(south), parseFloat(west)), L.latLng(parseFloat(north), parseFloat(east)));
+          result.bounds = new L.LatLngBounds(new L.LatLng(parseFloat(south), parseFloat(west)), new L.LatLng(parseFloat(north), parseFloat(east)));
         }
 
         query.addResult(result);

--- a/core/code/search_hooks.js
+++ b/core/code/search_hooks.js
@@ -149,7 +149,7 @@ window.addHook('search', async (query) => {
             weight: 2,
             fill: false,
             pointToLayer: (featureData, latLng) =>
-              L.marker(latLng, {
+              new L.Marker(latLng, {
                 icon: new L.DivIcon.ColoredSvg('red'),
                 title: item.display_name,
               }),

--- a/core/code/search_query.js
+++ b/core/code/search_query.js
@@ -201,7 +201,7 @@ class Query {
 
       if (result.position) {
         L.marker(result.position, {
-          icon: L.divIcon.coloredSvg('red'),
+          icon: new L.DivIcon.ColoredSvg('red'),
           title: result.title,
         }).addTo(result.layer);
       }

--- a/core/code/search_query.js
+++ b/core/code/search_query.js
@@ -105,7 +105,7 @@ class Query {
   addPortalResult(data, guid) {
     const team = window.teamStringToId(data.team);
     const color = team === window.TEAM_NONE ? '#CCC' : window.COLORS[team];
-    const latLng = L.latLng(data.latE6 / 1e6, data.lngE6 / 1e6);
+    const latLng = new L.LatLng(data.latE6 / 1e6, data.lngE6 / 1e6);
 
     this.addResult({
       title: data.title,

--- a/core/code/search_query.js
+++ b/core/code/search_query.js
@@ -200,7 +200,7 @@ class Query {
       result.layer = L.layerGroup();
 
       if (result.position) {
-        L.marker(result.position, {
+        new L.Marker(result.position, {
           icon: new L.DivIcon.ColoredSvg('red'),
           title: result.title,
         }).addTo(result.layer);

--- a/core/code/search_query.js
+++ b/core/code/search_query.js
@@ -197,7 +197,7 @@ class Query {
    */
   resultLayer(result) {
     if (!result.layer) {
-      result.layer = L.layerGroup();
+      result.layer = new L.LayerGroup();
 
       if (result.position) {
         new L.Marker(result.position, {

--- a/core/code/search_query.js
+++ b/core/code/search_query.js
@@ -207,7 +207,7 @@ class Query {
       }
 
       if (result.bounds) {
-        L.rectangle(result.bounds, {
+        new L.Rectangle(result.bounds, {
           title: result.title,
           interactive: false,
           color: 'red',

--- a/core/code/utils.js
+++ b/core/code/utils.js
@@ -470,7 +470,7 @@ const clampLatLng = function (latlng) {
 const clampLatLngBounds = function (bounds) {
   var SW = bounds.getSouthWest(),
     NE = bounds.getNorthEast();
-  return L.latLngBounds(window.clampLatLng(SW), window.clampLatLng(NE));
+  return new L.LatLngBounds(window.clampLatLng(SW), window.clampLatLng(NE));
 };
 
 /**

--- a/core/external/L.Geodesic.js
+++ b/core/external/L.Geodesic.js
@@ -36,7 +36,7 @@
         (sinLat1CosLat2 * Math.sin(iLng-lng2) - sinLat2CosLat1 * Math.sin(iLng-lng1))
           / cosLat1CosLat2SinDLng
       );
-      convertedPoints.push(L.latLng(iLat*r2d, iLng*r2d));
+      convertedPoints.push(new L.LatLng(iLat * r2d, iLng * r2d));
     }
   }
 
@@ -71,14 +71,14 @@
 
     // points are wrapped after being offset relative to the first point coordinate, so they're
     // within +-180 degrees
-    latlngs = latlngs.map(function (a) { return L.latLng(a.lat, a.lng-lngOffset).wrap(); });
+    latlngs = latlngs.map(function (a) { return new L.LatLng(a.lat, a.lng - lngOffset).wrap(); });
 
     var geodesiclatlngs = this._processPoly(latlngs,this._geodesicConvertLine);
 
     // now add back the offset subtracted above. no wrapping here - the drawing code handles
     // things better when there's no sudden jumps in coordinates. yes, lines will extend
     // beyond +-180 degrees - but they won't be 'broken'
-    geodesiclatlngs = geodesiclatlngs.map(function (a) { return L.latLng(a.lat, a.lng+lngOffset); });
+    geodesiclatlngs = geodesiclatlngs.map(function (a) { return new L.LatLng(a.lat, a.lng + lngOffset); });
 
     return geodesiclatlngs;
   }
@@ -111,7 +111,7 @@
     },
 
     _setLatLngs: function (latlngs) {
-      this._bounds = L.latLngBounds();
+      this._bounds = new L.LatLngBounds();
       this._latlngsinit = this._convertLatLngs(latlngs);
     },
 
@@ -142,14 +142,14 @@
         // Backwards compatibility with 0.7.x factory (latlng, radius, options?)
         options = L.extend({}, legacyOptions, {radius: options});
       }
-      this._latlng = L.latLng(latlng);
+      this._latlng = latlng.clone();
       this._radius = options.radius; // note: https://github.com/Leaflet/Leaflet/issues/6656
       var points = this._calcPoints();
       L.Polygon.prototype.initialize.call(this, points, options);
     },
 
     setLatLng: function (latlng) {
-      this._latlng = L.latLng(latlng);
+      this._latlng = latlng.clone();
       var points = this._calcPoints();
       this.setLatLngs(points);
     },
@@ -187,7 +187,7 @@
         var lat = Math.asin(sinCentreLat*cosRadRadius + cosCentreLat*sinRadRadius*Math.cos(angle));
         var lng = centreLng + Math.atan2(Math.sin(angle)*sinRadRadius*cosCentreLat, cosRadRadius-sinCentreLat*Math.sin(lat));
 
-        return L.latLng(lat * r2d,lng * r2d);
+        return new L.LatLng(lat * r2d, lng * r2d);
       };
 
       var o = this.options;

--- a/plugins/basemap-gaode.js
+++ b/plugins/basemap-gaode.js
@@ -82,13 +82,13 @@ mapGaode.setup = function () {
   // add('Gaode Roads 8',     new GaodeLayer({ style: 8, site: 1 }));
   // add('Gaode Roads 8 [zh]',new GaodeLayer({ style: 8, site: 1, lang: 'zh_cn' }));
 
-  add('Gaode Roads + Traffic', L.layerGroup([Roads, new AmapTraffic({ opacity: 0.75 })]));
+  add('Gaode Roads + Traffic', new L.LayerGroup([Roads, new AmapTraffic({ opacity: 0.75 })]));
 
   var Satellite = add('Gaode Satellite', new GaodeLayer({ style: 6, type: 'satellite' }));
 
   // new GaodeLayer({ style: 8, type: 'roadnet', opacity: 0.75, lang: 'zh_cn', scl: 2 }), // (512*512 tile, w/o labels)
   // new GaodeLayer({ style: 8, type: 'labels', opacity: 0.75, lang: 'zh_cn', ltype: 4 }) // (feature mask) here: 2: roads, 4: labels)
-  add('Gaode Hybrid', L.layerGroup([Satellite, new GaodeLayer({ style: 8, type: 'roadnet', opacity: 0.75 })]));
+  add('Gaode Hybrid', new L.LayerGroup([Satellite, new GaodeLayer({ style: 8, type: 'roadnet', opacity: 0.75 })]));
 };
 
 function setup() {

--- a/plugins/basemap-google-gray.js
+++ b/plugins/basemap-google-gray.js
@@ -42,7 +42,7 @@ grayGMaps.addLayer = function () {
     ],
   };
 
-  var grayGMaps = L.gridLayer.googleMutant(grayGMapsOptions);
+  var grayGMaps = new L.GridLayer.GoogleMutant(grayGMapsOptions);
 
   window.layerChooser.addBaseLayer(grayGMaps, 'Google Gray');
 };

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -600,7 +600,7 @@ window.plugin.bookmarks.onSearch = function (query) {
         title: window.escapeHtmlSpecialChars(bookmark.label),
         description: `Map in folder "${window.escapeHtmlSpecialChars(folder.label)}"`,
         icon: '@include_img:images/icon-bookmark-map.png@',
-        position: L.latLng(bookmark.latlng.split(',')),
+        position: new L.LatLng(...bookmark.latlng.split(',')),
         zoom: bookmark.z,
         onSelected: window.plugin.bookmarks.onSearchResultSelected,
       });
@@ -615,7 +615,7 @@ window.plugin.bookmarks.onSearch = function (query) {
         title: window.escapeHtmlSpecialChars(bookmark.label),
         description: `Bookmark in folder "${window.escapeHtmlSpecialChars(folder.label)}"`,
         icon: '@include_img:images/icon-bookmark.png@',
-        position: L.latLng(bookmark.latlng.split(',')),
+        position: new L.LatLng(...bookmark.latlng.split(',')),
         guid: bookmark.guid,
         onSelected: window.plugin.bookmarks.onSearchResultSelected,
       });
@@ -967,13 +967,13 @@ window.plugin.bookmarks.autoDrawOnSelect = function () {
   }
 
   if (latlngs.length === 2) {
-    var distance = L.latLng(latlngs[0]).distanceTo(latlngs[1]);
+    var distance = new L.LatLng(...latlngs[0]).distanceTo(latlngs[1]);
     text = 'Distance between portals: ' + distanceElement(distance);
     color = '';
   } else if (latlngs.length === 3) {
     var distances = latlngs.map(function (ll1, i, latlngs) {
       var ll2 = latlngs[(i + 1) % 3];
-      return distanceElement(L.latLng(ll1).distanceTo(ll2));
+      return distanceElement(new L.LatLng(...ll1).distanceTo(ll2));
     });
     text = 'Distances: ' + distances.join(', ');
     color = '';

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -1190,7 +1190,7 @@ window.plugin.bookmarks.resetAllStars = function () {
 };
 
 window.plugin.bookmarks.addStar = function (guid, latlng, lbl) {
-  var star = L.marker(latlng, {
+  var star = new L.Marker(latlng, {
     title: lbl,
     icon: new L.Icon({
       iconUrl: '@include_img:images/marker-star.png@',

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -1192,7 +1192,7 @@ window.plugin.bookmarks.resetAllStars = function () {
 window.plugin.bookmarks.addStar = function (guid, latlng, lbl) {
   var star = L.marker(latlng, {
     title: lbl,
-    icon: L.icon({
+    icon: new L.Icon({
       iconUrl: '@include_img:images/marker-star.png@',
       iconAnchor: [15, 40],
       iconSize: [30, 40],

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -1454,7 +1454,7 @@ var setup = function () {
   window.addPortalHighlighter('Bookmarked Portals', window.plugin.bookmarks.highlight);
 
   // Layer - Bookmarked portals
-  window.plugin.bookmarks.starLayerGroup = L.layerGroup();
+  window.plugin.bookmarks.starLayerGroup = new L.LayerGroup();
   window.layerChooser.addOverlay(window.plugin.bookmarks.starLayerGroup, 'Bookmarked Portals', { default: false });
   window.plugin.bookmarks.addAllStars();
   window.addHook('pluginBkmrksEdit', window.plugin.bookmarks.editStar);

--- a/plugins/distance-to-portal.js
+++ b/plugins/distance-to-portal.js
@@ -93,7 +93,7 @@ window.plugin.distanceToPortal.setLocation = function () {
   }
 
   window.plugin.distanceToPortal.currentLocMarker = L.marker(window.plugin.distanceToPortal.currentLoc, {
-    icon: L.divIcon.coloredSvg('#444'),
+    icon: new L.DivIcon.ColoredSvg('#444'),
     draggable: true,
     title: 'Drag to change current location',
   });

--- a/plugins/distance-to-portal.js
+++ b/plugins/distance-to-portal.js
@@ -92,7 +92,7 @@ window.plugin.distanceToPortal.setLocation = function () {
     window.plugin.distanceToPortal.currentLoc = window.map.getCenter();
   }
 
-  window.plugin.distanceToPortal.currentLocMarker = L.marker(window.plugin.distanceToPortal.currentLoc, {
+  window.plugin.distanceToPortal.currentLocMarker = new L.Marker(window.plugin.distanceToPortal.currentLoc, {
     icon: new L.DivIcon.ColoredSvg('#444'),
     draggable: true,
     title: 'Drag to change current location',

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -55,7 +55,7 @@ window.plugin.drawTools.getMarkerIcon = function (color) {
     console.warn('Color is not set (default #a24ac3 will be used)');
   }
   // todo: refactor to get rid of getMarkerIcon
-  return L.divIcon.coloredSvg(color);
+  return new L.DivIcon.ColoredSvg(color);
 };
 
 window.plugin.drawTools.currentColor = '#a24ac3';
@@ -549,8 +549,7 @@ window.plugin.drawTools.promptImport = function (promptAction) {
     } else {
       if (window.plugin.drawTools.merge.status) {
         promptAction =
-          typeof window.localStorage[window.plugin.drawTools.KEY_STORAGE] !== 'undefined' &&
-            window.localStorage[window.plugin.drawTools.KEY_STORAGE].length > 4
+          typeof window.localStorage[window.plugin.drawTools.KEY_STORAGE] !== 'undefined' && window.localStorage[window.plugin.drawTools.KEY_STORAGE].length > 4
             ? window.localStorage[window.plugin.drawTools.KEY_STORAGE].slice(0, -1) + ',' + promptAction.slice(1)
             : promptAction;
       }

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -278,7 +278,7 @@ window.plugin.drawTools.import = function (data) {
       case 'marker':
         var extraMarkerOpt = {};
         if (item.color) extraMarkerOpt.icon = window.plugin.drawTools.getMarkerIcon(item.color);
-        layer = L.marker(item.latLng, L.extend({}, window.plugin.drawTools.markerOptions, extraMarkerOpt));
+        layer = new L.Marker(item.latLng, L.extend({}, window.plugin.drawTools.markerOptions, extraMarkerOpt));
         window.registerMarkerForOMS(layer);
         break;
       default:

--- a/plugins/experimental/marker-canvas-icon-data.js
+++ b/plugins/experimental/marker-canvas-icon-data.js
@@ -82,10 +82,10 @@ window.plugin.markerIconCanvasUrl.setup  = function() {
 
     var dataurl = canvas.toDataURL();
 
-    return L.icon({
+    return new L.Icon({
       iconUrl: dataurl,
-      iconSize: [size,size],
-      iconAnchor: [anchor,anchor]
+      iconSize: [size, size],
+      iconAnchor: [anchor, anchor],
     });
 
   }

--- a/plugins/experimental/marker-canvas-icon-data.js
+++ b/plugins/experimental/marker-canvas-icon-data.js
@@ -4,6 +4,7 @@
 // @version        0.1.0
 // @description    EXPERIMENTAL: draw markers using individual Leaflet Icons, created from canvas elements converted to data: URLs
 
+/* global L -- eslint */
 
 // use own namespace for plugin
 window.plugin.markerIconCanvasUrl = function() {};
@@ -16,11 +17,10 @@ window.plugin.markerIconCanvasUrl.setup  = function() {
 
     var options = L.extend({}, data, { icon: icon });
 
-    var marker = L.marker (latlng, options);
-    marker.bringToFront = function(){}; //TEMP - until the rest of IITC code is changed to take account of non-path markers
+    var marker = new L.Marker(latlng, options);
+    marker.bringToFront = function () {}; // TEMP - until the rest of IITC code is changed to take account of non-path markers
     return marker;
-
-  }
+  };
 
   window.setMarkerStyle = function(marker, selected) {
     var icon = createMarkerIcon(marker.options,selected);

--- a/plugins/experimental/marker-divicon-svg.js
+++ b/plugins/experimental/marker-divicon-svg.js
@@ -4,6 +4,7 @@
 // @version        0.1.0
 // @description    EXPERIMENTAL: draw markers using individual Leaflet DivIcons, as SVG
 
+/* global L -- eslint */
 
 // use own namespace for plugin
 window.plugin.markerDivIconSvg = function() {};
@@ -45,9 +46,9 @@ window.plugin.markerDivIconSvg.setup  = function() {
             + '<circle cx="'+anchor+'" cy="'+anchor+'" r="'+lvlRadius+'" stroke="'+COLORS[details.team]+'" stroke-width="'+lvlWeight+'" fill="'+COLORS[details.team]+'" fill-opacity="0.5" />'
             + '</svg>';
 
-    return L.divIcon({
-      iconSize: [size,size],
-      iconAnchor: [anchor,anchor],
+    return new L.DivIcon({
+      iconSize: [size, size],
+      iconAnchor: [anchor, anchor],
       className: 'portal-marker',
       html: svg
     });

--- a/plugins/experimental/marker-divicon-svg.js
+++ b/plugins/experimental/marker-divicon-svg.js
@@ -17,7 +17,7 @@ window.plugin.markerDivIconSvg.setup  = function() {
 
     var options = L.extend({}, data, { icon: icon });
 
-    var marker = L.marker (latlng, options);
+    var marker = new L.Marker(latlng, options);
     return marker;
 
   }

--- a/plugins/external/Bing.js
+++ b/plugins/external/Bing.js
@@ -119,7 +119,7 @@ L.BingLayer = L.TileLayer.extend({
 			if (options.retinaDpi && options.detectRetina && options.zoomOffset) {
 				this._url += '&dpi=' + options.retinaDpi;
 			}
-			this.fire('load', {meta: meta});
+			this.fire('load', { meta: meta });
 			if (this._map) { this._update(); }
 		});
 	},
@@ -127,7 +127,7 @@ L.BingLayer = L.TileLayer.extend({
 	_prepAttrBounds: function (providers) {
 		providers.forEach(function (provider) {
 			provider.coverageAreas.forEach(function (area) {
-				area.bounds = L.latLngBounds(
+				area.bounds = new L.LatLngBounds(
 					[area.bbox[0], area.bbox[1]],
 					[area.bbox[2], area.bbox[3]]
 				);
@@ -148,7 +148,7 @@ L.BingLayer = L.TileLayer.extend({
 			this._attributions = {}; return;
 		}
 		var bounds = this._map.getBounds();
-		bounds = L.latLngBounds(bounds.getSouthWest().wrap(), bounds.getNorthEast().wrap());
+		bounds = new L.LatLngBounds(bounds.getSouthWest().wrap(), bounds.getNorthEast().wrap());
 		var zoom = this._getZoomForUrl();
 		var attributions = this._providers.map(function (provider) {
 			return remove ? false : provider.coverageAreas.some(function (area) {
@@ -156,7 +156,7 @@ L.BingLayer = L.TileLayer.extend({
 					bounds.intersects(area.bounds);
 			});
 		});
-		attributions.forEach(function (a,i) {
+		attributions.forEach(function (a, i) {
 			if (a == this._attributions[i]) { // eslint-disable-line eqeqeq
 				return;
 			} else if (a) {

--- a/plugins/external/Control.MiniMap.js
+++ b/plugins/external/Control.MiniMap.js
@@ -93,8 +93,8 @@
 			}
 
 			this._miniMap.whenReady(L.Util.bind(function () {
-				this._aimingRect = L.rectangle(this._mainMap.getBounds(), this.options.aimingRectOptions).addTo(this._miniMap);
-				this._shadowRect = L.rectangle(this._mainMap.getBounds(), this.options.shadowRectOptions).addTo(this._miniMap);
+				this._aimingRect = new L.Rectangle(this._mainMap.getBounds(), this.options.aimingRectOptions).addTo(this._miniMap);
+				this._shadowRect = new L.Rectangle(this._mainMap.getBounds(), this.options.shadowRectOptions).addTo(this._miniMap);
 				this._mainMap.on('moveend', this._onMainMapMoved, this);
 				this._mainMap.on('move', this._onMainMapMoving, this);
 				this._miniMap.on('movestart', this._onMiniMapMoveStarted, this);

--- a/plugins/external/L.Control.Zoomslider.js
+++ b/plugins/external/L.Control.Zoomslider.js
@@ -61,7 +61,7 @@
 
 			setPosition: function (y) {
 				L.DomUtil.setPosition(this._element,
-									  L.point(0, this._adjust(y)));
+					new L.Point(0, this._adjust(y)));
 			},
 
 			setValue: function (v) {

--- a/plugins/external/Yandex.js
+++ b/plugins/external/Yandex.js
@@ -24,7 +24,7 @@ L.Yandex = L.Layer.extend({
 		options = L.Util.setOptions(this, options);
 		if (type) { options.type = type; }
 		this._isOverlay = options.type.indexOf('overlay') !== -1 ||
-		                  options.type.indexOf('skeleton') !== -1;
+			options.type.indexOf('skeleton') !== -1;
 		this._animatedElements = [];
 	},
 
@@ -41,7 +41,7 @@ L.Yandex = L.Layer.extend({
 		if (opacity) {
 			L.DomUtil.setOpacity(_container, opacity);
 		}
-		var auto = {width: '100%', height: '100%'};
+		var auto = { width: '100%', height: '100%' };
 		this._setStyle(parentEl, auto);   // need to set this explicitly,
 		this._setStyle(_container, auto); // otherwise ymaps fails to follow container size changes
 		return _container;
@@ -100,21 +100,21 @@ L.Yandex = L.Layer.extend({
 		var map = this._map;
 		var center = map.getCenter();
 		this._yandex.setCenter([center.lat, center.lng], map.getZoom());
-		var offset = L.point(0,0).subtract(L.DomUtil.getPosition(map.getPane('mapPane')));
+		var offset = new L.Point(0, 0).subtract(L.DomUtil.getPosition(map.getPane('mapPane')));
 		L.DomUtil.setPosition(this._container, offset); // move to visible part of pane
 	},
 
 	_resyncView: function () { // for use in addons
 		if (!this._map) { return; }
 		var ymap = this._yandex;
-		this._map.setView(ymap.getCenter(), ymap.getZoom(), {animate: false});
+		this._map.setView(ymap.getCenter(), ymap.getZoom(), { animate: false });
 	},
 
 	_animateZoom: function (e) {
 		var map = this._map;
 		var viewHalf = map.getSize()._divideBy(2);
 		var topLeft = map.project(e.center, e.zoom)._subtract(viewHalf)._round();
-                var offset = map.project(map.getBounds().getNorthWest(), e.zoom)._subtract(topLeft);
+		var offset = map.project(map.getBounds().getNorthWest(), e.zoom)._subtract(topLeft);
 		var scale = map.getZoomScale(e.zoom);
 		this._animatedElements.length = 0;
 		this._yandex.panes._array.forEach(function (el) {
@@ -124,7 +124,7 @@ L.Yandex = L.Layer.extend({
 				L.DomUtil.setTransform(element, offset, scale);
 				this._animatedElements.push(element);
 			}
-		},this);
+		}, this);
 	},
 
 	_animateZoomEnd: function () {

--- a/plugins/external/leaflet.draw-geodesic.js
+++ b/plugins/external/leaflet.draw-geodesic.js
@@ -24,7 +24,7 @@ L.Draw.Polyline.include({
 			// also do not want to trigger any click handlers of objects we are clicking on
 			// while drawing.
 			if (!this._mouseMarker) {
-				this._mouseMarker = L.marker(this._map.getCenter(), {
+				this._mouseMarker = new L.Marker(this._map.getCenter(), {
 					icon: new L.DivIcon({
 						className: 'leaflet-mouse-marker',
 						iconAnchor: [20, 20],

--- a/plugins/external/leaflet.draw-geodesic.js
+++ b/plugins/external/leaflet.draw-geodesic.js
@@ -142,7 +142,7 @@ L.GeodesicCircle.addInitHook(function () { // todo check if this does not confli
 L.Edit.Circle.include({
 	_getResizeMarkerPoint: function (latlng) {
 		var bounds = this._shape.getBounds(); // geodesic circle stores precalculated bounds
-		return L.latLng(bounds.getNorth(), latlng.lng);
+		return new L.LatLng(bounds.getNorth(), latlng.lng);
 	}
 });
 

--- a/plugins/external/leaflet.draw-geodesic.js
+++ b/plugins/external/leaflet.draw-geodesic.js
@@ -25,7 +25,7 @@ L.Draw.Polyline.include({
 			// while drawing.
 			if (!this._mouseMarker) {
 				this._mouseMarker = L.marker(this._map.getCenter(), {
-					icon: L.divIcon({
+					icon: new L.DivIcon({
 						className: 'leaflet-mouse-marker',
 						iconAnchor: [20, 20],
 						iconSize: [40, 40]

--- a/plugins/external/leaflet.draw-snap.js
+++ b/plugins/external/leaflet.draw-snap.js
@@ -3,7 +3,7 @@
 L.Draw.Polyline.include({
 	_endPoint: function (clientX, clientY, e) {
 		if (this._mouseDownOrigin) {
-			var dragCheckDistance = L.point(clientX, clientY)
+			var dragCheckDistance = new L.Point(clientX, clientY)
 				.distanceTo(this._mouseDownOrigin);
 			var lastPtDistance = this._calculateFinishDistance(e.latlng);
 			if (this.options.maxPoints > 1 && this.options.maxPoints == this._markers.length + 1) {
@@ -26,12 +26,12 @@ L.Draw.Polyline.include({
 });
 
 (function (_onClick) {
-L.Draw.Marker.include({
-	_onClick: function () {
-		if (this.options.snapPoint) {
-			this._marker.setLatLng(this.options.snapPoint(this._marker.getLatLng()));
+	L.Draw.Marker.include({
+		_onClick: function () {
+			if (this.options.snapPoint) {
+				this._marker.setLatLng(this.options.snapPoint(this._marker.getLatLng()));
+			}
+			return _onClick.call(this);
 		}
-		return _onClick.call(this);
-	}
-});
+	});
 })(L.Draw.Marker.prototype._onClick);

--- a/plugins/external/leaflet.draw-src.js
+++ b/plugins/external/leaflet.draw-src.js
@@ -570,7 +570,7 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 			// also do not want to trigger any click handlers of objects we are clicking on
 			// while drawing.
 			if (!this._mouseMarker) {
-				this._mouseMarker = L.marker(this._map.getCenter(), {
+					this._mouseMarker = new L.Marker(this._map.getCenter(), {
 					icon: L.divIcon({
 						className: 'leaflet-mouse-marker',
 						iconAnchor: [20, 20],

--- a/plugins/fly-links.js
+++ b/plugins/fly-links.js
@@ -374,8 +374,8 @@ flyLinks.Triangle = function (a, b, c, depth) {
 };
 
 function setup() {
-  flyLinks.linksLayerGroup = L.layerGroup();
-  flyLinks.fieldsLayerGroup = L.layerGroup();
+  flyLinks.linksLayerGroup = new L.LayerGroup();
+  flyLinks.fieldsLayerGroup = new L.LayerGroup();
 
   function update() {
     if (!window.map.hasLayer(flyLinks.linksLayerGroup) || !window.map.hasLayer(flyLinks.fieldsLayerGroup)) {

--- a/plugins/hide-portal-levels.js
+++ b/plugins/hide-portal-levels.js
@@ -36,7 +36,7 @@ var changelog = [
 function setup() {
   var ctrl = window.layerChooser;
 
-  hideLevels.portals = L.layerGroup();
+  hideLevels.portals = new L.LayerGroup();
 
   var levels = ctrl._layers.filter(function (data) {
     return data.overlay && (data.name === 'Unclaimed/Placeholder Portals' || data.name.match(hideLevels.layerFilterRegexp));

--- a/plugins/highlight-moved-portals.js
+++ b/plugins/highlight-moved-portals.js
@@ -29,7 +29,7 @@ var getLinkData = (lguid) => {
 };
 
 var toLatLng = (latE6, lngE6) => {
-  return L.latLng(latE6 / 1e6, lngE6 / 1e6);
+  return new L.LatLng(latE6 / 1e6, lngE6 / 1e6);
 };
 
 var getDLatLng = (lguid) => {

--- a/plugins/keys-on-map.js
+++ b/plugins/keys-on-map.js
@@ -70,7 +70,7 @@ window.plugin.keysOnMap.renderKey = function (guid, latLng) {
   var keyCount = window.plugin.keys.keys[guid];
   if (keyCount > 0) {
     var key = L.marker(latLng, {
-      icon: L.divIcon({
+      icon: new L.DivIcon({
         className: 'plugin-keys-on-map-key',
         iconAnchor: [6, 7],
         iconSize: [12, 10],

--- a/plugins/keys-on-map.js
+++ b/plugins/keys-on-map.js
@@ -69,7 +69,7 @@ window.plugin.keysOnMap.renderKey = function (guid, latLng) {
 
   var keyCount = window.plugin.keys.keys[guid];
   if (keyCount > 0) {
-    var key = L.marker(latLng, {
+    var key = new L.Marker(latLng, {
       icon: new L.DivIcon({
         className: 'plugin-keys-on-map-key',
         iconAnchor: [6, 7],

--- a/plugins/linked-portals-show.js
+++ b/plugins/linked-portals-show.js
@@ -217,7 +217,7 @@ showLinkedPortal.showPreview = function () {
   var remote = new L.LatLng(info.lat, info.lng);
   var local = window.portals[window.selectedPortal].getLatLng();
 
-  showLinkedPortal.preview = L.layerGroup().addTo(window.map);
+  showLinkedPortal.preview = new L.LayerGroup().addTo(window.map);
 
   L.circleMarker(remote, showLinkedPortal.previewOptions).addTo(showLinkedPortal.preview);
 

--- a/plugins/linked-portals-show.js
+++ b/plugins/linked-portals-show.js
@@ -114,7 +114,7 @@ showLinkedPortal.portalDetail = function (data) {
     var lat = link[key + 'LatE6'] / 1e6;
     var lng = link[key + 'LngE6'] / 1e6;
 
-    var length = L.latLng(link.oLatE6 / 1e6, link.oLngE6 / 1e6).distanceTo([link.dLatE6 / 1e6, link.dLngE6 / 1e6]);
+    var length = new L.LatLng(link.oLatE6 / 1e6, link.oLngE6 / 1e6).distanceTo([link.dLatE6 / 1e6, link.dLngE6 / 1e6]);
     var info = {
       guid: guid,
       lat: lat,
@@ -169,7 +169,7 @@ showLinkedPortal.renderPortalDetails = function (ev) {
 
   var info = $(this).data();
 
-  var position = L.latLng(info.lat, info.lng);
+  var position = new L.LatLng(info.lat, info.lng);
   if (!window.map.getBounds().contains(position)) {
     window.map.panInside(position);
   }
@@ -203,7 +203,7 @@ showLinkedPortal.showLinkOnMap = function () {
   }
 
   var info = $(this).data();
-  var position = L.latLng(info.lat, info.lng);
+  var position = new L.LatLng(info.lat, info.lng);
   if (!window.map.getBounds().contains(position)) {
     var targetBounds = [position, window.portals[window.selectedPortal].getLatLng()];
     window.map.fitBounds(targetBounds, { padding: [15, 15], maxZoom: window.map.getZoom() });
@@ -214,7 +214,7 @@ showLinkedPortal.showPreview = function () {
   showLinkedPortal.removePreview();
 
   var info = $(this).data();
-  var remote = L.latLng(info.lat, info.lng);
+  var remote = new L.LatLng(info.lat, info.lng);
   var local = window.portals[window.selectedPortal].getLatLng();
 
   showLinkedPortal.preview = L.layerGroup().addTo(window.map);

--- a/plugins/links-to-moved-portals.js
+++ b/plugins/links-to-moved-portals.js
@@ -28,7 +28,7 @@ plugin.styles = {
 };
 
 var toLatLng = (latE6, lngE6) => {
-  return L.latLng(latE6 / 1e6, lngE6 / 1e6);
+  return new L.LatLng(latE6 / 1e6, lngE6 / 1e6);
 };
 
 var getDLatLng = (linkData) => {

--- a/plugins/machina-tools.js
+++ b/plugins/machina-tools.js
@@ -139,7 +139,7 @@ machinaTools.goToSeed = function (portalGuid) {
 };
 
 function toLatLng(latE6, lngE6) {
-  return L.latLng(latE6 / 1e6, lngE6 / 1e6);
+  return new L.LatLng(latE6 / 1e6, lngE6 / 1e6);
 }
 
 machinaTools.getOLatLng = function (link) {
@@ -724,7 +724,10 @@ machinaTools.refreshLinkLengths = function () {
     machinaTools.removeLinkLengths();
     machinaTools._maxLinks[0] = 0;
     machinaTools._maxLinks = Object.values(window.links)
-      .filter((l) => l.options.team === window.TEAM_MAC && window.map.getBounds().contains(L.latLng(l.options.data.oLatE6 / 1e6, l.options.data.oLngE6 / 1e6)))
+      .filter((l) => {
+        const ll = new L.LatLng(l.options.data.oLatE6 / 1e6, l.options.data.oLngE6 / 1e6);
+        return l.options.team === window.TEAM_MAC && window.map.getBounds().contains(ll);
+      })
       .reduce((previousValue, link) => {
         var origin = window.portals[link.options.data.oGuid];
         if (origin && origin.options.data.resCount === 8) {

--- a/plugins/machina-tracker.js
+++ b/plugins/machina-tracker.js
@@ -100,7 +100,7 @@ machinaTracker.discardOldData = function () {
 };
 
 machinaTracker.toLanLng = function (locationData) {
-  return L.latLng(locationData.latE6 / 1e6, locationData.lngE6 / 1e6);
+  return new L.LatLng(locationData.latE6 / 1e6, locationData.lngE6 / 1e6);
 };
 
 machinaTracker.createEvent = function (json) {

--- a/plugins/machina-tracker.js
+++ b/plugins/machina-tracker.js
@@ -203,7 +203,7 @@ machinaTracker.drawData = function () {
         .appendTo(linkList);
     });
 
-    var m = L.marker(position, { icon: icon, opacity: opacity, desc: popup[0], title: title });
+    var m = new L.Marker(position, { icon: icon, opacity: opacity, desc: popup[0], title: title });
     m.addEventListener('spiderfiedclick', machinaTracker.onClickListener);
 
     window.registerMarkerForOMS(m);

--- a/plugins/machina-tracker.js
+++ b/plugins/machina-tracker.js
@@ -44,7 +44,7 @@ machinaTracker.setup = () => {
 
   var iconImage = '@include_img:images/marker-machina.png@';
 
-  machinaTracker.icon = L.icon({
+  machinaTracker.icon = new L.Icon({
     iconUrl: iconImage,
     iconSize: [26, 32],
     iconAnchor: [12, 32],

--- a/plugins/machina-tracker.js
+++ b/plugins/machina-tracker.js
@@ -50,7 +50,7 @@ machinaTracker.setup = () => {
     iconAnchor: [12, 32],
   });
 
-  machinaTracker.popup = new L.Popup({ offset: L.point([1, -34]) });
+  machinaTracker.popup = new L.Popup({ offset: new L.Point([1, -34]) });
   machinaTracker.drawnTraces = new L.LayerGroup([], { minZoom: machinaTracker.MACHINA_TRACKER_MIN_ZOOM });
   window.addLayerGroup('Machina Tracker', machinaTracker.drawnTraces, true);
 

--- a/plugins/minimap.js
+++ b/plugins/minimap.js
@@ -59,7 +59,7 @@ function clone(layer) {
   } else if (layer instanceof L.TileLayer) {
     return L.tileLayer(layer._url, options);
   } else if (L.GridLayer.GoogleMutant && layer instanceof L.GridLayer.GoogleMutant) {
-    var gm = L.gridLayer.googleMutant(options);
+    var gm = new L.GridLayer.GoogleMutant(options);
     layer.whenReady(function () {
       for (var name in layer._subLayers) {
         gm.addGoogleLayer(name);

--- a/plugins/minimap.js
+++ b/plugins/minimap.js
@@ -74,7 +74,7 @@ function clone(layer) {
     if (layers.length === 1) {
       return clone(layers[0]);
     } // unwrap layerGroup if it contains only 1 layer (e.g. Bing)
-    var group = L.layerGroup();
+    var group = new L.LayerGroup();
     for (var l in layers) {
       var cloned = clone(layers[l]);
       if (!cloned) {
@@ -140,7 +140,7 @@ function setup() {
   var baseLayer = layerChooser._layers.find(function (el) {
     return !el.overlay && map.hasLayer(el.layer);
   });
-  var current = baseLayer ? getLayerSafe(baseLayer) : L.layerGroup();
+  var current = baseLayer ? getLayerSafe(baseLayer) : new L.LayerGroup();
   miniMap.control = L.control.minimap(current, miniMap.options).addTo(map);
 
   map.on('baselayerchange', function (e) {

--- a/plugins/missions.js
+++ b/plugins/missions.js
@@ -390,7 +390,7 @@ window.plugin.missions = {
         return [waypoint.portal.latE6 / 1e6, waypoint.portal.lngE6 / 1e6];
       });
 
-    return L.latLngBounds(latlngs);
+    return new L.LatLngBounds(latlngs);
   },
 
   loadMissionsInBounds: function (bounds, callback, errorcallback) {
@@ -571,7 +571,7 @@ window.plugin.missions = {
           return !!waypoint.portal;
         })
         .map(function (waypoint) {
-          return L.latLng(waypoint.portal.latE6 / 1e6, waypoint.portal.lngE6 / 1e6);
+          return new L.LatLng(waypoint.portal.latE6 / 1e6, waypoint.portal.lngE6 / 1e6);
         })
         .map(function (latlng1, i, latlngs) {
           if (i === 0) return 0;
@@ -656,7 +656,7 @@ window.plugin.missions = {
         return !!waypoint.portal;
       })
       .map(function (waypoint) {
-        var position = L.latLng(waypoint.portal.latE6 / 1e6, waypoint.portal.lngE6 / 1e6);
+        var position = new L.LatLng(waypoint.portal.latE6 / 1e6, waypoint.portal.lngE6 / 1e6);
         var distance = position.distanceTo(window.plugin.distanceToPortal.currentLoc);
         return {
           waypoint: waypoint,
@@ -1038,7 +1038,7 @@ window.plugin.missions = {
         return;
       }
 
-      this.markedStarterPortals[guid] = L.circleMarker(L.latLng(portal.options.data.latE6 / 1e6, portal.options.data.lngE6 / 1e6), {
+      this.markedStarterPortals[guid] = L.circleMarker(new L.LatLng(portal.options.data.latE6 / 1e6, portal.options.data.lngE6 / 1e6), {
         radius: portal.options.radius + Math.ceil(portal.options.radius / 2),
         weight: 3,
         opacity: 1,

--- a/plugins/overlay-kml.js
+++ b/plugins/overlay-kml.js
@@ -99,7 +99,7 @@ overlayKML.layerOptions = {
         var style = overlayKML.layerOptions.style;
         color = style && style.defaults && style.defaults['marker-color'];
       }
-      icon = L.divIcon.coloredSvg(color, overlayKML.iconSizes);
+      icon = new L.DivIcon.ColoredSvg(color, overlayKML.iconSizes);
     }
     // old icon: new L.Icon.Default(overlayKML.iconSizes);
     return L.marker(latlng, { icon: icon });

--- a/plugins/overlay-kml.js
+++ b/plugins/overlay-kml.js
@@ -102,7 +102,7 @@ overlayKML.layerOptions = {
       icon = new L.DivIcon.ColoredSvg(color, overlayKML.iconSizes);
     }
     // old icon: new L.Icon.Default(overlayKML.iconSizes);
-    return L.marker(latlng, { icon: icon });
+    return new L.Marker(latlng, { icon: icon });
   },
 
   // https://leafletjs.com/reference.html#geojson-oneachfeature

--- a/plugins/player-activity-tracker.js
+++ b/plugins/player-activity-tracker.js
@@ -276,7 +276,7 @@ window.plugin.playerTracker.getLatLngFromEvent = function (ev) {
     lngs += latlng[1];
   });
 
-  return L.latLng(lats / ev.latlngs.length, lngs / ev.latlngs.length);
+  return new L.LatLng(lats / ev.latlngs.length, lngs / ev.latlngs.length);
 };
 
 window.plugin.playerTracker.drawData = function () {

--- a/plugins/player-activity-tracker.js
+++ b/plugins/player-activity-tracker.js
@@ -371,7 +371,7 @@ window.plugin.playerTracker.drawData = function () {
     // as per OverlappingMarkerSpiderfier docs, click events (popups, etc) must be handled via it rather than the standard
     // marker click events. so store the popup text in the options, then display it in the oms click handler
     const markerPos = gllfe(last);
-    var m = L.marker(markerPos, { icon: icon, opacity: absOpacity, desc: popup[0], title: tooltip });
+    var m = new L.Marker(markerPos, { icon: icon, opacity: absOpacity, desc: popup[0], title: tooltip });
     m.addEventListener('spiderfiedclick', window.plugin.playerTracker.onClickListener);
 
     // m.bindPopup(title);

--- a/plugins/player-activity-tracker.js
+++ b/plugins/player-activity-tracker.js
@@ -82,7 +82,7 @@ window.plugin.playerTracker.setup = function () {
     }
   });
 
-  window.plugin.playerTracker.playerPopup = new L.Popup({ offset: L.point([1, -34]) });
+  window.plugin.playerTracker.playerPopup = new L.Popup({ offset: new L.Point([1, -34]) });
 
   window.addHook('publicChatDataAvailable', window.plugin.playerTracker.handleData);
 

--- a/plugins/player-level-guess.js
+++ b/plugins/player-level-guess.js
@@ -301,7 +301,7 @@ window.plugin.guessPlayerLevels.handleAttackData = function (nick, latlngs) {
   }
 
   // circle.range is useless, because it is calculated in degrees (simplified algorithm!)
-  var latlng = L.latLng(circle.y, circle.x);
+  var latlng = new L.LatLng(circle.y, circle.x);
   var range = 0;
   for (let i = 0; i < latlngs.length; i++) {
     var d = latlng.distanceTo([latlngs[i].y, latlngs[i].x]);

--- a/plugins/portal-level-numbers.js
+++ b/plugins/portal-level-numbers.js
@@ -63,7 +63,7 @@ window.plugin.portalLevelNumbers.addLabel = function (guid, latLng) {
   // add portal level to layers
   var p = window.portals[guid];
   var levelNumber = p.options.level;
-  var level = L.marker(latLng, {
+  var level = new L.Marker(latLng, {
     icon: new L.DivIcon({
       className: 'plugin-portal-level-numbers',
       iconSize: [window.plugin.portalLevelNumbers.ICON_SIZE, window.plugin.portalLevelNumbers.ICON_SIZE],

--- a/plugins/portal-level-numbers.js
+++ b/plugins/portal-level-numbers.js
@@ -102,7 +102,7 @@ window.plugin.portalLevelNumbers.updatePortalLabels = function () {
   for (const guid in portalPoints) {
     const point = portalPoints[guid];
 
-    var bucketId = L.point([Math.floor(point.x / (SQUARE_SIZE * 2)), Math.floor((point.y / SQUARE_SIZE) * 2)]);
+    var bucketId = new L.Point([Math.floor(point.x / (SQUARE_SIZE * 2)), Math.floor((point.y / SQUARE_SIZE) * 2)]);
     // the guid is added to four buckets. this way, when testing for overlap we don't need to test
     // all 8 buckets surrounding the one around the particular portal, only the bucket it is in itself
     var bucketIds = [bucketId, bucketId.add([1, 0]), bucketId.add([0, 1]), bucketId.add([1, 1])];

--- a/plugins/portal-level-numbers.js
+++ b/plugins/portal-level-numbers.js
@@ -64,7 +64,7 @@ window.plugin.portalLevelNumbers.addLabel = function (guid, latLng) {
   var p = window.portals[guid];
   var levelNumber = p.options.level;
   var level = L.marker(latLng, {
-    icon: L.divIcon({
+    icon: new L.DivIcon({
       className: 'plugin-portal-level-numbers',
       iconSize: [window.plugin.portalLevelNumbers.ICON_SIZE, window.plugin.portalLevelNumbers.ICON_SIZE],
       html: levelNumber,

--- a/plugins/portal-level-numbers.js
+++ b/plugins/portal-level-numbers.js
@@ -123,7 +123,7 @@ window.plugin.portalLevelNumbers.updatePortalLabels = function () {
       // overlap between two different portals text
       var southWest = point.subtract([SQUARE_SIZE, SQUARE_SIZE]);
       var northEast = point.add([SQUARE_SIZE, SQUARE_SIZE]);
-      var largeBounds = L.bounds(southWest, northEast);
+      var largeBounds = new L.Bounds(southWest, northEast);
 
       for (const otherGuid in bucketGuids) {
         // do not check portals already marked as covered

--- a/plugins/portal-names.js
+++ b/plugins/portal-names.js
@@ -70,7 +70,7 @@ window.plugin.portalNames.addLabel = function (guid, latLng) {
     var portalName = d.title;
 
     var label = L.marker(latLng, {
-      icon: L.divIcon({
+      icon: new L.DivIcon({
         className: 'plugin-portal-names',
         iconAnchor: [window.plugin.portalNames.NAME_WIDTH / 2, 0],
         iconSize: [window.plugin.portalNames.NAME_WIDTH, window.plugin.portalNames.NAME_HEIGHT],

--- a/plugins/portal-names.js
+++ b/plugins/portal-names.js
@@ -112,7 +112,7 @@ window.plugin.portalNames.updatePortalLabels = function () {
   for (const guid in portalPoints) {
     const point = portalPoints[guid];
 
-    var bucketId = L.point([Math.floor(point.x / (window.plugin.portalNames.NAME_WIDTH * 2)), Math.floor(point.y / window.plugin.portalNames.NAME_HEIGHT)]);
+    var bucketId = new L.Point([Math.floor(point.x / (window.plugin.portalNames.NAME_WIDTH * 2)), Math.floor(point.y / window.plugin.portalNames.NAME_HEIGHT)]);
     // the guid is added to four buckets. this way, when testing for overlap we don't need to test
     // all 8 buckets surrounding the one around the particular portal, only the bucket it is in itself
     var bucketIds = [bucketId, bucketId.add([1, 0]), bucketId.add([0, 1]), bucketId.add([1, 1])];

--- a/plugins/portal-names.js
+++ b/plugins/portal-names.js
@@ -131,7 +131,7 @@ window.plugin.portalNames.updatePortalLabels = function () {
       var point = portalPoints[guid];
       // the bounds used for testing are twice as wide as the portal name marker. this is so that there's no left/right
       // overlap between two different portals text
-      var largeBounds = L.bounds(
+      var largeBounds = new L.Bounds(
         point.subtract([window.plugin.portalNames.NAME_WIDTH, 0]),
         point.add([window.plugin.portalNames.NAME_WIDTH, window.plugin.portalNames.NAME_HEIGHT])
       );

--- a/plugins/portal-names.js
+++ b/plugins/portal-names.js
@@ -69,7 +69,7 @@ window.plugin.portalNames.addLabel = function (guid, latLng) {
     var d = window.portals[guid].options.data;
     var portalName = d.title;
 
-    var label = L.marker(latLng, {
+    var label = new L.Marker(latLng, {
       icon: new L.DivIcon({
         className: 'plugin-portal-names',
         iconAnchor: [window.plugin.portalNames.NAME_WIDTH / 2, 0],

--- a/plugins/regions.js
+++ b/plugins/regions.js
@@ -27,12 +27,12 @@ var changelog = [
 ];
 
 // use own namespace for plugin
-window.plugin.regions = function () { };
+window.plugin.regions = function () {};
 
 window.plugin.regions.setup = function () {
   '@include_raw:external/s2geometry.js@';
 
-  window.plugin.regions.regionLayer = L.layerGroup();
+  window.plugin.regions.regionLayer = new L.LayerGroup();
 
   $('<style>')
     .prop('type', 'text/css')
@@ -84,10 +84,10 @@ window.plugin.regions.CODE_WORDS = [
 // component is omitted, the 4x4 cell group is used.
 window.plugin.regions.REGEXP = new RegExp(
   '^(?:(?:(' +
-  window.plugin.regions.FACE_NAMES.join('|') +
-  ')-?)?((?:1[0-6])|(?:0?[1-9]))-?)?(' +
-  window.plugin.regions.CODE_WORDS.join('|') +
-  ')(?:-?((?:1[0-5])|(?:0?\\d)))?$',
+    window.plugin.regions.FACE_NAMES.join('|') +
+    ')-?)?((?:1[0-6])|(?:0?[1-9]))-?)?(' +
+    window.plugin.regions.CODE_WORDS.join('|') +
+    ')(?:-?((?:1[0-5])|(?:0?\\d)))?$',
   'i'
 );
 

--- a/plugins/regions.js
+++ b/plugins/regions.js
@@ -309,7 +309,7 @@ window.plugin.regions.drawCell = function (cell) {
     }
   }
 
-  var marker = L.marker(center, {
+  var marker = new L.Marker(center, {
     icon: new L.DivIcon({
       className: 'plugin-regions-name',
       iconAnchor: [100, 5],

--- a/plugins/regions.js
+++ b/plugins/regions.js
@@ -27,7 +27,7 @@ var changelog = [
 ];
 
 // use own namespace for plugin
-window.plugin.regions = function () {};
+window.plugin.regions = function () { };
 
 window.plugin.regions.setup = function () {
   '@include_raw:external/s2geometry.js@';
@@ -84,10 +84,10 @@ window.plugin.regions.CODE_WORDS = [
 // component is omitted, the 4x4 cell group is used.
 window.plugin.regions.REGEXP = new RegExp(
   '^(?:(?:(' +
-    window.plugin.regions.FACE_NAMES.join('|') +
-    ')-?)?((?:1[0-6])|(?:0?[1-9]))-?)?(' +
-    window.plugin.regions.CODE_WORDS.join('|') +
-    ')(?:-?((?:1[0-5])|(?:0?\\d)))?$',
+  window.plugin.regions.FACE_NAMES.join('|') +
+  ')-?)?((?:1[0-6])|(?:0?[1-9]))-?)?(' +
+  window.plugin.regions.CODE_WORDS.join('|') +
+  ')(?:-?((?:1[0-5])|(?:0?\\d)))?$',
   'i'
 );
 
@@ -310,7 +310,7 @@ window.plugin.regions.drawCell = function (cell) {
   }
 
   var marker = L.marker(center, {
-    icon: L.divIcon({
+    icon: new L.DivIcon({
       className: 'plugin-regions-name',
       iconAnchor: [100, 5],
       iconSize: [200, 10],

--- a/plugins/regions.js
+++ b/plugins/regions.js
@@ -182,7 +182,7 @@ window.plugin.regions.getSearchResult = function (match) {
 
   result.title = window.plugin.regions.regionName(cell);
   result.layer = L.geodesicPolygon(corners, { fill: false, color: 'red', interactive: false });
-  result.bounds = L.latLngBounds(corners);
+  result.bounds = new L.LatLngBounds(corners);
 
   return result;
 };
@@ -203,7 +203,7 @@ window.plugin.regions.update = function () {
 
       // is it on the screen?
       var corners = cell.getCornerLatLngs();
-      var cellBounds = L.latLngBounds([corners[0], corners[1]]).extend(corners[2]).extend(corners[3]);
+      var cellBounds = new L.LatLngBounds(corners);
 
       if (cellBounds.intersects(bounds)) {
         // on screen - draw it
@@ -298,7 +298,7 @@ window.plugin.regions.drawCell = function (cell) {
       var newlat = Math.max(Math.min(center.lat, namebounds.getNorth()), namebounds.getSouth());
       var newlng = Math.max(Math.min(center.lng, namebounds.getEast()), namebounds.getWest());
 
-      var newpos = L.latLng(newlat, newlng);
+      var newpos = new L.LatLng(newlat, newlng);
 
       // ensure the new position is still within the same cell
       var newposcell = window.S2.S2Cell.FromLatLng(newpos, 6);

--- a/plugins/tidy-links.js
+++ b/plugins/tidy-links.js
@@ -134,7 +134,7 @@ function setup() {
   tidyLinks.Delaunay = loadDelaunay();
 
   map = window.map;
-  tidyLinks.layer = L.layerGroup([])
+  tidyLinks.layer = new L.LayerGroup([])
     .on('add', function () {
       tidyLinks.update();
       window.addHook('mapDataRefreshEnd', tidyLinks.update);

--- a/plugins/user-location.js
+++ b/plugins/user-location.js
@@ -182,7 +182,7 @@ window.plugin.userLocation.locate = function (lat, lng, accuracy, persistentZoom
   const latAccuracy = (180 * accuracy) / 40075017;
   const lngAccuracy = latAccuracy / Math.cos((Math.PI / 180) * lat);
 
-  const bounds = L.latLngBounds([lat - latAccuracy, lng - lngAccuracy], [lat + latAccuracy, lng + lngAccuracy]);
+  const bounds = new L.LatLngBounds([lat - latAccuracy, lng - lngAccuracy], [lat + latAccuracy, lng + lngAccuracy]);
 
   // an extremely close view is pretty pointless (especially with maps that support zoom level 20+)
   // so limit to 17 (enough to see all portals)

--- a/plugins/user-location.js
+++ b/plugins/user-location.js
@@ -40,7 +40,7 @@ window.plugin.userLocation.setup = function () {
     html: `<div class="container ${cssClass} circle"><div class="outer"></div><div class="inner"></div></div>`,
   });
 
-  const marker = L.marker(latlng, {
+  const marker = new L.Marker(latlng, {
     icon: icon,
     zIndexOffset: 300,
     interactive: false,

--- a/plugins/user-location.js
+++ b/plugins/user-location.js
@@ -34,8 +34,8 @@ window.plugin.userLocation.setup = function () {
   const latlng = new L.LatLng(0, 0);
 
   const icon = new L.DivIcon({
-    iconSize: L.point(32, 32),
-    iconAnchor: L.point(16, 16),
+    iconSize: new L.Point(32, 32),
+    iconAnchor: new L.Point(16, 16),
     className: 'user-location',
     html: `<div class="container ${cssClass} circle"><div class="outer"></div><div class="inner"></div></div>`,
   });

--- a/plugins/user-location.js
+++ b/plugins/user-location.js
@@ -33,7 +33,7 @@ window.plugin.userLocation.setup = function () {
 
   const latlng = new L.LatLng(0, 0);
 
-  const icon = L.divIcon({
+  const icon = new L.DivIcon({
     iconSize: L.point(32, 32),
     iconAnchor: L.point(16, 16),
     className: 'user-location',


### PR DESCRIPTION
while Leaflet v2 is still in development phase (alpha.1) the breaking changes are already announced.

One of these changes is
- remove all factory functions ( use `x = new L.Marker(..) ` instead of  `x = L.marker(..) `)

IITC uses a lot of these. This can already be changed in current code.

There is also a polyfill lib available to catch these.
IMHO the main code should not rely on this and should only include the polyfill to keep old 3rd-Party plugins running.
