### PR TITLE
add safe area inset support and refactor layout variables to CSS

### DIFF
--- a/core/code/_deprecated.js
+++ b/core/code/_deprecated.js
@@ -211,3 +211,51 @@ window.renderUpdateStatus = function () {
 window.smartphoneInfo = function (selectedPortalData) {
   return IITC.statusbar.portal.update(selectedPortalData);
 };
+
+/**
+ * How much space to leave for scrollbars, in pixels, default 20.
+ * @type {number}
+ * @memberof config_options
+ * @deprecated Use CSS variable `--hidden-scrollbar-width` instead
+ */
+Object.defineProperty(window, 'HIDDEN_SCROLLBAR_ASSUMED_WIDTH', {
+  get: function () {
+    return parseInt(getComputedStyle(document.documentElement).getPropertyValue('--hidden-scrollbar-width'), 10);
+  },
+  set: function (value) {
+    document.documentElement.style.setProperty('--hidden-scrollbar-width', value + 'px');
+  },
+  configurable: true,
+});
+
+/**
+ * How wide should the sidebar be, in pixels, default 300.
+ * @type {number}
+ * @memberof config_options
+ * @deprecated Use CSS variable `--sidebar-width` instead
+ */
+Object.defineProperty(window, 'SIDEBAR_WIDTH', {
+  get: function () {
+    return parseInt(getComputedStyle(document.documentElement).getPropertyValue('--sidebar-width'), 10);
+  },
+  set: function (value) {
+    document.documentElement.style.setProperty('--sidebar-width', value + 'px');
+  },
+  configurable: true,
+});
+
+/**
+ * Controls height of chat when chat is collapsed, in pixels, default 60.
+ * @type {number}
+ * @memberof config_options
+ * @deprecated Use CSS variable `--chat-shrinked` instead
+ */
+Object.defineProperty(window, 'CHAT_SHRINKED', {
+  get: function () {
+    return parseInt(getComputedStyle(document.documentElement).getPropertyValue('--chat-shrinked'), 10);
+  },
+  set: function (value) {
+    document.documentElement.style.setProperty('--chat-shrinked', value + 'px');
+  },
+  configurable: true,
+});

--- a/core/code/sidebar.js
+++ b/core/code/sidebar.js
@@ -36,8 +36,6 @@ window.setupStyles = function () {
         '#largepreview.enl img { border:2px solid ' + window.COLORS[window.TEAM_ENL] + '; } ',
         '#largepreview.res img { border:2px solid ' + window.COLORS[window.TEAM_RES] + '; } ',
         '#largepreview.none img { border:2px solid ' + window.COLORS[window.TEAM_NONE] + '; } ',
-        '#chatcontrols { bottom: ' + (window.CHAT_SHRINKED + 22) + 'px; }',
-        '#chat { height: ' + window.CHAT_SHRINKED + 'px; } ',
       ].join('\n') +
       '</style>'
   );

--- a/core/code/sidebar.js
+++ b/core/code/sidebar.js
@@ -38,14 +38,6 @@ window.setupStyles = function () {
         '#largepreview.none img { border:2px solid ' + window.COLORS[window.TEAM_NONE] + '; } ',
         '#chatcontrols { bottom: ' + (window.CHAT_SHRINKED + 22) + 'px; }',
         '#chat { height: ' + window.CHAT_SHRINKED + 'px; } ',
-        '.leaflet-right { margin-right: ' + (window.SIDEBAR_WIDTH + 1) + 'px } ',
-        '#updatestatus { width:' + (window.SIDEBAR_WIDTH + 2) + 'px;  } ',
-        '#sidebar { width:' + (window.SIDEBAR_WIDTH + window.HIDDEN_SCROLLBAR_ASSUMED_WIDTH + 1) /* border*/ + 'px;  } ',
-        '#sidebartoggle { right:' + (window.SIDEBAR_WIDTH + 1) + 'px;  } ',
-        `#scrollwrapper  { width:${window.SIDEBAR_WIDTH + 2 * window.HIDDEN_SCROLLBAR_ASSUMED_WIDTH}px; right:-${
-          2 * window.HIDDEN_SCROLLBAR_ASSUMED_WIDTH - 2
-        }px } `,
-        '#sidebar > * { width:' + (window.SIDEBAR_WIDTH + 1) + 'px;  }',
       ].join('\n') +
       '</style>'
   );
@@ -129,20 +121,19 @@ window.setupPlayerStat = function () {
  * @function setupSidebarToggle
  */
 function setupSidebarToggle() {
+  $('body').addClass('sidebar-open');
   $('#sidebartoggle').on('click', function () {
     var toggle = $('#sidebartoggle');
     var sidebar = $('#scrollwrapper');
     if (sidebar.is(':visible')) {
       sidebar.hide();
-      $('.leaflet-right').css('margin-right', '0');
+      $('body').removeClass('sidebar-open');
       toggle.html('<span class="toggle open"></span>');
-      toggle.css('right', '0');
     } else {
       sidebar.show();
       window.resetScrollOnNewPortal();
-      $('.leaflet-right').css('margin-right', window.SIDEBAR_WIDTH + 1 + 'px');
+      $('body').addClass('sidebar-open');
       toggle.html('<span class="toggle close"></span>');
-      toggle.css('right', window.SIDEBAR_WIDTH + 1 + 'px');
     }
     $('.ui-tooltip').remove();
   });

--- a/core/code/smartphone.js
+++ b/core/code/smartphone.js
@@ -86,7 +86,7 @@ window.runOnSmartphonesBeforeBoot = function () {
   $('#chatcontrols').append(window.smartphone.mapButton).append(window.smartphone.sideButton);
 
   if (!window.useAppPanes()) {
-    document.body.classList.add('show_controls');
+    document.body.classList.add('show-controls');
   }
 
   window.addHook('portalDetailsUpdated', function () {

--- a/core/smartphone.css
+++ b/core/smartphone.css
@@ -9,6 +9,9 @@ body {
   border: 0;
   padding: 0;
   padding-bottom: var(--safe-area-inset-bottom);
+  padding-left: var(--safe-area-inset-left);
+  padding-right: var(--safe-area-inset-right);
+  right: 0;
 }
 
 #updatestatus .map {

--- a/core/smartphone.css
+++ b/core/smartphone.css
@@ -1,10 +1,3 @@
-:root {
-  --safe-area-inset-top: env(safe-area-inset-top);
-  --safe-area-inset-bottom: env(safe-area-inset-bottom);
-  --safe-area-inset-left: env(safe-area-inset-left);
-  --safe-area-inset-right: env(safe-area-inset-right);
-}
-
 body {
   color: #fff;
 }
@@ -280,6 +273,13 @@ body {
 }
 
 /* Position fix for edge-to-edge screens */
+#scrollwrapper {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
 .safe-area-insets,
 #scrollwrapper {
   padding-top: var(--safe-area-inset-top);
@@ -288,19 +288,7 @@ body {
   padding-right: var(--safe-area-inset-right);
 }
 
-.leaflet-top {
-  margin-top: var(--safe-area-inset-top);
-}
-
-.leaflet-bottom {
-  margin-bottom: calc(22px + var(--safe-area-inset-bottom));
-}
-
-.leaflet-left {
-  margin-left: var(--safe-area-inset-left);
-}
-
-.leaflet-bottom {
+body.sidebar-open .leaflet-right {
   margin-right: var(--safe-area-inset-right);
 }
 
@@ -318,28 +306,33 @@ body {
   --top-controls-height: 38px;
 }
 
-body.show_controls #chatcontrols {
+body.show-controls #chatcontrols {
+  box-sizing: border-box;
   display: flex !important;
   top: 0;
+  padding-top: var(--safe-area-inset-top);
+  padding-left: var(--safe-area-inset-left);
+  padding-right: var(--safe-area-inset-right);
   overflow-x: auto;
   width: calc(100% - 1px);
+  height: calc(var(--top-controls-height) + var(--safe-area-inset-top));
 }
 
-body.show_controls #chatcontrols a {
+body.show-controls #chatcontrols a {
   flex: 1;
   min-width: fit-content;
   padding: 0 5px;
 }
 
-body.show_controls #map {
+body.show-controls #map {
   height: calc(100vh - var(--top-controls-height) - 25px);
   margin-top: var(--top-controls-height);
 }
 
-body.show_controls #scrollwrapper {
+body.show-controls #scrollwrapper {
   margin-top: var(--top-controls-height)
 }
 
-body.show_controls #chat {
+body.show-controls #chat {
   top: var(--top-controls-height) !important;
 }

--- a/core/smartphone.css
+++ b/core/smartphone.css
@@ -160,6 +160,7 @@ body {
 #chatcontrols {
   height: 38px;
   width: 100%;
+  left: 0;
   display: none !important;
 }
 
@@ -186,17 +187,15 @@ body {
   top: 1px !important;
   bottom: 30px;
   width: auto;
+  height: auto;
   margin-top: var(--safe-area-inset-top);
   margin-bottom: var(--safe-area-inset-bottom);
-  padding-left: var(--safe-area-inset-left);
   padding-right: var(--safe-area-inset-right);
 }
 
 #chatinput {
   width: 100%;
-  height: 30px;
-  margin-bottom: var(--safe-area-inset-bottom);
-  padding-left: var(--safe-area-inset-left);
+  height: calc(var(--safe-area-inset-bottom) + 30px);
   padding-right: var(--safe-area-inset-right);
 }
 

--- a/core/style.css
+++ b/core/style.css
@@ -16,8 +16,9 @@
   --safe-area-inset-bottom: env(safe-area-inset-bottom);
   --safe-area-inset-left: env(safe-area-inset-left);
   --safe-area-inset-right: env(safe-area-inset-right);
-  --sidebar-width: 300px;
-  --hidden-scrollbar-width: 20px;
+  --sidebar-width: 300px; /* How wide should the sidebar be, in pixels */
+  --hidden-scrollbar-width: 20px; /* How much space to leave for scrollbars, in pixels */
+  --chat-shrinked: 60px; /* Height of chat when chat is collapsed, in pixels */
 }
 
 .text-overflow-ellipsis {
@@ -253,14 +254,15 @@ body.sidebar-open .leaflet-right {
   color: #FFCE00;
   background: rgba(8, 48, 78, 0.9);
   position: absolute;
-  left: 0;
+  bottom: calc(var(--chat-shrinked) + var(--safe-area-inset-bottom) + 22px);
+  left: var(--safe-area-inset-left);
   z-index: 3000;
   height: 26px;
   padding-left:1px;
 }
 
 #chatcontrols.expand {
-  top: 0;
+  top: var(--safe-area-inset-top);
   bottom: auto;
 }
 
@@ -334,7 +336,10 @@ body.sidebar-open .leaflet-right {
 #chat {
   position: absolute;
   width: 708px;
-  bottom: 23px;
+  max-width: 100vw;
+  height: var(--chat-shrinked);
+  bottom: calc(var(--safe-area-inset-bottom) + 23px);
+  padding-left: var(--safe-area-inset-left);
   left: 0;
   z-index: 3000;
   background: rgba(8, 48, 78, 0.9);
@@ -342,8 +347,6 @@ body.sidebar-open .leaflet-right {
   color: #eee;
   border: 1px solid #20A8B1;
   border-bottom: 0;
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 
@@ -354,7 +357,7 @@ em {
 
 #chat.expand {
   height:auto;
-  top: 25px;
+  top: calc(var(--safe-area-inset-top) + 25px);
 }
 
 
@@ -471,12 +474,13 @@ mark {
   padding: 0 2px;
   background: rgba(8, 48, 78, 0.9);
   width: 708px;
-  height: 23px;
+  max-width: 100vw;
+  height: calc(var(--safe-area-inset-bottom) + 23px);
   border: 1px solid #20A8B1;
   z-index: 3001;
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
+  padding-bottom: var(--safe-area-inset-bottom);
+  padding-left: var(--safe-area-inset-left);
 }
 
 #chatinput td {

--- a/core/style.css
+++ b/core/style.css
@@ -11,6 +11,15 @@
   #portal_highlight_select { display: none !important; }
 }
 
+:root {
+  --safe-area-inset-top: env(safe-area-inset-top);
+  --safe-area-inset-bottom: env(safe-area-inset-bottom);
+  --safe-area-inset-left: env(safe-area-inset-left);
+  --safe-area-inset-right: env(safe-area-inset-right);
+  --sidebar-width: 300px;
+  --hidden-scrollbar-width: 20px;
+}
+
 .text-overflow-ellipsis {
   display: inline-block;
   overflow: hidden;
@@ -60,10 +69,10 @@ i.large { font-size: 6rem; }
   overflow-x: hidden;
   overflow-y: auto;
   position: fixed;
-  right: -38px;
-  top: 0;
-  width: 340px;
-  bottom: 45px;
+  right: calc(-2 * var(--hidden-scrollbar-width) + 2px + var(--safe-area-inset-right));
+  top: var(--safe-area-inset-top);
+  width: calc(var(--sidebar-width) + 2 * var(--hidden-scrollbar-width));
+  bottom: calc(var(--safe-area-inset-bottom) + 45px);
   z-index: 3001;
   pointer-events: none;
 }
@@ -75,6 +84,7 @@ i.large { font-size: 6rem; }
   position: relative;
   left: 0;
   top: 0;
+  width: calc(var(--sidebar-width) + var(--hidden-scrollbar-width) + 1px);
   max-height: 100%;
   overflow-y:scroll;
   overflow-x:hidden;
@@ -87,7 +97,7 @@ i.large { font-size: 6rem; }
   margin-top: -31px; /* -(toggle height / 2) */
   line-height: 10px;
   position: absolute;
-  top: 108px;
+  top: calc(var(--safe-area-inset-top) + 108px);
   z-index: 3002;
   background-color: rgba(8, 48, 78, 0.9);
   color: #FFCE00;
@@ -95,7 +105,10 @@ i.large { font-size: 6rem; }
   border-right: none;
   border-radius: 5px 0 0 5px;
   text-decoration: none;
-  right: -50px; /* overwritten later by the script with SIDEBAR_WIDTH */
+  right: var(--safe-area-inset-right);
+}
+body.sidebar-open #sidebartoggle {
+  right: calc(var(--sidebar-width) + 1px + var(--safe-area-inset-right));
 }
 
 .enl {
@@ -129,7 +142,7 @@ a:hover {
 }
 
 .leaflet-control {
-  user-select: none; 
+  user-select: none;
 }
 
 .leaflet-control-container .leaflet-top.leaflet-left {
@@ -195,15 +208,22 @@ a:hover {
 
 .leaflet-top {
   top: 10px;
+  margin-top: var(--safe-area-inset-top);
 }
 .leaflet-right {
   right: 10px;
+  margin-right: var(--safe-area-inset-right);
+}
+body.sidebar-open .leaflet-right {
+  margin-right: calc(var(--sidebar-width) + 1px + var(--safe-area-inset-right));
 }
 .leaflet-bottom {
   bottom: 10px;
+  margin-bottom: calc(22px + var(--safe-area-inset-bottom));
 }
 .leaflet-left {
   left: 10px;
+  margin-left: var(--safe-area-inset-left);
 }
 
 .help {
@@ -485,6 +505,7 @@ mark {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
+  width: calc(var(--sidebar-width) + 1px);
 }
 
 
@@ -963,6 +984,7 @@ h3.title {
 
 /* update status */
 #updatestatus {
+  width: var(--sidebar-width);
   background-color: rgba(8, 48, 78, 0.9);
   border-bottom: 0;
   border-top: 1px solid #20A8B1;

--- a/core/style.css
+++ b/core/style.css
@@ -993,11 +993,10 @@ h3.title {
   color: #ffce00;
   font-size:13px;
   padding: 4px;
+  padding-bottom: var(--safe-area-inset-bottom);
   position: fixed;
-  right: 0;
+  right: var(--safe-area-inset-right);
   z-index: 3002;
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -287,37 +287,6 @@ window.REFRESH_GAME_SCORE = 15 * 60;
  */
 window.MAX_IDLE_TIME = 15 * 60;
 
-/**
- * How much space to leave for scrollbars, in pixels, default 20.
- * @type {number}
- * @memberof config_options
- * @deprecated Use CSS value `--hidden-scrollbar-width` instead
- */
-Object.defineProperty(window, 'HIDDEN_SCROLLBAR_ASSUMED_WIDTH', {
-  get: function () {
-    return parseInt(getComputedStyle(document.documentElement).getPropertyValue('--hidden-scrollbar-width'), 10);
-  },
-  set: function (value) {
-    document.documentElement.style.setProperty('--hidden-scrollbar-width', value + 'px');
-  },
-  configurable: true,
-});
-
-/**
- * How wide should the sidebar be, in pixels, default 300.
- * @type {number}
- * @memberof config_options
- * @deprecated Use CSS value `--sidebar-width`
- */
-Object.defineProperty(window, 'SIDEBAR_WIDTH', {
-  get: function () {
-    return parseInt(getComputedStyle(document.documentElement).getPropertyValue('--sidebar-width'), 10);
-  },
-  set: function (value) {
-    document.documentElement.style.setProperty('--sidebar-width', value + 'px');
-  },
-  configurable: true,
-});
 
 /**
  * Controls requesting chat data based on the pixel distance from the line currently in view
@@ -327,21 +296,6 @@ Object.defineProperty(window, 'SIDEBAR_WIDTH', {
  */
 window.CHAT_REQUEST_SCROLL_TOP = 200;
 
-/**
- * Controls height of chat when chat is collapsed, in pixels, default 60
- * @type {number}
- * @memberof config_options
- * @deprecated Use CSS value `--chat-shrinked`
- */
-Object.defineProperty(window, 'CHAT_SHRINKED', {
-  get: function () {
-    return parseInt(getComputedStyle(document.documentElement).getPropertyValue('--chat-shrinked'), 10);
-  },
-  set: function (value) {
-    document.documentElement.style.setProperty('--chat-shrinked', value + 'px');
-  },
-  configurable: true,
-});
 
 /**
  * What colour should the selected portal be, string(css hex code), default ‘#f0f’ (hot pink)

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -331,8 +331,17 @@ window.CHAT_REQUEST_SCROLL_TOP = 200;
  * Controls height of chat when chat is collapsed, in pixels, default 60
  * @type {number}
  * @memberof config_options
+ * @deprecated Use CSS value `--chat-shrinked`
  */
-window.CHAT_SHRINKED = 60;
+Object.defineProperty(window, 'CHAT_SHRINKED', {
+  get: function () {
+    return parseInt(getComputedStyle(document.documentElement).getPropertyValue('--chat-shrinked'), 10);
+  },
+  set: function (value) {
+    document.documentElement.style.setProperty('--chat-shrinked', value + 'px');
+  },
+  configurable: true,
+});
 
 /**
  * What colour should the selected portal be, string(css hex code), default ‘#f0f’ (hot pink)

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -291,15 +291,33 @@ window.MAX_IDLE_TIME = 15 * 60;
  * How much space to leave for scrollbars, in pixels, default 20.
  * @type {number}
  * @memberof config_options
+ * @deprecated Use CSS value `--hidden-scrollbar-width` instead
  */
-window.HIDDEN_SCROLLBAR_ASSUMED_WIDTH = 20;
+Object.defineProperty(window, 'HIDDEN_SCROLLBAR_ASSUMED_WIDTH', {
+  get: function () {
+    return parseInt(getComputedStyle(document.documentElement).getPropertyValue('--hidden-scrollbar-width'), 10);
+  },
+  set: function (value) {
+    document.documentElement.style.setProperty('--hidden-scrollbar-width', value + 'px');
+  },
+  configurable: true,
+});
 
 /**
  * How wide should the sidebar be, in pixels, default 300.
  * @type {number}
  * @memberof config_options
+ * @deprecated Use CSS value `--sidebar-width`
  */
-window.SIDEBAR_WIDTH = 300;
+Object.defineProperty(window, 'SIDEBAR_WIDTH', {
+  get: function () {
+    return parseInt(getComputedStyle(document.documentElement).getPropertyValue('--sidebar-width'), 10);
+  },
+  set: function (value) {
+    document.documentElement.style.setProperty('--sidebar-width', value + 'px');
+  },
+  configurable: true,
+});
 
 /**
  * Controls requesting chat data based on the pixel distance from the line currently in view


### PR DESCRIPTION
Adds safe area inset support for the desktop layout, bringing it in line with the existing mobile implementation.

- Apply safe area insets to sidebar, chat, and statusbar elements
- Introduce `--sidebar-width`, `--hidden-scrollbar-width`, and `--chat-shrinked` CSS custom properties as the source of truth for layout dimensions
- Replace JS-computed inline styles with CSS `calc()` expressions using the new variables
- Add `body.sidebar-open` class for toggling sidebar state via CSS instead of direct style manipulation
- Keep `window.SIDEBAR_WIDTH`, `window.HIDDEN_SCROLLBAR_ASSUMED_WIDTH`, and `window.CHAT_SHRINKED` as deprecated shims in `_deprecated.js` for backwards compatibility

fix https://github.com/IITC-CE/ingress-intel-total-conversion/issues/893