### PR TITLE
fix: crash when sharing user-installed plugin files

### DIFF
--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_PluginManager.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_PluginManager.java
@@ -152,6 +152,7 @@ public class IITC_PluginManager {
 
                 PluginInfo info = getPluginMetadata(fileName, PluginType.DEV, file, storageManager, null);
                 if (info != null && !isExcludedCategory(info.getCategory())) {
+                    info.setDocumentFileUri(file.getUri().toString());
                     Plugin plugin = new Plugin(fileName, PluginType.DEV, info, file);
                     plugins.put(fileName, plugin);
                 }
@@ -176,6 +177,7 @@ public class IITC_PluginManager {
 
             PluginInfo info = getPluginMetadata(fileName, PluginType.USER, file, storageManager, null);
             if (info != null && !isExcludedCategory(info.getCategory())) {
+                info.setDocumentFileUri(file.getUri().toString());
                 Plugin plugin = new Plugin(fileName, PluginType.USER, info, file);
                 plugins.put(fileName, plugin);
             }

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/prefs/PluginInfo.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/prefs/PluginInfo.java
@@ -14,6 +14,7 @@ public class PluginInfo extends HashMap<String, String> {
 
     private String key;
     private boolean userPlugin;
+    private String documentFileUri;
 
     private PluginInfo() {
         super();
@@ -23,6 +24,7 @@ public class PluginInfo extends HashMap<String, String> {
         super(other);
         this.key = other.key;
         this.userPlugin = other.userPlugin;
+        this.documentFileUri = other.documentFileUri;
     }
 
     public static PluginInfo createEmpty() {
@@ -106,5 +108,13 @@ public class PluginInfo extends HashMap<String, String> {
 
     public boolean isUserPlugin() {
         return userPlugin;
+    }
+
+    public String getDocumentFileUri() {
+        return documentFileUri;
+    }
+
+    public void setDocumentFileUri(String documentFileUri) {
+        this.documentFileUri = documentFileUri;
     }
 }

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/prefs/PluginPreference.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/prefs/PluginPreference.java
@@ -2,6 +2,7 @@ package org.exarhteam.iitc_mobile.prefs;
 
 import android.app.AlertDialog;
 import android.content.Context;
+import android.net.Uri;
 import android.preference.CheckBoxPreference;
 import android.view.ContextMenu;
 import android.view.MenuItem;
@@ -10,8 +11,6 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import org.exarhteam.iitc_mobile.R;
 import org.exarhteam.iitc_mobile.share.ShareActivity;
-
-import java.io.File;
 
 // multiline checkbox preference
 public class PluginPreference extends CheckBoxPreference {
@@ -56,7 +55,11 @@ public class PluginPreference extends CheckBoxPreference {
             }
             MenuItem sharePluginMenu = menu.add(R.string.menu_share_plugin_file);
             sharePluginMenu.setOnMenuItemClickListener(item -> {
-                getContext().startActivity(ShareActivity.forFile(getContext(), new File(getPluginInfo().getKey()), "application/javascript"));
+                String uriString = getPluginInfo().getDocumentFileUri();
+                if (uriString != null) {
+                    Uri uri = Uri.parse(uriString);
+                    getContext().startActivity(ShareActivity.forUri(getContext(), uri, "application/javascript"));
+                }
                 return true;
             });
             MenuItem deleteItem = menu.add(R.string.menu_delete_plugin);

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/share/ShareActivity.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/share/ShareActivity.java
@@ -46,6 +46,14 @@ public class ShareActivity extends FragmentActivity implements ActionBar.TabList
                 .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
     }
 
+    public static Intent forUri(final Context context, final Uri uri, final String type) {
+        return new Intent(context, ShareActivity.class)
+                .putExtra(EXTRA_TYPE, TYPE_FILE)
+                .putExtra("uri", uri)
+                .putExtra("type", type)
+                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+    }
+
     public static Intent forPosition(final Context context, final double lat, final double lng, final int zoom,
                                      final String title, final boolean isPortal, String guid) {
         return new Intent(context, ShareActivity.class)


### PR DESCRIPTION
User plugins stored via SAF caused FileProvider error when shared. Add ShareActivity.forUri() to handle DocumentFile URIs and store URI reference in PluginInfo for user-installed plugins.