### PR TITLE
Shorter delays

### DIFF
--- a/core/code/map.js
+++ b/core/code/map.js
@@ -409,29 +409,4 @@ window.setupMap = function () {
     // Start map refresh (after Map location is set)
     window.mapDataRequest.start();
   });
-
-  /* !!This block is commented out as it's unlikely that we still need this workaround in leaflet 1+
-  // on zoomend, check to see the zoom level is an int, and reset the view if not
-  // (there's a bug on mobile where zoom levels sometimes end up as fractional levels. this causes the base map to be invisible)
-  map.on('zoomend', function() {
-    var z = map.getZoom();
-    if (z != parseInt(z))
-    {
-      log.warn('Non-integer zoom level at zoomend: '+z+' - trying to fix...');
-      map.setZoom(parseInt(z), {animate:false});
-    }
-  });
-  */
-
-  /* !!This block is commented out as it's unlikely that we still need this workaround in leaflet 1+
-  // Fix Leaflet: handle touchcancel events in Draggable
-  L.Draggable.prototype._onDownOrig = L.Draggable.prototype._onDown;
-  L.Draggable.prototype._onDown = function(e) {
-    L.Draggable.prototype._onDownOrig.apply(this, arguments);
-
-    if(e.type === "touchstart") {
-      L.DomEvent.on(document, "touchcancel", this._onUp, this);
-    }
-  };
-  */
 };

--- a/core/code/map.js
+++ b/core/code/map.js
@@ -371,7 +371,6 @@ window.setupMap = function () {
 
   // create the map data requester
   window.mapDataRequest = new window.MapDataRequest();
-  window.mapDataRequest.start();
 
   // start the refresh process with a small timeout, so the first data request happens quickly
   // (the code originally called the request function directly, and triggered a normal delay for the next refresh.
@@ -406,6 +405,9 @@ window.setupMap = function () {
     map.on('baselayerchange', function () {
       map.setZoom(map.getZoom());
     });
+
+    // Start map refresh (after Map location is set)
+    window.mapDataRequest.start();
   });
 
   /* !!This block is commented out as it's unlikely that we still need this workaround in leaflet 1+

--- a/core/code/map_data_request.js
+++ b/core/code/map_data_request.js
@@ -31,8 +31,8 @@ window.MapDataRequest = function () {
   this.MAX_TILE_RETRIES = 5;
 
   // refresh timers
-  this.MOVE_REFRESH = 3; // time, after a map move (pan/zoom) before starting the refresh processing
-  this.STARTUP_REFRESH = 3; // refresh time used on first load of IITC
+  this.MOVE_REFRESH = 0.4; // time, after a map move (pan/zoom) before starting the refresh processing
+  this.STARTUP_REFRESH = 0.1; // refresh time used on first load of IITC
   this.IDLE_RESUME_REFRESH = 5; // refresh time used after resuming from idle
 
   // after one of the above, there's an additional delay between preparing the refresh (clearing out of bounds,

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -264,7 +264,7 @@ window.ZOOM_LEVEL_ADJ = 5;
  * @type {number}
  * @memberof config_options
  */
-window.ON_MOVE_REFRESH = 2.5;
+window.ON_MOVE_REFRESH = 0.4;
 
 /**
  * Limit on refresh time since previous refresh, limiting repeated move refresh rate, in seconds, default 10


### PR DESCRIPTION
By comparing IITC with Vanilla Intel, it’s clear that Intel performs significantly faster.

While investigation is still ongoing, one key difference stands out:  
Intel uses much shorter delays before requesting tiles.

- It sends a request immediately after the base map layer loads (essentially right after initialization), which is about **1.5 seconds after the initial page request**.  
- After a pan or zoom action, it waits only **~0.4 seconds** before triggering tile requests.

In contrast, IITC currently uses much longer delays. While these values were reasonable in the past (and compared well to older Intel versions), they are now noticeably slower:

- The first tile request is sent **~5.6 seconds after the page request starts**.  
- After pan/zoom, IITC waits **~3 seconds** before requesting tiles.

## Changes in this PR

- Set the **initial refresh delay** to **0.1 seconds after IITC initialization**  
  (not zero, to give legacy plugins a small buffer — this could potentially be reduced or removed later)
- Set **pan/zoom delay** to **0.4 seconds**, matching Intel
- Set **chat pan/zoom delay** to **0.4 seconds**, matching Intel

With these adjustments, the first tile request in IITC occurs **~2.8 seconds after the page request starts**.

## Bug fix

- Fixed an issue where the **initial loading timer was being overwritten by the initial map position update**