### PR TITLE
fix escapeHtml to support class attribute on allowed tags

### DIFF
--- a/core/code/utils.js
+++ b/core/code/utils.js
@@ -319,11 +319,11 @@ const escapeHtml = function (str, allowedTags = []) {
     return str.replace(/[&<>"']/g, (char) => escapeMap[char]);
   }
 
-  // Create pattern for allowed tags (self-closing and paired)
-  const allowedTagsPattern = new RegExp(`(<\\/?(?:${allowedTags.join('|')})>)`, 'g');
+  // Create pattern for allowed tags (opening with optional class attribute, closing, and self-closing)
+  const allowedTagsPattern = new RegExp(`^<\\/?(?:${allowedTags.join('|')})(?:\\s+class="[^"]*")?>$`);
 
-  // Split text by allowed tags to preserve them
-  const parts = str.split(allowedTagsPattern);
+  // Split text by all HTML tags to process each part individually
+  const parts = str.split(/(<[^>]*>)/g);
 
   return parts
     .map((part) => {
@@ -408,7 +408,7 @@ const textToTable = function (text) {
   for (const row of rows) {
     let rowHtml = '<tr>';
     for (let k = 0; k < row.length; k++) {
-      const cell = IITC.utils.escapeHtml(row[k], ['hr', 'br', 'b', 'i', 'strong', 'em']);
+      const cell = IITC.utils.escapeHtml(row[k], ['hr', 'br', 'b', 'i', 'strong', 'em', 'span', 'mark']);
       const colspan = k === 0 && row.length < columnCount ? ` colspan="${columnCount - row.length + 1}"` : '';
       rowHtml += `<td${colspan}>${cell}</td>`;
     }

--- a/plugins/player-level-guess.js
+++ b/plugins/player-level-guess.js
@@ -456,7 +456,7 @@ window.plugin.guessPlayerLevels.guess = function () {
   });
 
   var s = 'Players have at least the following level:\n\n';
-  s += 'Resistance:\t&nbsp;&nbsp;&nbsp;\tEnlightened:\t\n';
+  s += 'Resistance:\t\u00A0\u00A0\u00A0\tEnlightened:\t\n';
 
   var namesR = window.plugin.guessPlayerLevels.sort(playersRes);
   var namesE = window.plugin.guessPlayerLevels.sort(playersEnl);
@@ -467,10 +467,10 @@ window.plugin.guessPlayerLevels.guess = function () {
   function makeRow(nick, lvl, team) {
     if (!nick) return '\t';
 
-    var color = window.COLORS[team];
-    if (nick === window.PLAYER.nickname) color = '#fd6'; // highlight the player's name in a unique colour (similar to @player mentions from others in the chat text itself)
+    var teamClass = team === window.TEAM_ENL ? 'enl' : 'res';
+    if (nick === window.PLAYER.nickname) teamClass = 'self';
 
-    return `<mark class="nickname" style="color:${color}">${nick}</mark>\t${lvl}`;
+    return `<mark class="nickname ${teamClass}">${nick}</mark>\t${lvl}`;
   }
 
   var nick, lvl, lineE, lineR;
@@ -530,6 +530,14 @@ window.plugin.guessPlayerLevels.sort = function (playerHash) {
 };
 
 var setup = function () {
+  var style = document.createElement('style');
+  style.textContent = `
+    .nickname.res { color: ${window.COLORS[window.TEAM_RES]}; }
+    .nickname.enl { color: ${window.COLORS[window.TEAM_ENL]}; }
+    .nickname.self { color: #fd6; }
+  `;
+  document.head.appendChild(style);
+
   window.plugin.guessPlayerLevels.setupCallback();
   window.plugin.guessPlayerLevels.setupChatNickHelper();
 };

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -468,6 +468,36 @@ describe('IITC.utils.escapeHtml', () => {
     const result = IITC.utils.escapeHtml('<strong>Strong</strong> and <div>unsafe</div>', ['strong']);
     expect(result).to.equal('<strong>Strong</strong> and &lt;div&gt;unsafe&lt;/div&gt;');
   });
+
+  it('should preserve allowed tags with class attribute', () => {
+    const result = IITC.utils.escapeHtml('<span class="nickname">player</span>', ['span']);
+    expect(result).to.equal('<span class="nickname">player</span>');
+  });
+
+  it('should preserve allowed tags with multiple classes', () => {
+    const result = IITC.utils.escapeHtml('<mark class="nickname help">text</mark>', ['mark']);
+    expect(result).to.equal('<mark class="nickname help">text</mark>');
+  });
+
+  it('should escape non-allowed tags even with class attribute', () => {
+    const result = IITC.utils.escapeHtml('<div class="evil">text</div>', ['span']);
+    expect(result).to.equal('&lt;div class=&quot;evil&quot;&gt;text&lt;/div&gt;');
+  });
+
+  it('should escape style attribute on allowed tags', () => {
+    const result = IITC.utils.escapeHtml('<span style="color:red">text</span>', ['span']);
+    expect(result).to.equal('&lt;span style=&quot;color:red&quot;&gt;text</span>');
+  });
+
+  it('should escape event handler attributes on allowed tags', () => {
+    const result = IITC.utils.escapeHtml('<span onclick="alert(1)">text</span>', ['span']);
+    expect(result).to.equal('&lt;span onclick=&quot;alert(1)&quot;&gt;text</span>');
+  });
+
+  it('should preserve allowed tag without attributes alongside one with class', () => {
+    const result = IITC.utils.escapeHtml('<b>bold</b> <span class="nick">player</span>', ['b', 'span']);
+    expect(result).to.equal('<b>bold</b> <span class="nick">player</span>');
+  });
 });
 
 describe('IITC.utils.prettyEnergy', () => {


### PR DESCRIPTION
- `escapeHtml` now preserves allowed tags with class attribute while still escaping style, onclick and other attributes
- Add span and mark to the allowed tags in textToTable
- Replace inline styles with CSS classes in `player-level-guess` plugin

fix #869