### PR TITLE
[experiment, do not merge] Portal prefetch usage statistics

### DIFF
--- a/core/code/portal_detail.js
+++ b/core/code/portal_detail.js
@@ -58,7 +58,7 @@ window.portalDetail.remove = function (guid) {
   return cache.remove(guid);
 };
 
-var handleResponseSuccess = function (deferred, guid, data) {
+var handleResponseSuccess = function (deferred, guid, data, prefetch) {
   if (!data || data.error || !data.result) {
     handleResponseFailure(deferred, guid, data);
     return;
@@ -74,6 +74,11 @@ var handleResponseSuccess = function (deferred, guid, data) {
 
   deferred.resolve(portal.options.data);
   window.runHooks('portalDetailLoaded', { guid: guid, success: true, details: portal.options.data, ent: ent, portal: portal });
+
+  // prefetch portal image
+  if (prefetch && portal.options.data.image) {
+      (new Image()).src = portal.options.data.image;
+  }  
 };
 
 var handleResponseFailure = function (deferred, guid, data) {
@@ -86,12 +91,12 @@ var handleResponseFailure = function (deferred, guid, data) {
   }
 };
 
-var doRequest = function (deferred, guid) {
+var doRequest = function (deferred, guid, prefetch) {
   window.postAjax(
     'getPortalDetails',
     { guid: guid },
     function (data) {
-      handleResponseSuccess(deferred, guid, data);
+      handleResponseSuccess(deferred, guid, data, prefetch);
     },
     function () {
       handleResponseFailure(deferred, guid);
@@ -107,7 +112,7 @@ var doRequest = function (deferred, guid) {
  * @param {string} guid - The Global Unique Identifier of the portal.
  * @returns {Promise} A promise that resolves with the portal details upon successful retrieval or rejection on failure.
  */
-window.portalDetail.request = function (guid) {
+window.portalDetail.request = function (guid, prefetch = false) {
   if (!requestQueue[guid]) {
     var deferred = $.Deferred();
     requestQueue[guid] = deferred.promise();
@@ -115,7 +120,7 @@ window.portalDetail.request = function (guid) {
       delete requestQueue[guid];
     });
 
-    doRequest(deferred, guid);
+    doRequest(deferred, guid, prefetch);
   }
 
   return requestQueue[guid];

--- a/core/code/portal_detail.js
+++ b/core/code/portal_detail.js
@@ -60,7 +60,7 @@ window.portalDetail.remove = function (guid) {
 
 var handleResponseSuccess = function (deferred, guid, data, prefetch) {
   if (!data || data.error || !data.result) {
-    handleResponseFailure(deferred, guid, data);
+    handleResponseFailure(deferred, guid, data, prefetch);
     return;
   }
 
@@ -73,18 +73,18 @@ var handleResponseSuccess = function (deferred, guid, data, prefetch) {
   var portal = window.mapDataRequest.render.createPortalEntity(ent, 'detailed');
 
   deferred.resolve(portal.options.data);
-  window.runHooks('portalDetailLoaded', { guid: guid, success: true, details: portal.options.data, ent: ent, portal: portal });
+  window.runHooks('portalDetailLoaded', { guid: guid, success: true, details: portal.options.data, ent: ent, portal: portal, prefetch: !!prefetch });
 
   // prefetch portal image
   if (prefetch && portal.options.data.image) {
       (new Image()).src = portal.options.data.image;
-  }  
+  }
 };
 
-var handleResponseFailure = function (deferred, guid, data) {
+var handleResponseFailure = function (deferred, guid, data, prefetch) {
   if (data && data.error === 'RETRY') {
     // server asked us to try again
-    doRequest(deferred, guid);
+    doRequest(deferred, guid, prefetch);
   } else {
     deferred.reject();
     window.runHooks('portalDetailLoaded', { guid: guid, success: false });

--- a/core/code/portal_detail.js
+++ b/core/code/portal_detail.js
@@ -58,30 +58,31 @@ window.portalDetail.remove = function (guid) {
   return cache.remove(guid);
 };
 
-var handleResponse = function (deferred, guid, data, success) {
+var handleResponseSuccess = function (deferred, guid, data) {
   if (!data || data.error || !data.result) {
-    success = false;
+    handleResponseFailure(deferred, guid, data);
+    return;
   }
 
-  if (success) {
-    // Parse portal details
-    var dict = window.decodeArray.portal(data.result, 'detailed');
-    cache.store(guid, dict);
+  // Parse portal details
+  var dict = window.decodeArray.portal(data.result, 'detailed');
+  cache.store(guid, dict);
 
-    // entity format, as used in map data
-    var ent = [guid, data.result[13], data.result];
-    var portal = window.mapDataRequest.render.createPortalEntity(ent, 'detailed');
+  // entity format, as used in map data
+  var ent = [guid, data.result[13], data.result];
+  var portal = window.mapDataRequest.render.createPortalEntity(ent, 'detailed');
 
-    deferred.resolve(portal.options.data);
-    window.runHooks('portalDetailLoaded', { guid: guid, success: success, details: portal.options.data, ent: ent, portal: portal });
+  deferred.resolve(portal.options.data);
+  window.runHooks('portalDetailLoaded', { guid: guid, success: true, details: portal.options.data, ent: ent, portal: portal });
+};
+
+var handleResponseFailure = function (deferred, guid, data) {
+  if (data && data.error === 'RETRY') {
+    // server asked us to try again
+    doRequest(deferred, guid);
   } else {
-    if (data && data.error === 'RETRY') {
-      // server asked us to try again
-      doRequest(deferred, guid);
-    } else {
-      deferred.reject();
-      window.runHooks('portalDetailLoaded', { guid: guid, success: success });
-    }
+    deferred.reject();
+    window.runHooks('portalDetailLoaded', { guid: guid, success: false });
   }
 };
 
@@ -90,10 +91,10 @@ var doRequest = function (deferred, guid) {
     'getPortalDetails',
     { guid: guid },
     function (data) {
-      handleResponse(deferred, guid, data, true);
+      handleResponseSuccess(deferred, guid, data);
     },
     function () {
-      handleResponse(deferred, guid, undefined, false);
+      handleResponseFailure(deferred, guid);
     }
   );
 };

--- a/core/code/portal_marker.js
+++ b/core/code/portal_marker.js
@@ -5,6 +5,8 @@
  * @module portal_marker
  */
 
+const PREFETCH_TIME = 200; // if the mouse stays these miliseconds on the marker prefetch portal details
+
 // portal hooks
 function handler_portal_click(e) {
   window.selectPortal(e.target.options.guid, e.type);
@@ -25,6 +27,23 @@ function handler_portal_contextmenu(e) {
   } else if (!$('#scrollwrapper').is(':visible')) {
     $('#sidebartoggle').click();
   }
+}
+
+function handler_portal_mouse_enter(e) {
+  window.clearTimeout(e.target.options.prefetchTimer);
+  e.target.options.prefetchTimer = window.setTimeout(()=>do_prefetch(e), PREFETCH_TIME);
+}
+
+function handler_portal_mouse_leave(e) {
+  window.clearTimeout(e.target.options.prefetchTimer);
+}
+
+function do_prefetch(e) {
+  const guid = e.target.options.guid;
+  if (guid && !window.portalDetail.isFresh(guid)) {
+    log.debug(`prefetch portal details ${guid}`);
+    window.portalDetail.request(guid, true);
+  }  
 }
 
 L.PortalMarker = L.CircleMarker.extend({
@@ -57,6 +76,8 @@ L.PortalMarker = L.CircleMarker.extend({
     this.on('click', handler_portal_click);
     this.on('dblclick', handler_portal_dblclick);
     this.on('contextmenu', handler_portal_contextmenu);
+    this.on('mouseover', handler_portal_mouse_enter);
+    this.on('mouseout', handler_portal_mouse_leave);    
   },
 
   willUpdate: function (details) {

--- a/plugins/prefetch-stats.js
+++ b/plugins/prefetch-stats.js
@@ -1,0 +1,134 @@
+// @author         modos189
+// @name           Prefetch statistics
+// @category       Debug
+// @version        0.1.0
+// @description    Track and display portal detail prefetch statistics: total fetches, wasted prefetches, and cold fetches (no prefetch).
+
+/* exported setup --eslint */
+/* global IITC -- eslint */
+
+// use own namespace for plugin
+window.plugin.prefetchStats = {};
+
+var STORAGE_KEY = 'plugin-prefetch-stats';
+
+var stats = {
+  total: 0,
+  prefetchWithoutClick: 0,
+  clickWithoutPrefetch: 0,
+};
+
+function loadStats() {
+  var stored = localStorage.getItem(STORAGE_KEY);
+  if (!stored) return;
+  try {
+    var parsed = JSON.parse(stored);
+    stats.total = parsed.total || 0;
+    stats.prefetchWithoutClick = parsed.prefetchWithoutClick || 0;
+    stats.clickWithoutPrefetch = parsed.clickWithoutPrefetch || 0;
+  } catch (e) {
+    // ignore malformed data
+  }
+}
+
+function saveStats() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(stats));
+}
+
+function buildDialogHtml() {
+  var prefetchUsed = stats.total - stats.prefetchWithoutClick - stats.clickWithoutPrefetch;
+
+  var rows = [
+    ['Total portal data fetches', stats.total],
+    ['Prefetched, then clicked (prefetch helped)', prefetchUsed],
+    ['Prefetched, but never clicked (wasted prefetch)', stats.prefetchWithoutClick],
+    ['Clicked without prior prefetch (cold fetch)', stats.clickWithoutPrefetch],
+  ];
+
+  var html = '<table id="prefetch-stats-table">';
+  rows.forEach(function (row) {
+    html += '<tr><td>' + row[0] + '</td><td class="prefetch-stats-num">' + Math.max(0, row[1]) + '</td></tr>';
+  });
+  html += '</table>';
+
+  if (stats.total > 0) {
+    var userFetches = prefetchUsed + stats.clickWithoutPrefetch;
+    if (userFetches > 0) {
+      var hitRate = ((prefetchUsed / userFetches) * 100).toFixed(1);
+      html += '<p class="prefetch-stats-rate">Prefetch hit rate (user-triggered fetches): <b>' + hitRate + '%</b></p>';
+    }
+
+    var allPrefetches = prefetchUsed + stats.prefetchWithoutClick;
+    if (allPrefetches > 0) {
+      var usefulRate = ((prefetchUsed / allPrefetches) * 100).toFixed(1);
+      html += '<p class="prefetch-stats-rate">Useful prefetch rate (prefetch requests used): <b>' + usefulRate + '%</b></p>';
+    }
+  }
+
+  html += '<p><button id="prefetch-stats-reset">Reset statistics</button></p>';
+  return html;
+}
+
+function showStats() {
+  var container = window.dialog({
+    html: buildDialogHtml(),
+    title: 'Prefetch Statistics',
+    id: 'plugin-prefetch-stats',
+    width: 'auto',
+  });
+
+  container.on('click', '#prefetch-stats-reset', function () {
+    window.plugin.prefetchStats.resetStats();
+  });
+}
+
+window.plugin.prefetchStats.resetStats = function () {
+  stats.total = 0;
+  stats.prefetchWithoutClick = 0;
+  stats.clickWithoutPrefetch = 0;
+  saveStats();
+  var dlg = document.getElementById('plugin-prefetch-stats');
+  if (dlg) {
+    $(dlg).html(buildDialogHtml());
+    $(dlg).off('click', '#prefetch-stats-reset').on('click', '#prefetch-stats-reset', function () {
+      window.plugin.prefetchStats.resetStats();
+    });
+  }
+};
+
+function onPortalDetailLoaded(data) {
+  if (!data.success) return;
+
+  stats.total++;
+
+  if (data.prefetch) {
+    // Prefetch response: check if user had already selected this portal (clicked it while loading)
+    if (window.selectedPortal !== data.guid) {
+      stats.prefetchWithoutClick++;
+    }
+  } else {
+    // User-triggered fetch: no prefetch was in progress, so user clicked before the prefetch timer fired
+    stats.clickWithoutPrefetch++;
+  }
+
+  saveStats();
+}
+
+function setup() {
+  loadStats();
+
+  window.addHook('portalDetailLoaded', onPortalDetailLoaded);
+
+  IITC.toolbox.addButton({
+    label: 'Prefetch stats',
+    title: 'Show portal detail prefetch statistics',
+    action: showStats,
+  });
+
+  $('<style>').prop('type', 'text/css').text(
+    '#prefetch-stats-table { border-collapse: collapse; width: 100%; margin-bottom: 8px; }' +
+    '#prefetch-stats-table td { padding: 4px 8px; border-bottom: 1px solid #0b314e; }' +
+    '#prefetch-stats-table .prefetch-stats-num { text-align: right; font-weight: bold; min-width: 4em; }' +
+    '.prefetch-stats-rate { margin: 4px 0; }'
+  ).appendTo('head');
+}


### PR DESCRIPTION
Adds a debug plugin to collect real-world data on portal detail prefetch effectiveness.

Tracks: total fetches, wasted prefetches (hover but no click), and cold fetches (click before prefetch timer).

see https://github.com/IITC-CE/ingress-intel-total-conversion/pull/905