### PR TITLE
IITC Mobile: Add update channel selection

### DIFF
--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_FileManager.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_FileManager.java
@@ -20,6 +20,7 @@ import androidx.documentfile.provider.DocumentFile;
 
 import org.exarhteam.iitc_mobile.IITC_Mobile.ResponseHandler;
 import org.exarhteam.iitc_mobile.async.UpdateScript;
+import org.exarhteam.iitc_mobile.channel.ChannelManager;
 import org.exarhteam.iitc_mobile.prefs.PluginInfo;
 import org.exarhteam.iitc_mobile.prefs.PluginPreferenceActivity;
 import org.json.JSONObject;
@@ -59,6 +60,7 @@ public class IITC_FileManager {
     private final SharedPreferences mPrefs;
     private final IITC_StorageManager mStorageManager;
     private final IITC_PluginManager mPluginManager;
+    private ChannelManager mChannelManager;
 
     public IITC_FileManager(final Activity activity) {
         mActivity = activity;
@@ -66,6 +68,10 @@ public class IITC_FileManager {
         mAssetManager = mActivity.getAssets();
         mStorageManager = new IITC_StorageManager(activity);
         mPluginManager = IITC_PluginManager.getInstance();
+    }
+
+    public void setChannelManager(ChannelManager channelManager) {
+        mChannelManager = channelManager;
     }
 
     /**
@@ -148,7 +154,17 @@ public class IITC_FileManager {
             }
         }
 
-        // load plugins from asset folder
+        // Try channel cache for core script when a remote channel is active
+        if (mChannelManager != null
+                && mChannelManager.getCurrentChannel().isRemote()
+                && mChannelManager.isChannelReady()) {
+            String content = mChannelManager.readCore();
+            if (content != null) {
+                return new ByteArrayInputStream(content.getBytes());
+            }
+        }
+
+        // Fall back to asset folder
         return mAssetManager.open(filename);
     }
 

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -55,6 +55,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.melnykov.fab.FloatingActionButton;
 
 import org.exarhteam.iitc_mobile.IITC_NavigationHelper.Pane;
+import org.exarhteam.iitc_mobile.channel.ChannelManager;
 import org.exarhteam.iitc_mobile.prefs.PluginPreferenceActivity;
 import org.exarhteam.iitc_mobile.prefs.PreferenceActivity;
 import org.exarhteam.iitc_mobile.share.ShareActivity;
@@ -84,6 +85,7 @@ public class IITC_Mobile extends AppCompatActivity
     private LocalizationActivityDelegate localizationDelegate = new LocalizationActivityDelegate(this);
     private SharedPreferences mSharedPrefs;
     private IITC_FileManager mFileManager;
+    private ChannelManager mChannelManager;
     private IITC_WebView mIitcWebView;
     private IITC_UserLocation mUserLocation;
     private IITC_NavigationHelper mNavigationHelper;
@@ -278,8 +280,11 @@ public class IITC_Mobile extends AppCompatActivity
             }
         }
 
+        mChannelManager = new ChannelManager(this);
+
         mFileManager = new IITC_FileManager(this);
         mFileManager.setUpdateInterval(Integer.parseInt(mSharedPrefs.getString("pref_update_plugins_interval", "7")));
+        mFileManager.setChannelManager(mChannelManager);
 
         // Perform data migrations
         IITC_MigrationHelper migrationHelper = new IITC_MigrationHelper(this);
@@ -293,7 +298,8 @@ public class IITC_Mobile extends AppCompatActivity
         IITC_PluginManager.getInstance().loadAllPlugins(
                 mFileManager.getStorageManager(),
                 getAssets(),
-                devMode
+                devMode,
+                mChannelManager
         );
 
         mUserLocation = new IITC_UserLocation(this);
@@ -420,7 +426,19 @@ public class IITC_Mobile extends AppCompatActivity
             IITC_PluginManager.getInstance().loadAllPlugins(
                     mFileManager.getStorageManager(),
                     getAssets(),
-                    devMode
+                    devMode,
+                    mChannelManager
+            );
+            mReloadNeeded = true;
+            return;
+        } else if (key.equals("pref_update_channel")) {
+            // Reload PluginManager when channel changes
+            boolean devMode = sharedPreferences.getBoolean("pref_dev_checkbox", false);
+            IITC_PluginManager.getInstance().loadAllPlugins(
+                    mFileManager.getStorageManager(),
+                    getAssets(),
+                    devMode,
+                    mChannelManager
             );
             mReloadNeeded = true;
             return;
@@ -1292,6 +1310,10 @@ public class IITC_Mobile extends AppCompatActivity
 
     public IITC_FileManager getFileManager() {
         return mFileManager;
+    }
+
+    public ChannelManager getChannelManager() {
+        return mChannelManager;
     }
 
     public SharedPreferences getPrefs() {

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -337,6 +337,39 @@ public class IITC_Mobile extends AppCompatActivity
             updateChecker.checkForUpdates();
         }
 
+        // Background sync for remote channel
+        if (mChannelManager.getCurrentChannel().isRemote()
+                && mSharedPrefs.getBoolean("pref_check_for_updates", true)) {
+            new Thread(() -> {
+                if (mChannelManager.checkForUpdates()) {
+                    Log.d("Channel update available, syncing...");
+                    mChannelManager.syncChannel(new org.exarhteam.iitc_mobile.channel.ChannelDownloader.Callback() {
+                        @Override
+                        public void onProgress(int current, int total) {}
+
+                        @Override
+                        public void onComplete() {
+                            Log.d("Channel sync complete");
+                            runOnUiThread(() -> {
+                                boolean devMode = mSharedPrefs.getBoolean("pref_dev_checkbox", false);
+                                IITC_PluginManager.getInstance().loadAllPlugins(
+                                        mFileManager.getStorageManager(),
+                                        getAssets(),
+                                        devMode,
+                                        mChannelManager
+                                );
+                            });
+                        }
+
+                        @Override
+                        public void onError(String message) {
+                            Log.w("Channel sync failed: " + message);
+                        }
+                    });
+                }
+            }).start();
+        }
+
         // receive downloadManagers downloadComplete intent
         // afterwards install iitc update
         IntentFilter downloadFilter = new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE);

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -338,36 +338,46 @@ public class IITC_Mobile extends AppCompatActivity
         }
 
         // Background sync for remote channel
-        if (mChannelManager.getCurrentChannel().isRemote()
-                && mSharedPrefs.getBoolean("pref_check_for_updates", true)) {
-            new Thread(() -> {
-                if (mChannelManager.checkForUpdates()) {
-                    Log.d("Channel update available, syncing...");
-                    mChannelManager.syncChannel(new org.exarhteam.iitc_mobile.channel.ChannelDownloader.Callback() {
-                        @Override
-                        public void onProgress(int current, int total) {}
+        if (mChannelManager.getCurrentChannel().isRemote()) {
+            int channelInterval = Integer.parseInt(mSharedPrefs.getString("pref_channel_update_interval", "1"));
+            if (channelInterval > 0) {
+                long lastSync = mSharedPrefs.getLong("pref_last_channel_sync", 0);
+                long now = System.currentTimeMillis();
+                long intervalMs = 1000L * 60 * 60 * 24 * channelInterval;
+                if (now - lastSync >= intervalMs) {
+                    new Thread(() -> {
+                        if (mChannelManager.checkForUpdates()) {
+                            Log.d("Channel update available, syncing...");
+                            mChannelManager.syncChannel(new org.exarhteam.iitc_mobile.channel.ChannelDownloader.Callback() {
+                                @Override
+                                public void onProgress(int current, int total) {}
 
-                        @Override
-                        public void onComplete() {
-                            Log.d("Channel sync complete");
-                            runOnUiThread(() -> {
-                                boolean devMode = mSharedPrefs.getBoolean("pref_dev_checkbox", false);
-                                IITC_PluginManager.getInstance().loadAllPlugins(
-                                        mFileManager.getStorageManager(),
-                                        getAssets(),
-                                        devMode,
-                                        mChannelManager
-                                );
+                                @Override
+                                public void onComplete() {
+                                    Log.d("Channel sync complete");
+                                    mSharedPrefs.edit()
+                                            .putLong("pref_last_channel_sync", System.currentTimeMillis())
+                                            .apply();
+                                    runOnUiThread(() -> {
+                                        boolean devMode = mSharedPrefs.getBoolean("pref_dev_checkbox", false);
+                                        IITC_PluginManager.getInstance().loadAllPlugins(
+                                                mFileManager.getStorageManager(),
+                                                getAssets(),
+                                                devMode,
+                                                mChannelManager
+                                        );
+                                    });
+                                }
+
+                                @Override
+                                public void onError(String message) {
+                                    Log.w("Channel sync failed: " + message);
+                                }
                             });
                         }
-
-                        @Override
-                        public void onError(String message) {
-                            Log.w("Channel sync failed: " + message);
-                        }
-                    });
+                    }).start();
                 }
-            }).start();
+            }
         }
 
         // receive downloadManagers downloadComplete intent

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_PluginManager.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_PluginManager.java
@@ -5,6 +5,8 @@ import android.content.res.AssetManager;
 import android.os.Build;
 import androidx.documentfile.provider.DocumentFile;
 
+import org.exarhteam.iitc_mobile.channel.ChannelManager;
+import org.exarhteam.iitc_mobile.channel.ChannelMetaData;
 import org.exarhteam.iitc_mobile.prefs.PluginInfo;
 
 import java.io.IOException;
@@ -25,9 +27,10 @@ public class IITC_PluginManager {
     private static IITC_PluginManager instance;
 
     public enum PluginType {
-        ASSET,  // Built-in plugins from assets (lowest priority)
-        DEV,    // Development override plugins (medium priority)
-        USER    // User-installed plugins (highest priority)
+        ASSET,   // Built-in plugins from assets (lowest priority)
+        CHANNEL, // Plugins from remote channel (overrides assets)
+        DEV,     // Development override plugins (medium priority)
+        USER     // User-installed plugins (highest priority)
     }
 
     public static class Plugin {
@@ -47,6 +50,10 @@ public class IITC_PluginManager {
             return type == PluginType.ASSET;
         }
 
+        public boolean isChannel() {
+            return type == PluginType.CHANNEL;
+        }
+
         public boolean isDev() {
             return type == PluginType.DEV;
         }
@@ -56,8 +63,11 @@ public class IITC_PluginManager {
         }
     }
 
-    // Main registry: ID -> Plugin (highest priority only)
+    // Main registry: filename -> Plugin (highest priority only)
     private final Map<String, Plugin> plugins = new HashMap<>();
+
+    // Reference to ChannelManager for reading channel plugin content
+    private ChannelManager channelManager;
     
     // Plugin cache with modification time tracking
     private static class CachedPlugin {
@@ -94,9 +104,23 @@ public class IITC_PluginManager {
      * Load and register all plugins from available sources
      */
     public void loadAllPlugins(IITC_StorageManager storageManager, AssetManager assetManager, boolean devMode) {
+        loadAllPlugins(storageManager, assetManager, devMode, null);
+    }
+
+    /**
+     * Load and register all plugins from available sources, with optional channel support
+     * Load order: assets -> channel (overrides assets) -> dev -> user
+     */
+    public void loadAllPlugins(IITC_StorageManager storageManager, AssetManager assetManager,
+                               boolean devMode, ChannelManager channelManager) {
         plugins.clear();
+        this.channelManager = channelManager;
 
         loadAssetPlugins(assetManager);
+
+        if (channelManager != null) {
+            loadChannelPlugins(channelManager);
+        }
 
         if (devMode) {
             loadDevPlugins(storageManager);
@@ -127,6 +151,32 @@ public class IITC_PluginManager {
         } catch (IOException e) {
             Log.e("Failed to list asset plugins", e);
         }
+    }
+
+    /**
+     * Load plugins from remote channel cache
+     * Channel plugins override asset plugins with the same filename
+     */
+    private void loadChannelPlugins(ChannelManager channelManager) {
+        if (!channelManager.getCurrentChannel().isRemote()) return;
+        if (!channelManager.isChannelReady()) return;
+
+        ChannelMetaData meta = channelManager.getMetaData();
+        if (meta == null) return;
+
+        for (ChannelMetaData.PluginMeta pluginMeta : meta.getAllPlugins()) {
+            String content = channelManager.readPlugin(pluginMeta.filename);
+            if (content == null || content.isEmpty()) continue;
+
+            PluginInfo info = IITC_FileManager.getScriptInfo(content);
+            if (!isExcludedCategory(info.getCategory())) {
+                Plugin plugin = new Plugin(pluginMeta.filename, PluginType.CHANNEL, info, null);
+                plugins.put(pluginMeta.filename, plugin); // overrides ASSET if same filename
+            }
+        }
+
+        // Remove asset plugins not present in the channel
+        plugins.values().removeIf(p -> p.type == PluginType.ASSET);
     }
 
     /**
@@ -189,6 +239,15 @@ public class IITC_PluginManager {
      */
     private CachedPlugin getCachedPluginData(String filename, PluginType type, DocumentFile file, 
                                             IITC_StorageManager storageManager, AssetManager assetManager) {
+        // Channel plugins - read from ChannelManager
+        if (type == PluginType.CHANNEL) {
+            if (channelManager == null) return null;
+            String content = channelManager.readPlugin(filename);
+            if (content == null || content.isEmpty()) return null;
+            PluginInfo metadata = IITC_FileManager.getScriptInfo(content);
+            return new CachedPlugin(content, metadata, 0);
+        }
+
         // Asset plugins - no caching needed (fast access), read directly
         if (type == PluginType.ASSET) {
             try {

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/channel/Channel.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/channel/Channel.java
@@ -1,0 +1,51 @@
+package org.exarhteam.iitc_mobile.channel;
+
+/**
+ * Represents an update channel for IITC scripts
+ */
+public enum Channel {
+    BUILTIN("builtin", null),
+    RELEASE("release", "https://iitc.app/build/release"),
+    BETA("beta", "https://iitc.app/build/beta"),
+    CUSTOM("custom", null);
+
+    private final String key;
+    private final String defaultUrl;
+
+    Channel(String key, String defaultUrl) {
+        this.key = key;
+        this.defaultUrl = defaultUrl;
+    }
+
+    /**
+     * The string key used in SharedPreferences and storage paths
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * Default base URL for this channel, or null for BUILTIN/CUSTOM
+     */
+    public String getDefaultUrl() {
+        return defaultUrl;
+    }
+
+    /**
+     * Whether this channel requires network to fetch scripts
+     */
+    public boolean isRemote() {
+        return this != BUILTIN;
+    }
+
+    /**
+     * Parse a channel from its preference key string
+     */
+    public static Channel fromKey(String key) {
+        if (key == null) return BUILTIN;
+        for (Channel c : values()) {
+            if (c.key.equals(key)) return c;
+        }
+        return BUILTIN;
+    }
+}

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/channel/ChannelDownloader.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/channel/ChannelDownloader.java
@@ -1,0 +1,167 @@
+package org.exarhteam.iitc_mobile.channel;
+
+import org.exarhteam.iitc_mobile.Log;
+
+import java.io.IOException;
+import java.util.List;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * Downloads channel data (meta.json, core script, plugins) from a remote URL
+ */
+public class ChannelDownloader {
+
+    /**
+     * Callback for download progress and completion
+     */
+    public interface Callback {
+        void onProgress(int current, int total);
+        void onComplete();
+        void onError(String message);
+    }
+
+    private final OkHttpClient client;
+
+    public ChannelDownloader() {
+        this.client = new OkHttpClient();
+    }
+
+    /**
+     * Download all channel data from baseUrl and save to storage
+     * Must be called from a background thread
+     *
+     * @param channel   the channel to download
+     * @param baseUrl   base URL (e.g. "https://iitc.app/build/release")
+     * @param storage   storage to save downloaded data
+     * @param callback  progress/completion callback (called on the calling thread)
+     */
+    public void download(Channel channel, String baseUrl, ChannelStorage storage, Callback callback) {
+        try {
+            // Step 1: Download meta.json and extract cache validator
+            DownloadResult metaResult = downloadWithHeaders(baseUrl + "/meta.json");
+            if (metaResult == null) {
+                callback.onError("Failed to download meta.json");
+                return;
+            }
+            storage.saveMetaJson(channel, metaResult.body);
+            if (metaResult.cacheValidator != null) {
+                storage.setCacheValidator(channel, metaResult.cacheValidator);
+            }
+
+            ChannelMetaData meta = ChannelMetaData.fromJson(metaResult.body);
+            List<ChannelMetaData.PluginMeta> plugins = meta.getAllPlugins();
+            int total = plugins.size() + 1; // +1 for core script
+            int current = 0;
+
+            // Step 2: Download core script
+            callback.onProgress(current, total);
+            String coreScript = downloadString(baseUrl + "/total-conversion-build.user.js");
+            if (coreScript == null) {
+                callback.onError("Failed to download IITC core script");
+                return;
+            }
+            storage.saveCoreScript(channel, coreScript);
+            current++;
+
+            // Step 3: Download each plugin
+            for (ChannelMetaData.PluginMeta plugin : plugins) {
+                callback.onProgress(current, total);
+                String pluginScript = downloadString(baseUrl + "/plugins/" + plugin.filename);
+                if (pluginScript != null) {
+                    storage.savePlugin(channel, plugin.filename, pluginScript);
+                } else {
+                    Log.w("Failed to download plugin: " + plugin.filename);
+                }
+                current++;
+            }
+
+            callback.onProgress(total, total);
+            callback.onComplete();
+
+        } catch (Exception e) {
+            Log.e("Channel download failed", e);
+            callback.onError("Download failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Check if remote meta.json has been modified since last download
+     * Uses ETag with priority, falls back to Last-Modified
+     *
+     * @return new cache validator value if changed, null if unchanged or on error
+     */
+    public String checkForUpdate(String baseUrl, String storedCacheValidator) {
+        try {
+            Request request = new Request.Builder()
+                    .url(baseUrl + "/meta.json")
+                    .head()
+                    .build();
+
+            try (Response response = client.newCall(request).execute()) {
+                if (!response.isSuccessful()) return null;
+
+                String validator = extractCacheValidator(response);
+                if (validator == null) {
+                    // No cache headers available — treat as changed
+                    return "";
+                }
+                if (!validator.equals(storedCacheValidator)) {
+                    return validator;
+                }
+                return null;
+            }
+        } catch (IOException e) {
+            Log.w("Failed to check for channel update: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Extract cache validator from response: ETag if available, otherwise Last-Modified
+     */
+    static String extractCacheValidator(Response response) {
+        String etag = response.header("ETag");
+        if (etag != null) return etag;
+        return response.header("Last-Modified");
+    }
+
+    private static class DownloadResult {
+        final String body;
+        final String cacheValidator;
+
+        DownloadResult(String body, String cacheValidator) {
+            this.body = body;
+            this.cacheValidator = cacheValidator;
+        }
+    }
+
+    /**
+     * Download a URL and return body + cache validator headers
+     */
+    private DownloadResult downloadWithHeaders(String url) throws IOException {
+        Request request = new Request.Builder()
+                .url(url)
+                .get()
+                .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                Log.d("Error downloading \"" + url + "\", code: " + response.code());
+                return null;
+            }
+            if (response.body() == null) {
+                Log.d("Empty response from " + url);
+                return null;
+            }
+            return new DownloadResult(response.body().string(), extractCacheValidator(response));
+        }
+    }
+
+    private String downloadString(String url) throws IOException {
+        DownloadResult result = downloadWithHeaders(url);
+        return result != null ? result.body : null;
+    }
+}

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/channel/ChannelManager.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/channel/ChannelManager.java
@@ -1,0 +1,172 @@
+package org.exarhteam.iitc_mobile.channel;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+/**
+ * Orchestrates channel storage and downloading
+ * Single entry point for all channel-related operations
+ */
+public class ChannelManager {
+
+    private static ChannelManager instance;
+
+    private static final String PREF_CHANNEL = "pref_update_channel";
+    private static final String PREF_CUSTOM_URL = "pref_custom_channel_url";
+
+    private final SharedPreferences prefs;
+    private final ChannelStorage storage;
+    private final ChannelDownloader downloader;
+
+    public ChannelManager(Context context) {
+        this.prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        this.storage = new ChannelStorage(context);
+        this.downloader = new ChannelDownloader();
+        instance = this;
+    }
+
+    public static ChannelManager getInstance() {
+        return instance;
+    }
+
+    /**
+     * Get the currently selected channel
+     */
+    public Channel getCurrentChannel() {
+        return Channel.fromKey(prefs.getString(PREF_CHANNEL, Channel.BUILTIN.getKey()));
+    }
+
+    /**
+     * Set the active channel
+     */
+    public void setChannel(Channel channel) {
+        prefs.edit().putString(PREF_CHANNEL, channel.getKey()).apply();
+    }
+
+    /**
+     * Get custom channel URL
+     */
+    public String getCustomChannelUrl() {
+        return prefs.getString(PREF_CUSTOM_URL, "");
+    }
+
+    /**
+     * Set custom channel URL
+     */
+    public void setCustomChannelUrl(String url) {
+        prefs.edit().putString(PREF_CUSTOM_URL, url).apply();
+    }
+
+    /**
+     * Get the base URL for a channel
+     */
+    public String getBaseUrl(Channel channel) {
+        if (channel == Channel.CUSTOM) {
+            return getCustomChannelUrl();
+        }
+        return channel.getDefaultUrl();
+    }
+
+    /**
+     * Check if a channel has cached scripts ready to use
+     */
+    public boolean isChannelReady() {
+        return isChannelReady(getCurrentChannel());
+    }
+
+    /**
+     * Check if a specific channel has cached scripts ready to use
+     */
+    public boolean isChannelReady(Channel channel) {
+        if (!channel.isRemote()) return true; // BUILTIN is always ready
+        return storage.isChannelReady(channel);
+    }
+
+    /**
+     * Get parsed metadata for the current channel, or null if not cached
+     */
+    public ChannelMetaData getMetaData() {
+        return getMetaData(getCurrentChannel());
+    }
+
+    /**
+     * Get parsed metadata for a specific channel, or null if not cached/BUILTIN
+     */
+    public ChannelMetaData getMetaData(Channel channel) {
+        if (!channel.isRemote()) return null;
+        return storage.loadMetaJson(channel);
+    }
+
+    /**
+     * Read the IITC core script from channel cache
+     * Returns null for BUILTIN (caller should fall back to assets)
+     */
+    public String readCore() {
+        Channel channel = getCurrentChannel();
+        if (!channel.isRemote()) return null;
+        return storage.loadCoreScript(channel);
+    }
+
+    /**
+     * Read a plugin script from channel cache
+     * Returns null for BUILTIN or if plugin not cached
+     */
+    public String readPlugin(String filename) {
+        Channel channel = getCurrentChannel();
+        if (!channel.isRemote()) return null;
+        return storage.loadPlugin(channel, filename);
+    }
+
+    /**
+     * Download/update scripts for the current channel
+     * Must be called from a background thread
+     */
+    public void syncChannel(ChannelDownloader.Callback callback) {
+        Channel channel = getCurrentChannel();
+        if (!channel.isRemote()) {
+            callback.onComplete();
+            return;
+        }
+
+        String baseUrl = getBaseUrl(channel);
+        if (baseUrl == null || baseUrl.isEmpty()) {
+            callback.onError("Channel URL is not configured");
+            return;
+        }
+
+        downloader.download(channel, baseUrl, storage, callback);
+    }
+
+    /**
+     * Check if the current channel has updates available
+     * Must be called from a background thread
+     *
+     * @return true if updates are available
+     */
+    public boolean checkForUpdates() {
+        Channel channel = getCurrentChannel();
+        if (!channel.isRemote()) return false;
+
+        String baseUrl = getBaseUrl(channel);
+        if (baseUrl == null || baseUrl.isEmpty()) return false;
+
+        String storedValidator = storage.getCacheValidator(channel);
+        String newValidator = downloader.checkForUpdate(baseUrl, storedValidator);
+        return newValidator != null;
+    }
+
+    /**
+     * Clear cached data for a specific channel
+     */
+    public void clearChannel(Channel channel) {
+        storage.clearChannel(channel);
+    }
+
+    /**
+     * Get the underlying storage (for use by PluginManager)
+     */
+    public ChannelStorage getStorage() {
+        return storage;
+    }
+}

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/channel/ChannelMetaData.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/channel/ChannelMetaData.java
@@ -1,0 +1,134 @@
+package org.exarhteam.iitc_mobile.channel;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Parsed representation of a channel's meta.json file
+ * Format matches the one used by lib-iitc-manager
+ */
+public class ChannelMetaData {
+
+    public final String iitcVersion;
+    public final Map<String, CategoryInfo> categories;
+
+    private ChannelMetaData(String iitcVersion, Map<String, CategoryInfo> categories) {
+        this.iitcVersion = iitcVersion;
+        this.categories = categories;
+    }
+
+    /**
+     * Parse a meta.json string into a ChannelMetaData object
+     *
+     * Expected format:
+     * {
+     *   "iitc_version": "0.42.1",
+     *   "categories": {
+     *     "Info": {
+     *       "name": "Info",
+     *       "description": "...",
+     *       "plugins": [
+     *         { "filename": "ap-stats.user.js", "id": "ap-stats", "name": "...", "version": "0.4.2", ... }
+     *       ]
+     *     }
+     *   }
+     * }
+     */
+    public static ChannelMetaData fromJson(String json) throws JSONException {
+        JSONObject root = new JSONObject(json);
+
+        String iitcVersion = root.has("iitc_version") ? root.getString("iitc_version") : null;
+        Map<String, CategoryInfo> categories = new LinkedHashMap<>();
+
+        JSONObject cats = root.getJSONObject("categories");
+        Iterator<String> keys = cats.keys();
+        while (keys.hasNext()) {
+            String catKey = keys.next();
+            JSONObject catObj = cats.getJSONObject(catKey);
+
+            String name = catObj.optString("name", catKey);
+            String description = catObj.optString("description", "");
+
+            List<PluginMeta> plugins = new ArrayList<>();
+            if (catObj.has("plugins")) {
+                JSONArray pluginsArray = catObj.getJSONArray("plugins");
+                for (int i = 0; i < pluginsArray.length(); i++) {
+                    JSONObject p = pluginsArray.getJSONObject(i);
+                    plugins.add(new PluginMeta(
+                            p.getString("filename"),
+                            p.optString("id", ""),
+                            p.optString("name", ""),
+                            p.optString("author", ""),
+                            p.optString("description", ""),
+                            p.optString("namespace", ""),
+                            p.optString("version", "")
+                    ));
+                }
+            }
+
+            categories.put(catKey, new CategoryInfo(name, description, plugins));
+        }
+
+        return new ChannelMetaData(iitcVersion, categories);
+    }
+
+    /**
+     * Get a flat list of all plugins across all categories
+     * (excluding Obsolete and Deleted)
+     */
+    public List<PluginMeta> getAllPlugins() {
+        List<PluginMeta> all = new ArrayList<>();
+        for (Map.Entry<String, CategoryInfo> entry : categories.entrySet()) {
+            String catName = entry.getKey();
+            if ("Obsolete".equals(catName) || "Deleted".equals(catName)) continue;
+            all.addAll(entry.getValue().plugins);
+        }
+        return all;
+    }
+
+    /**
+     * Category information from meta.json
+     */
+    public static class CategoryInfo {
+        public final String name;
+        public final String description;
+        public final List<PluginMeta> plugins;
+
+        public CategoryInfo(String name, String description, List<PluginMeta> plugins) {
+            this.name = name;
+            this.description = description;
+            this.plugins = plugins;
+        }
+    }
+
+    /**
+     * Plugin metadata from meta.json
+     */
+    public static class PluginMeta {
+        public final String filename;
+        public final String id;
+        public final String name;
+        public final String author;
+        public final String description;
+        public final String namespace;
+        public final String version;
+
+        public PluginMeta(String filename, String id, String name, String author,
+                          String description, String namespace, String version) {
+            this.filename = filename;
+            this.id = id;
+            this.name = name;
+            this.author = author;
+            this.description = description;
+            this.namespace = namespace;
+            this.version = version;
+        }
+    }
+}

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/channel/ChannelStorage.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/channel/ChannelStorage.java
@@ -1,0 +1,166 @@
+package org.exarhteam.iitc_mobile.channel;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import org.exarhteam.iitc_mobile.Log;
+import org.json.JSONException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Manages file I/O for cached channel data
+ * Scripts are stored in internal app storage: files/channel/{channel_name}/
+ */
+public class ChannelStorage {
+
+    private static final String CHANNEL_DIR = "channel";
+    private static final String META_JSON = "meta.json";
+    private static final String CORE_SCRIPT = "total-conversion-build.user.js";
+    private static final String PLUGINS_DIR = "plugins";
+    private static final String PREF_NAME = "channel_storage";
+    private static final String PREF_CACHE_VALIDATOR_PREFIX = "cache_validator_";
+
+    private final Context context;
+    private final SharedPreferences prefs;
+
+    public ChannelStorage(Context context) {
+        this.context = context;
+        this.prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+    }
+
+    /**
+     * Get the root directory for a channel's cached data
+     */
+    public File getChannelDir(Channel channel) {
+        return new File(context.getFilesDir(), CHANNEL_DIR + "/" + channel.getKey());
+    }
+
+    /**
+     * Save raw meta.json content for a channel
+     */
+    public void saveMetaJson(Channel channel, String rawJson) throws IOException {
+        writeFile(new File(getChannelDir(channel), META_JSON), rawJson);
+    }
+
+    /**
+     * Load and parse meta.json for a channel, or null if not cached
+     */
+    public ChannelMetaData loadMetaJson(Channel channel) {
+        String json = readFile(new File(getChannelDir(channel), META_JSON));
+        if (json == null) return null;
+        try {
+            return ChannelMetaData.fromJson(json);
+        } catch (JSONException e) {
+            Log.e("Failed to parse cached meta.json for channel " + channel.getKey(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Save the IITC core script for a channel
+     */
+    public void saveCoreScript(Channel channel, String content) throws IOException {
+        writeFile(new File(getChannelDir(channel), CORE_SCRIPT), content);
+    }
+
+    /**
+     * Load the IITC core script for a channel, or null if not cached
+     */
+    public String loadCoreScript(Channel channel) {
+        return readFile(new File(getChannelDir(channel), CORE_SCRIPT));
+    }
+
+    /**
+     * Save a plugin script for a channel
+     */
+    public void savePlugin(Channel channel, String filename, String content) throws IOException {
+        File pluginsDir = new File(getChannelDir(channel), PLUGINS_DIR);
+        writeFile(new File(pluginsDir, filename), content);
+    }
+
+    /**
+     * Load a plugin script for a channel, or null if not cached
+     */
+    public String loadPlugin(Channel channel, String filename) {
+        File pluginsDir = new File(getChannelDir(channel), PLUGINS_DIR);
+        return readFile(new File(pluginsDir, filename));
+    }
+
+    /**
+     * Check if a channel has cached core script (minimum requirement to be "ready")
+     */
+    public boolean isChannelReady(Channel channel) {
+        File coreFile = new File(getChannelDir(channel), CORE_SCRIPT);
+        return coreFile.exists() && coreFile.length() > 0;
+    }
+
+    /**
+     * Get stored cache validator (ETag or Last-Modified) for a channel
+     */
+    public String getCacheValidator(Channel channel) {
+        return prefs.getString(PREF_CACHE_VALIDATOR_PREFIX + channel.getKey(), null);
+    }
+
+    /**
+     * Store cache validator (ETag or Last-Modified) for a channel
+     */
+    public void setCacheValidator(Channel channel, String validator) {
+        prefs.edit().putString(PREF_CACHE_VALIDATOR_PREFIX + channel.getKey(), validator).apply();
+    }
+
+    /**
+     * Delete all cached data for a channel
+     */
+    public void clearChannel(Channel channel) {
+        deleteRecursive(getChannelDir(channel));
+        prefs.edit().remove(PREF_CACHE_VALIDATOR_PREFIX + channel.getKey()).apply();
+    }
+
+    private void writeFile(File file, String content) throws IOException {
+        File parent = file.getParentFile();
+        if (parent != null && !parent.exists() && !parent.mkdirs()) {
+            throw new IOException("Failed to create directory: " + parent.getAbsolutePath());
+        }
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(content.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    private String readFile(File file) {
+        if (!file.exists()) return null;
+        try {
+            try (FileInputStream fis = new FileInputStream(file)) {
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                byte[] buf = new byte[4096];
+                int len;
+                while ((len = fis.read(buf)) != -1) {
+                    bos.write(buf, 0, len);
+                }
+                return bos.toString("UTF-8");
+            }
+        } catch (IOException e) {
+            Log.e("Failed to read file: " + file.getAbsolutePath(), e);
+            return null;
+        }
+    }
+
+    private void deleteRecursive(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursive(child);
+                }
+            }
+        }
+        if (!file.delete()) {
+            Log.w("Failed to delete: " + file.getAbsolutePath());
+        }
+    }
+}

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/fragments/MainSettings.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/fragments/MainSettings.java
@@ -105,6 +105,20 @@ public class MainSettings extends PreferenceFragment {
                 return true;
             });
         }
+
+        // Force channel update button
+        Preference pref_force_channel = findPreference("pref_force_channel_update");
+        if (pref_force_channel != null) {
+            pref_force_channel.setOnPreferenceClickListener(preference -> {
+                ChannelManager channelManager = ChannelManager.getInstance();
+                if (channelManager != null && channelManager.getCurrentChannel().isRemote()) {
+                    syncChannel();
+                } else {
+                    Toast.makeText(getActivity(), R.string.channel_builtin, Toast.LENGTH_SHORT).show();
+                }
+                return true;
+            });
+        }
     }
 
     private void showCustomChannelUrlDialog(Runnable onConfirm) {

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/fragments/MainSettings.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/fragments/MainSettings.java
@@ -159,6 +159,10 @@ public class MainSettings extends PreferenceFragment {
 
                 @Override
                 public void onComplete() {
+                    android.preference.PreferenceManager.getDefaultSharedPreferences(getActivity())
+                            .edit()
+                            .putLong("pref_last_channel_sync", System.currentTimeMillis())
+                            .apply();
                     if (getActivity() != null) {
                         getActivity().runOnUiThread(() -> {
                             progress.dismiss();

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/fragments/MainSettings.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/fragments/MainSettings.java
@@ -1,20 +1,28 @@
 package org.exarhteam.iitc_mobile.fragments;
 
+import android.app.AlertDialog;
 import android.app.Dialog;
+import android.app.ProgressDialog;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.Bundle;
 import android.preference.*;
+import android.text.InputType;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.Toast;
 
 import org.exarhteam.iitc_mobile.BuildConfig;
 import org.exarhteam.iitc_mobile.IntroActivity;
 import org.exarhteam.iitc_mobile.Log;
 import org.exarhteam.iitc_mobile.R;
 import org.exarhteam.iitc_mobile.WindowInsetsHelper;
+import org.exarhteam.iitc_mobile.channel.Channel;
+import org.exarhteam.iitc_mobile.channel.ChannelDownloader;
+import org.exarhteam.iitc_mobile.channel.ChannelManager;
 import org.exarhteam.iitc_mobile.prefs.AboutDialogPreference;
 import org.exarhteam.iitc_mobile.prefs.DeepLinkPermissionPreference;
 import org.exarhteam.iitc_mobile.prefs.ShareDebugInfoPreference;
@@ -78,7 +86,102 @@ public class MainSettings extends PreferenceFragment {
             PreferenceCategory mCategory = (PreferenceCategory) findPreference("pref_mics");
             mCategory.removePreference(updateCheckPref);
         }
+
+        // Update channel preference
+        final ListPreference pref_channel = (ListPreference) findPreference("pref_update_channel");
+        if (pref_channel != null) {
+            pref_channel.setOnPreferenceChangeListener((preference, newValue) -> {
+                String channelKey = (String) newValue;
+                Channel channel = Channel.fromKey(channelKey);
+
+                if (channel == Channel.CUSTOM) {
+                    showCustomChannelUrlDialog(() -> syncChannel());
+                    return true;
+                }
+
+                if (channel.isRemote()) {
+                    syncChannel();
+                }
+                return true;
+            });
+        }
     }
+
+    private void showCustomChannelUrlDialog(Runnable onConfirm) {
+        ChannelManager channelManager = ChannelManager.getInstance();
+        if (channelManager == null || getActivity() == null) return;
+
+        final EditText input = new EditText(getActivity());
+        input.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_URI);
+        input.setText(channelManager.getCustomChannelUrl());
+        input.setHint("https://");
+
+        AlertDialog dialog = new AlertDialog.Builder(getActivity())
+                .setTitle(R.string.pref_custom_channel_url)
+                .setView(input)
+                .setPositiveButton(android.R.string.ok, (d, which) -> {
+                    String url = input.getText().toString().trim();
+                    channelManager.setCustomChannelUrl(url);
+                    if (onConfirm != null) onConfirm.run();
+                })
+                .setNeutralButton("PR", null)
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+
+        dialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener(v -> {
+            input.setText("https://iitc.app/build/artifact/PR");
+            input.setSelection(input.getText().length());
+            input.requestFocus();
+        });
+    }
+
+    private void syncChannel() {
+        ChannelManager channelManager = ChannelManager.getInstance();
+        if (channelManager == null || getActivity() == null) return;
+
+        final ProgressDialog progress = new ProgressDialog(getActivity());
+        progress.setMessage(getString(R.string.channel_downloading));
+        progress.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
+        progress.setCancelable(false);
+        progress.show();
+
+        new Thread(() -> {
+            channelManager.syncChannel(new ChannelDownloader.Callback() {
+                @Override
+                public void onProgress(int current, int total) {
+                    if (getActivity() != null) {
+                        getActivity().runOnUiThread(() -> {
+                            progress.setMax(total);
+                            progress.setProgress(current);
+                        });
+                    }
+                }
+
+                @Override
+                public void onComplete() {
+                    if (getActivity() != null) {
+                        getActivity().runOnUiThread(() -> {
+                            progress.dismiss();
+                            Toast.makeText(getActivity(), R.string.channel_download_complete,
+                                    Toast.LENGTH_SHORT).show();
+                        });
+                    }
+                }
+
+                @Override
+                public void onError(String message) {
+                    if (getActivity() != null) {
+                        getActivity().runOnUiThread(() -> {
+                            progress.dismiss();
+                            Toast.makeText(getActivity(), R.string.channel_download_failed,
+                                    Toast.LENGTH_SHORT).show();
+                        });
+                    }
+                }
+            });
+        }).start();
+    }
+
 
     @Override
     public void onResume() {

--- a/mobile/app/src/main/res/values/arrays.xml
+++ b/mobile/app/src/main/res/values/arrays.xml
@@ -118,6 +118,19 @@
         <item>th</item>
     </string-array>
 
+    <string-array name="pref_update_channel_titles">
+        <item>@string/channel_builtin</item>
+        <item>@string/channel_release</item>
+        <item>@string/channel_beta</item>
+        <item>@string/channel_custom</item>
+    </string-array>
+    <string-array name="pref_update_channel_values">
+        <item>builtin</item>
+        <item>release</item>
+        <item>beta</item>
+        <item>custom</item>
+    </string-array>
+
     <string-array name="pref_webview_zoom">
         <item>@string/pref_webview_zoom_defaultValue</item>
         <item>200%</item>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -113,10 +113,10 @@
     <string name="pref_android_menu">Configure IITCm menu</string>
     <string name="pref_android_menu_sum">Toggle visibility of IITCm menu entries</string>
     <string name="pref_update_plugins_cat">User plugin updates</string>
-    <string name="pref_update_plugins_interval">Configure plugin update interval</string>
-    <string name="pref_update_plugins_interval_sum">How often IITCm should search for new plugin versions</string>
-    <string name="pref_force_plugin_update">Force plugin update</string>
-    <string name="pref_force_plugin_update_sum">Update all enabled user plugins</string>
+    <string name="pref_update_plugins_interval">Third-party plugin update interval</string>
+    <string name="pref_update_plugins_interval_sum">How often to check for new versions of user-installed plugins</string>
+    <string name="pref_force_plugin_update">Force third-party plugin update</string>
+    <string name="pref_force_plugin_update_sum">Update all enabled user-installed plugins</string>
     <string name="pref_secure_updates">Require secure updates</string>
     <string name="pref_secure_updates_sum">If enabled, only https updates are handled</string>
     <string name="pref_hide_fullscreen_notification_bar">System Notification Bar</string>
@@ -300,6 +300,8 @@
     <string name="channel_downloading">Downloading scripts…</string>
     <string name="channel_download_failed">Failed to download channel data</string>
     <string name="channel_download_complete">Channel updated successfully</string>
+    <string name="pref_channel_update_interval">Channel update interval</string>
+    <string name="pref_channel_update_interval_sum">How often to check for new IITC scripts in the selected channel</string>
     <!-- Storage Access Framework -->
     <string name="plugins_folder_access_title">Select IITC_Mobile folder</string>
     <string name="plugins_folder_access_message">To install custom plugins, IITC Mobile needs access to a folder where plugins will be stored. Please select the IITC_Mobile folder or create a new one.</string>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -288,6 +288,18 @@
     </string>
     <string name="pref_check_for_updates">Update check</string>
     <string name="pref_check_for_updates_summary">Check for updates on startup</string>
+    <!-- Update channel -->
+    <string name="pref_update_channel">Update channel</string>
+    <string name="pref_update_channel_sum">Source for IITC scripts</string>
+    <string name="pref_custom_channel_url">Custom channel URL</string>
+    <string name="pref_custom_channel_url_sum">Base URL for custom channel scripts</string>
+    <string name="channel_builtin">Built-in</string>
+    <string name="channel_release">Release</string>
+    <string name="channel_beta">Beta</string>
+    <string name="channel_custom">Custom</string>
+    <string name="channel_downloading">Downloading scripts…</string>
+    <string name="channel_download_failed">Failed to download channel data</string>
+    <string name="channel_download_complete">Channel updated successfully</string>
     <!-- Storage Access Framework -->
     <string name="plugins_folder_access_title">Select IITC_Mobile folder</string>
     <string name="plugins_folder_access_message">To install custom plugins, IITC Mobile needs access to a folder where plugins will be stored. Please select the IITC_Mobile folder or create a new one.</string>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -302,6 +302,8 @@
     <string name="channel_download_complete">Channel updated successfully</string>
     <string name="pref_channel_update_interval">Channel update interval</string>
     <string name="pref_channel_update_interval_sum">How often to check for new IITC scripts in the selected channel</string>
+    <string name="pref_force_channel_update">Force channel update</string>
+    <string name="pref_force_channel_update_sum">Re-download all scripts from the selected channel</string>
     <!-- Storage Access Framework -->
     <string name="plugins_folder_access_title">Select IITC_Mobile folder</string>
     <string name="plugins_folder_access_message">To install custom plugins, IITC Mobile needs access to a folder where plugins will be stored. Please select the IITC_Mobile folder or create a new one.</string>

--- a/mobile/app/src/main/res/xml/preferences.xml
+++ b/mobile/app/src/main/res/xml/preferences.xml
@@ -53,6 +53,13 @@
     <PreferenceCategory
         android:key="pref_tweaks_cat"
         android:title="@string/pref_tweaks_cat">
+        <ListPreference
+            android:key="pref_update_channel"
+            android:title="@string/pref_update_channel"
+            android:summary="%s"
+            android:entries="@array/pref_update_channel_titles"
+            android:entryValues="@array/pref_update_channel_values"
+            android:defaultValue="builtin" />
         <PreferenceScreen
             android:fragment="org.exarhteam.iitc_mobile.fragments.PluginsFragment"
             android:key="pref_plugins"

--- a/mobile/app/src/main/res/xml/preferences.xml
+++ b/mobile/app/src/main/res/xml/preferences.xml
@@ -144,6 +144,10 @@
                     android:key="pref_update_plugins_interval"
                     android:title="@string/pref_update_plugins_interval"
                     android:summary="@string/pref_update_plugins_interval_sum"/>
+                <Preference
+                    android:key="pref_force_channel_update"
+                    android:title="@string/pref_force_channel_update"
+                    android:summary="@string/pref_force_channel_update_sum"/>
                 <org.exarhteam.iitc_mobile.prefs.ForceUpdatePreference
                     android:key="pref_force_plugin_update"
                     android:title="@string/pref_force_plugin_update"

--- a/mobile/app/src/main/res/xml/preferences.xml
+++ b/mobile/app/src/main/res/xml/preferences.xml
@@ -131,6 +131,13 @@
                 android:key="pref_update_plugins"
                 android:title="@string/pref_update_plugins_cat">
                 <ListPreference
+                    android:defaultValue="1"
+                    android:entries="@array/pref_update_plugins_interval_titles"
+                    android:entryValues="@array/pref_update_plugins_interval_values"
+                    android:key="pref_channel_update_interval"
+                    android:title="@string/pref_channel_update_interval"
+                    android:summary="@string/pref_channel_update_interval_sum"/>
+                <ListPreference
                     android:defaultValue="7"
                     android:entries="@array/pref_update_plugins_interval_titles"
                     android:entryValues="@array/pref_update_plugins_interval_values"


### PR DESCRIPTION
Add the ability to select an update channel for IITC scripts (core + plugins).
Users can choose between Built-in (default, bundled with APK), Release, Beta, or a Custom URL.
Scripts are downloaded and cached locally, with configurable auto-update interval.
The built-in channel remains the default, preserving current behavior.