### PR TITLE
mobile: hide navigation bar by default in fullscreen, fix it not restoring on exit

### DIFF
--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_MigrationHelper.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_MigrationHelper.java
@@ -5,8 +5,11 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Handles data migrations between app versions
@@ -25,6 +28,7 @@ public class IITC_MigrationHelper {
      */
     public void performMigrations() {
         migrateToSafPlugins();
+        migrateFullscreenNavbarDefault();
     }
 
     /**
@@ -82,6 +86,27 @@ public class IITC_MigrationHelper {
                 showMigrationDialog(activity);
             }
         }
+    }
+
+    /**
+     * Adds FS_NAVBAR (16) to fullscreen defaults for users who never changed the setting
+     * Previously the default was {2, 4}; now it is {2, 4, 16}
+     */
+    private void migrateFullscreenNavbarDefault() {
+        if (prefs.getBoolean("fullscreen_navbar_migrated", false)) {
+            return;
+        }
+
+        Set<String> oldDefault = new HashSet<>(Arrays.asList("2", "4"));
+        Set<String> stored = prefs.getStringSet("pref_fullscreen", null);
+
+        if (stored != null && stored.equals(oldDefault)) {
+            Set<String> newValue = new HashSet<>(stored);
+            newValue.add("16");
+            prefs.edit().putStringSet("pref_fullscreen", newValue).apply();
+        }
+
+        prefs.edit().putBoolean("fullscreen_navbar_migrated", true).apply();
     }
 
     /**

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -276,15 +276,15 @@ public class IITC_Mobile extends AppCompatActivity
             }
         }
 
-        // get fullscreen status from settings
-        mIitcWebView.updateFullscreenStatus();
-
         mFileManager = new IITC_FileManager(this);
         mFileManager.setUpdateInterval(Integer.parseInt(mSharedPrefs.getString("pref_update_plugins_interval", "7")));
 
         // Perform data migrations
         IITC_MigrationHelper migrationHelper = new IITC_MigrationHelper(this);
         migrationHelper.performMigrations();
+
+        // get fullscreen status from settings
+        mIitcWebView.updateFullscreenStatus();
 
         // Initialize PluginManager
         boolean devMode = mSharedPrefs.getBoolean("pref_dev_checkbox", false);
@@ -394,7 +394,7 @@ public class IITC_Mobile extends AppCompatActivity
             return;
         } else if (key.equals("pref_fullscreen")) {
             mIitcWebView.updateFullscreenStatus();
-            mNavigationHelper.onPrefChanged();
+            if (mNavigationHelper != null) mNavigationHelper.onPrefChanged();
             return;
         } else if (key.equals("pref_android_menu_options")) {
             final String[] menuDefaults = getResources().getStringArray(R.array.pref_android_menu_default);

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_WebView.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_WebView.java
@@ -197,6 +197,8 @@ public class IITC_WebView extends WebView {
             attrs.flags &= ~WindowManager.LayoutParams.FLAG_FULLSCREEN;
             mIitc.getNavigationHelper().showActionBar();
             loadUrl("javascript: $('#updatestatus').show();");
+            getHandler().removeCallbacks(mNavHider);
+            super.setSystemUiVisibility(SYSTEM_UI_FLAG_VISIBLE);
         }
         mIitc.getWindow().setAttributes(attrs);
         mIitc.invalidateOptionsMenu();

--- a/mobile/app/src/main/res/values/arrays.xml
+++ b/mobile/app/src/main/res/values/arrays.xml
@@ -15,6 +15,7 @@
     <string-array name="pref_hide_fullscreen_defaults">
         <item>2</item>
         <item>4</item>
+        <item>16</item>
     </string-array>
 
     <string-array name="pref_android_menu_titles">


### PR DESCRIPTION
- Add system navigation bar to fullscreen defaults ({2,4} → {2,4,16})
- Migrate existing users who never changed the fullscreen setting
- Fix navigation bar remaining hidden after exiting fullscreen