### PR TITLE
url-parameter: move to own function

### DIFF
--- a/core/code/_deprecated.js
+++ b/core/code/_deprecated.js
@@ -259,3 +259,19 @@ Object.defineProperty(window, 'CHAT_SHRINKED', {
   },
   configurable: true,
 });
+
+/**
+ * Portal GUID if the original URL had it.
+ * @type {string|null}
+ * @memberof storage_variables
+ * @deprecated use window.selectPortalWhenLoadedByLatLng(latLng: L.LatLng);
+ */
+window.urlPortal = null;
+
+/**
+ * Portal lng/lat if the orignial URL had it.
+ * @type {object|null}
+ * @memberof storage_variables
+ * @deprecated use window.selectPortalWhenLoadedByGuid(guid: PortalGUID);
+ */
+window.urlPortalLL = null;

--- a/core/code/map.js
+++ b/core/code/map.js
@@ -391,14 +391,7 @@ window.setupMap = function () {
     }
     map.setView(pos.center, pos.zoom, { reset: true });
 
-    // read here ONCE, so the URL is only evaluated one time after the
-    // necessary data has been loaded.
-    var pll = window.getURLParam('pll');
-    if (pll) {
-      pll = pll.split(',');
-      window.urlPortalLL = normLL(pll[0], pll[1]).center;
-    }
-    window.urlPortal = window.getURLParam('pguid');
+    parseURLParameters();
 
     // todo check
     // leaflet no longer ensures the base layer zoom is suitable for the map (a bug? feature change?), so do so here
@@ -409,4 +402,21 @@ window.setupMap = function () {
     // Start map refresh (after Map location is set)
     window.mapDataRequest.start();
   });
+};
+
+const parseURLParameters = () => {
+  // read here ONCE, so the URL is only evaluated one time after the
+  // necessary data has been loaded.
+  var pll = window.getURLParam('pll');
+  if (pll) {
+    pll = pll.split(',');
+    const center = normLL(pll[0], pll[1]).center;
+    const latLng = new L.LatLng(center[0], center[1]);
+    window.selectPortalWhenLoadedByLatLng(latLng);
+  }
+
+  const urlPGuid = window.getURLParam('pguid');
+  if (urlPGuid) {
+    window.selectPortalWhenLoadedByGuid(urlPGuid);
+  }
 };

--- a/core/code/map_data_render.js
+++ b/core/code/map_data_render.js
@@ -382,21 +382,6 @@ window.Render.prototype.createPortalEntity = function (ent, details) {
 
   window.pushPortalGuidPositionCache(data.guid, data.latE6, data.lngE6);
 
-  // check for URL links to portal, and select it if this is the one
-  if (window.urlPortalLL && window.urlPortalLL[0] === latlng.lat && window.urlPortalLL[1] === latlng.lng) {
-    // URL-passed portal found via pll parameter - set the guid-based parameter
-    log.log('urlPortalLL ' + window.urlPortalLL[0] + ',' + window.urlPortalLL[1] + ' matches portal GUID ' + data.guid);
-
-    window.urlPortal = data.guid;
-    window.urlPortalLL = undefined; // clear the URL parameter so it's not matched again
-  }
-  if (window.urlPortal === data.guid) {
-    // URL-passed portal found via guid parameter - set it as the selected portal
-    log.log('urlPortal GUID ' + window.urlPortal + ' found - selecting...');
-    window.selectedPortal = data.guid;
-    window.urlPortal = undefined; // clear the URL parameter so it's not matched again
-  }
-
   let marker = undefined;
   if (oldPortal) {
     // update marker style/highlight and layer
@@ -430,7 +415,6 @@ window.Render.prototype.createPortalEntity = function (ent, details) {
 
     window.portals[data.guid] = marker;
   }
-
 
   window.ornaments.addPortal(marker);
 

--- a/core/code/portal_data.js
+++ b/core/code/portal_data.js
@@ -1,4 +1,4 @@
-/* global L -- eslint */
+/* global L, log -- eslint */
 
 /**
  * @file Contain misc functions to get portal info
@@ -87,7 +87,7 @@ window.zoomToAndShowPortal = function (guid, latlng) {
   // if the data is available, render it immediately. Otherwise defer
   // until it becomes available.
   if (window.portals[guid]) window.renderPortalDetails(guid);
-  else window.urlPortal = guid;
+  else window.selectPortalWhenLoadedByGuid(guid);
 };
 
 /**
@@ -115,8 +115,67 @@ window.selectPortalByLatLng = function (lat, lng) {
   }
 
   // not currently visible
-  window.urlPortalLL = [lat, lng];
-  window.map.setView(window.urlPortalLL, window.DEFAULT_ZOOM);
+  const ll = new L.LatLng(lat, lng);
+  window.selectPortalWhenLoadedByLatLng(ll);
+  window.map.setView(ll, window.DEFAULT_ZOOM);
+};
+
+let urlPortalLL;
+/**
+ * Select a portal when it appears on the map
+ *
+ * @function
+ * @name selectPortalWhenLoadedByLatLng
+ * @param {L.LatLng} latLng - the location of the portal
+ */
+window.selectPortalWhenLoadedByLatLng = (latLng) => {
+  if (urlPortalLL === undefined) {
+    window.addHook('portalAdded', testPortalLatLng);
+  }
+
+  urlPortalLL = latLng;
+  window.urlPortalLL = latLng; // @deprecated
+};
+
+const testPortalLatLng = (data) => {
+  if (data.portal.getLatLng().equals(urlPortalLL)) {
+    log.log(`urlPortalLL ${urlPortalLL.toString()} matches portal GUID ${data.portal.options.guid}`);
+    window.selectedPortal = data.portal.options.guid;
+    window.renderPortalDetails(window.selectedPortal, true);
+    urlPortalLL = undefined;
+    window.urlPortalLL = undefined; // @deprecated
+  }
+
+  if (!urlPortalLL) window.removeHook('portalAdded', testPortalLatLng);
+};
+
+let urlPortal;
+/**
+ * Select a portal when it appears on the map
+ *
+ * @function
+ * @name selectPortalWhenLoadedByGuid
+ * @param {string} guid - the guid of the portal
+ */
+window.selectPortalWhenLoadedByGuid = (guid) => {
+  if (urlPortal === undefined) {
+    window.addHook('portalAdded', testPortalGuid);
+  }
+
+  urlPortal = guid;
+  window.urlPortal = guid; // @deprecated
+};
+
+const testPortalGuid = (data) => {
+  if (data.portal.options.guid === urlPortal) {
+    log.log(`urlPortal GUID ${window.urlPortal} found - selecting...`);
+    window.selectedPortal = urlPortal;
+    window.renderPortalDetails(window.selectedPortal, true);
+    urlPortal = undefined;
+    window.urlPortal = undefined; // @deprecated
+  }
+
+  if (!urlPortal) window.removeHook('portalAdded', testPortalGuid);
 };
 
 (function () {

--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -86,7 +86,7 @@ window.renderPortalDetails = function (guid, forceSelect) {
   }
 
   if (!guid || !window.portals[guid]) {
-    window.urlPortal = guid;
+    window.selectPortalWhenLoadedByGuid(guid);
     $('#portaldetails').html('');
     IITC.statusbar.portal.update();
     if (window.isSmartphone()) {

--- a/core/code/search_hooks.js
+++ b/core/code/search_hooks.js
@@ -68,7 +68,8 @@ window.addHook('search', (query) => {
             return;
           }
         }
-        window.urlPortalLL = [result.position.lat, result.position.lng];
+
+        window.selectPortalWhenLoadedByLatLng(result.position);
       },
     });
   };

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -686,20 +686,6 @@ window.TEAM_CODE_MAC = window.TEAM_CODES[window.TEAM_MAC];
 window.refreshTimeout = undefined;
 
 /**
- * Portal GUID if the original URL had it.
- * @type {string|null}
- * @memberof storage_variables
- */
-window.urlPortal = null;
-
-/**
- * Portal lng/lat if the orignial URL had it.
- * @type {object|null}
- * @memberof storage_variables
- */
-window.urlPortalLL = null;
-
-/**
  * Stores the GUID of the selected portal, or is `null` if there is none.
  * @type {string|null}
  * @memberof storage_variables


### PR DESCRIPTION
IITC (and Intel) support two URL parameters:

- `pll` — selects a portal by latitude/longitude when opening the map  
- `pguid` — selects a portal by GUID when opening the map  

Currently, these parameters are parsed at startup and then checked on every new portal creation.

This PR moves that logic into a dedicated hook, which is only active until the portal selection has been fulfilled.

The functions `selectPortalWhenLoadedByLatLng` and `selectPortalWhenLoadedByGuid` now register these hooks, replacing the corresponding logic previously located in `createPortalEntity`.

(this separated the responsibilty and saves a nanosecond in the render loop)