### PR TITLE
artifacts: Fix latlng instantiation

### DIFF
--- a/core/code/artifact.js
+++ b/core/code/artifact.js
@@ -253,7 +253,7 @@ window.artifact.updateLayer = function () {
   window.artifact._layer.clearLayers();
 
   $.each(window.artifact.portalInfo, function (guid, data) {
-    var latlng = new L.LatLng([data._data.latE6 / 1e6, data._data.lngE6 / 1e6]);
+    var latlng = new L.LatLng(data._data.latE6 / 1e6, data._data.lngE6 / 1e6);
 
     $.each(data, function (type) {
       // we'll construct the URL form the type - stock seems to do that now


### PR DESCRIPTION
another Bug I introducted while preparing for Leaflet v2. :(
artifacts/shards won't be displayed.

Details:
"new L.LatLng(array)" is not valid in Leaflet v1 but in v2.  
The array conversation is done in deprecated L.latLng function.  
But using an array here is useless anyway.