### PR TITLE
Improve mission title sorting method

### DIFF
--- a/plugins/missions.js
+++ b/plugins/missions.js
@@ -512,7 +512,7 @@ window.plugin.missions = {
       numeric: true,
       sensitivity: 'base',
     });
-    missions.sort((a,b) => collator.compare(a.title,b.title));
+    missions.sort((a, b) => collator.compare(a.title, b.title));
 
     missions.forEach(function (mission) {
       container.appendChild(this.renderMissionSummary(mission));

--- a/plugins/missions.js
+++ b/plugins/missions.js
@@ -507,18 +507,12 @@ window.plugin.missions = {
   renderMissionList: function (missions) {
     var container = document.createElement('div');
 
-    // Sort by name
-    function compare(a, b) {
-      if (a.title < b.title) {
-        return -1;
-      }
-      if (a.title > b.title) {
-        return 1;
-      }
-      return 0;
-    }
-
-    missions.sort(compare);
+    // Natural Alphanumeric Sort
+    const collator = new Intl.Collator(undefined, {
+      numeric: true,
+      sensitivity: 'base'
+    });
+    missions.sort((a,b) => collator.compare(a.title,b.title));
 
     missions.forEach(function (mission) {
       container.appendChild(this.renderMissionSummary(mission));

--- a/plugins/missions.js
+++ b/plugins/missions.js
@@ -510,7 +510,7 @@ window.plugin.missions = {
     // Natural Alphanumeric Sort
     const collator = new Intl.Collator(undefined, {
       numeric: true,
-      sensitivity: 'base'
+      sensitivity: 'base',
     });
     missions.sort((a,b) => collator.compare(a.title,b.title));
 


### PR DESCRIPTION
Change Mission Title sort to Natural Alpha Numeric.

Previous List:

```
Mis 1 / 18
Mis 10 / 18
Mis 2 / 18
```

will be sorted as

```
Mis 1 / 18
Mis 2 / 18
Mis 10 / 18
```

as a memento of: https://github.com/iitc-project/ingress-intel-total-conversion/issues/1130