### PR TITLE
Prefetch portal details (desktop only)

### DIFF
--- a/core/code/portal_detail.js
+++ b/core/code/portal_detail.js
@@ -58,30 +58,31 @@ window.portalDetail.remove = function (guid) {
   return cache.remove(guid);
 };
 
-var handleResponse = function (deferred, guid, data, success) {
+var handleResponseSuccess = function (deferred, guid, data) {
   if (!data || data.error || !data.result) {
-    success = false;
+    handleResponseFailure(deferred, guid, data);
+    return;
   }
 
-  if (success) {
-    // Parse portal details
-    var dict = window.decodeArray.portal(data.result, 'detailed');
-    cache.store(guid, dict);
+  // Parse portal details
+  var dict = window.decodeArray.portal(data.result, 'detailed');
+  cache.store(guid, dict);
 
-    // entity format, as used in map data
-    var ent = [guid, data.result[13], data.result];
-    var portal = window.mapDataRequest.render.createPortalEntity(ent, 'detailed');
+  // entity format, as used in map data
+  var ent = [guid, data.result[13], data.result];
+  var portal = window.mapDataRequest.render.createPortalEntity(ent, 'detailed');
 
-    deferred.resolve(portal.options.data);
-    window.runHooks('portalDetailLoaded', { guid: guid, success: success, details: portal.options.data, ent: ent, portal: portal });
+  deferred.resolve(portal.options.data);
+  window.runHooks('portalDetailLoaded', { guid: guid, success: true, details: portal.options.data, ent: ent, portal: portal });
+};
+
+var handleResponseFailure = function (deferred, guid, data) {
+  if (data && data.error === 'RETRY') {
+    // server asked us to try again
+    doRequest(deferred, guid);
   } else {
-    if (data && data.error === 'RETRY') {
-      // server asked us to try again
-      doRequest(deferred, guid);
-    } else {
-      deferred.reject();
-      window.runHooks('portalDetailLoaded', { guid: guid, success: success });
-    }
+    deferred.reject();
+    window.runHooks('portalDetailLoaded', { guid: guid, success: false });
   }
 };
 
@@ -90,10 +91,10 @@ var doRequest = function (deferred, guid) {
     'getPortalDetails',
     { guid: guid },
     function (data) {
-      handleResponse(deferred, guid, data, true);
+      handleResponseSuccess(deferred, guid, data);
     },
     function () {
-      handleResponse(deferred, guid, undefined, false);
+      handleResponseFailure(deferred, guid);
     }
   );
 };

--- a/core/code/portal_detail.js
+++ b/core/code/portal_detail.js
@@ -58,7 +58,7 @@ window.portalDetail.remove = function (guid) {
   return cache.remove(guid);
 };
 
-var handleResponseSuccess = function (deferred, guid, data) {
+var handleResponseSuccess = function (deferred, guid, data, prefetch) {
   if (!data || data.error || !data.result) {
     handleResponseFailure(deferred, guid, data);
     return;
@@ -74,6 +74,11 @@ var handleResponseSuccess = function (deferred, guid, data) {
 
   deferred.resolve(portal.options.data);
   window.runHooks('portalDetailLoaded', { guid: guid, success: true, details: portal.options.data, ent: ent, portal: portal });
+
+  // prefetch portal image
+  if (prefetch && portal.options.data.image) {
+    new Image().src = portal.options.data.image;
+  }
 };
 
 var handleResponseFailure = function (deferred, guid, data) {
@@ -86,12 +91,12 @@ var handleResponseFailure = function (deferred, guid, data) {
   }
 };
 
-var doRequest = function (deferred, guid) {
+var doRequest = function (deferred, guid, prefetch) {
   window.postAjax(
     'getPortalDetails',
     { guid: guid },
     function (data) {
-      handleResponseSuccess(deferred, guid, data);
+      handleResponseSuccess(deferred, guid, data, prefetch);
     },
     function () {
       handleResponseFailure(deferred, guid);
@@ -107,7 +112,7 @@ var doRequest = function (deferred, guid) {
  * @param {string} guid - The Global Unique Identifier of the portal.
  * @returns {Promise} A promise that resolves with the portal details upon successful retrieval or rejection on failure.
  */
-window.portalDetail.request = function (guid) {
+window.portalDetail.request = function (guid, prefetch = false) {
   if (!requestQueue[guid]) {
     var deferred = $.Deferred();
     requestQueue[guid] = deferred.promise();
@@ -115,7 +120,7 @@ window.portalDetail.request = function (guid) {
       delete requestQueue[guid];
     });
 
-    doRequest(deferred, guid);
+    doRequest(deferred, guid, prefetch);
   }
 
   return requestQueue[guid];

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -5,6 +5,8 @@
  * @module portal_marker
  */
 
+const PREFETCH_TIME = 200; // if the mouse stays these miliseconds on the marker prefetch portal details
+
 // portal hooks
 function handler_portal_click(e) {
   window.selectPortal(e.target.options.guid, e.type);
@@ -24,6 +26,23 @@ function handler_portal_contextmenu(e) {
     window.show('info');
   } else if (!$('#scrollwrapper').is(':visible')) {
     $('#sidebartoggle').click();
+  }
+}
+
+function handler_portal_mouse_enter(e) {
+  window.clearTimeout(e.target.options.prefetchTimer);
+  e.target.options.prefetchTimer = window.setTimeout(() => do_prefetch(e), PREFETCH_TIME);
+}
+
+function handler_portal_mouse_leave(e) {
+  window.clearTimeout(e.target.options.prefetchTimer);
+}
+
+function do_prefetch(e) {
+  const guid = e.target.options.guid;
+  if (guid && !window.portalDetail.isFresh(guid)) {
+    log.debug(`prefetch portal details ${guid}`);
+    window.portalDetail.request(guid, true);
   }
 }
 
@@ -57,6 +76,8 @@ L.PortalMarker = L.CircleMarker.extend({
     this.on('click', handler_portal_click);
     this.on('dblclick', handler_portal_dblclick);
     this.on('contextmenu', handler_portal_contextmenu);
+    this.on('mouseover', handler_portal_mouse_enter);
+    this.on('mouseout', handler_portal_mouse_leave);
   },
 
   willUpdate: function (details) {


### PR DESCRIPTION
Make portal details appear instant.

In reality, this does not speed up the actual request itself.   
Instead, it preloads portal data when the user hovers over a marker.

This gives IITC a head start when the user selects a portal, making the details feel instant.  
The trade-off is **increased network traffic** in cases where the user hovers over a marker but does not click it.

note: mouseover won't work on mobile, so this is desktop only
