### PR TITLE
statusbar: manage visibility centrally, hide when app handles status

### DIFF
--- a/core/code/chat.js
+++ b/core/code/chat.js
@@ -344,9 +344,9 @@ chat.toggle = function () {
  */
 chat.show = function (name) {
   if (window.isSmartphone()) {
-    $('#updatestatus').hide();
+    IITC.statusbar.hide();
   } else {
-    $('#updatestatus').show();
+    IITC.statusbar.show();
   }
   $('#chat, #chatinput').show();
 

--- a/core/code/panes.js
+++ b/core/code/panes.js
@@ -1,3 +1,5 @@
+/* global IITC */
+
 /**
  * @file Manages the display of different panes of the IITC interface.
  * @module panes
@@ -45,7 +47,8 @@ window.show = function (id) {
  * @function hideall
  */
 window.hideall = function () {
-  $('#chatcontrols, #chat, #chatinput, #sidebartoggle, #scrollwrapper, #updatestatus, #portal_highlight_select').hide();
+  $('#chatcontrols, #chat, #chatinput, #sidebartoggle, #scrollwrapper, #portal_highlight_select').hide();
+  IITC.statusbar.hide();
   $('#farm_level_select').hide();
   $('#map').css({ visibility: 'hidden', opacity: '0' });
   $('.ui-tooltip').remove();

--- a/core/code/smartphone.js
+++ b/core/code/smartphone.js
@@ -1,4 +1,4 @@
-/* global log -- eslint */
+/* global IITC, log -- eslint */
 
 /**
  * @file This file provides functions and utilities specifically for the smartphone layout of IITC.
@@ -70,7 +70,7 @@ window.runOnSmartphonesBeforeBoot = function () {
   window.smartphone.mapButton = $('<a>map</a>').click(function () {
     window.show('map');
     $('#map').css({ visibility: 'visible', opacity: '1' });
-    $('#updatestatus').show();
+    IITC.statusbar.show();
     $('#chatcontrols a.active').removeClass('active');
     $("#chatcontrols a:contains('map')").addClass('active');
   });

--- a/core/code/statusbar.js
+++ b/core/code/statusbar.js
@@ -43,6 +43,69 @@ IITC.statusbar.renderTemplate = (template, replacements) => {
   return result;
 };
 
+// Visibility state
+IITC.statusbar._htmlEnabled = true; // whether HTML element has content to display
+IITC.statusbar._paneVisible = true; // whether current pane wants statusbar visible
+
+/**
+ * Updates the actual visibility of the statusbar element.
+ * Visible only when both HTML is enabled and current pane wants it shown.
+ *
+ * @function IITC.statusbar._updateVisibility
+ * @private
+ */
+IITC.statusbar._updateVisibility = function () {
+  const el = document.getElementById('updatestatus');
+  if (!el) return;
+  el.style.display = this._htmlEnabled && this._paneVisible ? '' : 'none';
+};
+
+/**
+ * Enables the HTML statusbar element on the page.
+ * Plugins can call this to display custom content in the statusbar
+ * even when the app handles default status information.
+ *
+ * @function IITC.statusbar.enableHtml
+ */
+IITC.statusbar.enableHtml = function () {
+  this._htmlEnabled = true;
+  this._updateVisibility();
+};
+
+/**
+ * Disables the HTML statusbar element on the page.
+ * Called automatically when the app handles all status information via native APIs.
+ * The statusbar module continues to work (sending data to app), only the HTML block is hidden.
+ *
+ * @function IITC.statusbar.disableHtml
+ */
+IITC.statusbar.disableHtml = function () {
+  this._htmlEnabled = false;
+  this._updateVisibility();
+};
+
+/**
+ * Shows the statusbar (pane-level visibility).
+ * Called by pane-switching code when the map view is active.
+ *
+ * @function IITC.statusbar.show
+ */
+IITC.statusbar.show = function () {
+  this._paneVisible = true;
+  this._updateVisibility();
+};
+
+/**
+ * Hides the statusbar (pane-level visibility).
+ * Called by pane-switching code when switching away from the map view.
+ *
+ * @function IITC.statusbar.hide
+ */
+IITC.statusbar.hide = function () {
+  this._paneVisible = false;
+  this._updateVisibility();
+};
+
 /**
  * Templates for map status HTML elements
  * @type {Object.<string, string>}
@@ -121,6 +184,11 @@ IITC.statusbar.init = function () {
     if (innerstatus) {
       innerstatus.style.display = 'none';
     }
+  }
+
+  // Disable HTML statusbar when app handles all status information
+  if (!this.showHtmlPortalInfo && !this.showHtmlMapInfo) {
+    this.disableHtml();
   }
 
   // Set up portal selection hook - initial update with basic data


### PR DESCRIPTION
Move #updatestatus visibility control from jQuery calls in panes/smartphone/chat into IITC.statusbar with two independent states:
- `show()`/`hide()` - pane switching
- `enableHtml()`/`disableHtml()` - whether HTML block has content

Fixes empty statusbar block visible on devices with safe-area padding when the app handles all status information natively.
Plugins can call `IITC.statusbar.enableHtml()` to restore the block.