### PR TITLE
mobile: fix crashes and ANR reported via Google Play

### DIFF
--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_FileManager.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_FileManager.java
@@ -330,6 +330,7 @@ public class IITC_FileManager {
         final Thread thread = new Thread(new Runnable() {
             @Override
             public void run() {
+                boolean success = false;
                 try {
                     final String url = uri.toString();
                     InputStream is;
@@ -356,6 +357,7 @@ public class IITC_FileManager {
                         throw new IOException("Failed to create plugin file");
                     }
 
+                    success = true;
                     mActivity.runOnUiThread(() ->
                             Toast.makeText(mActivity, R.string.plugin_install_successful, Toast.LENGTH_SHORT).show()
                     );
@@ -365,17 +367,14 @@ public class IITC_FileManager {
                             Toast.makeText(mActivity, R.string.plugin_install_failed, Toast.LENGTH_SHORT).show()
                     );
                 }
+                if (success && invalidateHeaders && mActivity instanceof PluginPreferenceActivity) {
+                    mActivity.runOnUiThread(() ->
+                            ((PluginPreferenceActivity) mActivity).invalidateHeaders()
+                    );
+                }
             }
         });
         thread.start();
-        if (invalidateHeaders) {
-            try {
-                thread.join();
-                ((PluginPreferenceActivity) mActivity).invalidateHeaders();
-            } catch (final InterruptedException e) {
-                Log.w(e);
-            }
-        }
     }
 
     public void updatePlugins(final boolean force) {

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_FileManager.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_FileManager.java
@@ -361,7 +361,7 @@ public class IITC_FileManager {
                     mActivity.runOnUiThread(() ->
                             Toast.makeText(mActivity, R.string.plugin_install_successful, Toast.LENGTH_SHORT).show()
                     );
-                } catch (final IOException e) {
+                } catch (IOException | SecurityException e) {
                     Log.w(e);
                     mActivity.runOnUiThread(() ->
                             Toast.makeText(mActivity, R.string.plugin_install_failed, Toast.LENGTH_SHORT).show()

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/fragments/PluginsFragment.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/fragments/PluginsFragment.java
@@ -45,8 +45,10 @@ public class PluginsFragment extends PreferenceFragment {
 
             // add plugin checkbox preferences
             PreferenceScreen preferenceScreen = getPreferenceScreen();
-            for (PluginInfo pluginInfo : prefs) {
-                preferenceScreen.addPreference(createPluginPreference(prefs, preferenceScreen, pluginInfo));
+            if (prefs != null) {
+                for (PluginInfo pluginInfo : prefs) {
+                    preferenceScreen.addPreference(createPluginPreference(prefs, preferenceScreen, pluginInfo));
+                }
             }
 
             // set action bar stuff

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/prefs/PluginPreferenceActivity.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/prefs/PluginPreferenceActivity.java
@@ -52,8 +52,9 @@ public class PluginPreferenceActivity extends PreferenceActivity {
 
     @Override
     public void setListAdapter(final ListAdapter adapter) {
-        if (adapter == null) {
-            super.setListAdapter(null);
+        // mHeaders is null on state restore (onBuildHeaders skipped); invalidateHeaders() in onCreate rebuilds
+        if (adapter == null || mHeaders == null) {
+            super.setListAdapter(adapter);
         } else {
             super.setListAdapter(new HeaderAdapter(this, mHeaders));
         }
@@ -61,13 +62,13 @@ public class PluginPreferenceActivity extends PreferenceActivity {
 
     @Override
     public void onBuildHeaders(final List<Header> target) {
+        mHeaders = target;
+
         getActionBar().setDisplayHomeAsUpEnabled(true);
 
         // notify about external plugins
         final IITC_NotificationHelper nh = new IITC_NotificationHelper(this);
         nh.showNotice(IITC_NotificationHelper.NOTICE_EXTPLUGINS);
-
-        mHeaders = target;
 
         // Always rebuild plugin data to catch new installations
         setUpPluginPreferenceScreen();
@@ -90,7 +91,19 @@ public class PluginPreferenceActivity extends PreferenceActivity {
         if (uri != null) {
             mFileManager.installPlugin(uri, true);
         }
+
+        // state restore re-creates fragments inside super.onCreate before onBuildHeaders runs;
+        // populate plugin data up front so fragments can read sAssetPlugins/sUserPlugins
+        if (savedInstanceState != null) {
+            setUpPluginPreferenceScreen();
+        }
+
         super.onCreate(savedInstanceState);
+
+        // state restore skips onBuildHeaders; force rebuild to populate mHeaders
+        if (mHeaders == null) {
+            invalidateHeaders();
+        }
 
         // Fix for legacy PreferenceActivity not setting fitsSystemWindows on some devices
         android.view.View contentView = findViewById(android.R.id.content);


### PR DESCRIPTION
Fixes several issues reported through Google Play crash reports:

- Fix crashes in plugin preferences on activity state restore (rotation, process kill): PreferenceActivity skipped onBuildHeaders on restore, leaving plugin data and header list uninitialized
- Fix ANR when installing plugins via URL: main thread was blocked on Thread.join() during network download
- Fix crash when installing a plugin after granting folder access:
  content:// URI permission granted by the file picker was already revoked by the time the pending install was retried
