### PR TITLE
Plugin Zaprange: update range circle on update (closes #875)

### DIFF
--- a/plugins/zaprange.js
+++ b/plugins/zaprange.js
@@ -28,6 +28,16 @@ window.plugin.zaprange.zapLayers = {};
 window.plugin.zaprange.MIN_MAP_ZOOM = 16;
 
 window.plugin.zaprange.portalAdded = function (data) {
+  // this is an update and not a new marker
+  if (data.previousData) {
+    const guid = data.portal.options.guid;
+    if (window.plugin.zaprange.zapLayers[guid]) {
+      window.plugin.zaprange.remove(guid, data.portal.options.team);
+      window.plugin.zaprange.draw(guid, data.portal.options.team);
+    }
+    return;
+  }
+
   data.portal.on('add', function () {
     window.plugin.zaprange.draw(this.options.guid, this.options.team);
   });


### PR DESCRIPTION
on old iitc the portal marker was recreated and readded to the map. nowadays we are just update the style and no AddToMap is called. so zaprange.draw is never called for updated portals.