### PR TITLE
draw-tools: sync drawn items across devices via Sync plugin

### DIFF
--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -1,13 +1,14 @@
 // @author         ZasoGD
 // @name           Bookmarks for maps and portals
 // @category       Controls
-// @version        0.4.7
+// @version        0.4.8
 // @description    Save your favorite Maps and Portals and move the intel map with a click. Works with sync. Supports Multi-Project-Extension
 
 /* exported setup, changelog --eslint */
 /* global IITC, L -- eslint */
 
 var changelog = [
+  { version: '0.4.8', changes: ['Register with the Sync plugin regardless of plugin load order'] },
   { version: '0.4.7', changes: ['Fix data reset issue'] },
   {
     version: '0.4.6',
@@ -1064,9 +1065,12 @@ window.plugin.bookmarks.syncNow = function () {
   window.plugin.sync.updateMap('bookmarks', window.plugin.bookmarks.KEY.field, Object.keys(window.plugin.bookmarks.updatingQueue));
 };
 
-// Call after IITC and all plugin loaded
-window.plugin.bookmarks.registerFieldForSyncing = function () {
-  if (!window.plugin.sync) return;
+window.plugin.bookmarks.registerFieldForSyncing = () => {
+  // sync may not be loaded yet, and fires this hook once it is
+  if (!window.plugin.sync) {
+    window.addHook('pluginSyncReady', window.plugin.bookmarks.registerFieldForSyncing);
+    return;
+  }
   window.plugin.sync.registerMapForSync(
     'bookmarks',
     window.plugin.bookmarks.KEY.field,

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -1,13 +1,14 @@
 // @author         breunigs
 // @name           Draw tools
 // @category       Draw
-// @version        0.12.1
+// @version        0.13.0
 // @description    Allow drawing things onto the current map so you may plan your next move. Supports Multi-Project-Extension.
 
 /* global IITC, L -- eslint */
 /* exported setup, changelog --eslint */
 
 var changelog = [
+  { version: '0.13.0', changes: ['Sync drawn items across devices via the Sync plugin (Multi-Projects-Extension aware)'] },
   { version: '0.12.1', changes: ['Refactoring: update Leaflet API usage'] },
   {
     version: '0.11.0',
@@ -42,6 +43,15 @@ var changelog = [
 window.plugin.drawTools = function () {};
 
 window.plugin.drawTools.KEY_STORAGE = 'plugin-draw-tools-layer';
+window.plugin.drawTools.DEFAULT_KEY_STORAGE = 'plugin-draw-tools-layer';
+
+// Sync state: itemMap is the field synced by plugins/sync.js. Each entry is keyed by
+// "<projectStorageKey>::<uuid>" so a single registered field covers every MPE project.
+window.plugin.drawTools.itemMap = {};
+window.plugin.drawTools.updateQueue = {};
+window.plugin.drawTools.enableSync = false;
+window.plugin.drawTools.SYNC_DELAY = 5000;
+window.plugin.drawTools.KEY_DELIMITER = '::';
 
 window.plugin.drawTools.merge = {};
 window.plugin.drawTools.merge.status = true;
@@ -214,36 +224,99 @@ window.plugin.drawTools.getSnapLatLng = function (unsnappedLatLng) {
   return new L.LatLng(candidates[0][1].lat, candidates[0][1].lng); // return a clone of the portal location
 };
 
+window.plugin.drawTools.generateId = function () {
+  if (window.plugin.sync && typeof window.plugin.sync.generateUUID === 'function') {
+    return window.plugin.sync.generateUUID();
+  }
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    var r = (Math.random() * 16) | 0;
+    return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+  });
+};
+
+window.plugin.drawTools.makeKey = function (prefix, id) {
+  return prefix + window.plugin.drawTools.KEY_DELIMITER + id;
+};
+
+window.plugin.drawTools.parseKey = function (composite) {
+  var idx = composite.indexOf(window.plugin.drawTools.KEY_DELIMITER);
+  if (idx === -1) return null;
+  return { prefix: composite.slice(0, idx), id: composite.slice(idx + window.plugin.drawTools.KEY_DELIMITER.length) };
+};
+
+// Serialize a Leaflet layer to a plain object. Returns null for unknown layer types.
+window.plugin.drawTools.serializeLayer = function (layer) {
+  var item = {};
+  if (layer instanceof L.GeodesicCircle || layer instanceof L.Circle) {
+    item.type = 'circle';
+    item.latLng = layer.getLatLng();
+    item.radius = layer.getRadius();
+    item.color = layer.options.color;
+  } else if (layer instanceof L.GeodesicPolygon || layer instanceof L.Polygon) {
+    item.type = 'polygon';
+    item.latLngs = layer.getLatLngs();
+    item.color = layer.options.color;
+  } else if (layer instanceof L.GeodesicPolyline || layer instanceof L.Polyline) {
+    item.type = 'polyline';
+    item.latLngs = layer.getLatLngs();
+    item.color = layer.options.color;
+  } else if (layer instanceof L.Marker) {
+    item.type = 'marker';
+    item.latLng = layer.getLatLng();
+    item.color = layer.options.icon.options.color;
+  } else {
+    return null;
+  }
+  return item;
+};
+
 window.plugin.drawTools.save = function () {
   var data = [];
+  var currentItems = {};
+  var prefix = window.plugin.drawTools.KEY_STORAGE;
 
   window.plugin.drawTools.drawnItems.eachLayer(function (layer) {
-    var item = {};
-    if (layer instanceof L.GeodesicCircle || layer instanceof L.Circle) {
-      item.type = 'circle';
-      item.latLng = layer.getLatLng();
-      item.radius = layer.getRadius();
-      item.color = layer.options.color;
-    } else if (layer instanceof L.GeodesicPolygon || layer instanceof L.Polygon) {
-      item.type = 'polygon';
-      item.latLngs = layer.getLatLngs();
-      item.color = layer.options.color;
-    } else if (layer instanceof L.GeodesicPolyline || layer instanceof L.Polyline) {
-      item.type = 'polyline';
-      item.latLngs = layer.getLatLngs();
-      item.color = layer.options.color;
-    } else if (layer instanceof L.Marker) {
-      item.type = 'marker';
-      item.latLng = layer.getLatLng();
-      item.color = layer.options.icon.options.color;
-    } else {
+    var item = window.plugin.drawTools.serializeLayer(layer);
+    if (!item) {
       console.warn('Unknown layer type when saving draw tools layer');
       return; // .eachLayer 'continue'
     }
-
+    if (!layer._drawToolsId) {
+      layer._drawToolsId = window.plugin.drawTools.generateId();
+    }
+    item.id = layer._drawToolsId;
+    currentItems[item.id] = item;
     data.push(item);
   });
-  localStorage[window.plugin.drawTools.KEY_STORAGE] = JSON.stringify(data);
+  localStorage[prefix] = JSON.stringify(data);
+
+  // Reconcile itemMap slice for this project; enqueue any changed composite keys for sync.
+  var changed = [];
+  var delim = window.plugin.drawTools.KEY_DELIMITER;
+  Object.keys(window.plugin.drawTools.itemMap).forEach(function (compKey) {
+    var parsed = window.plugin.drawTools.parseKey(compKey);
+    if (!parsed || parsed.prefix !== prefix) return;
+    if (!currentItems[parsed.id]) {
+      delete window.plugin.drawTools.itemMap[compKey];
+      changed.push(compKey);
+    }
+  });
+  Object.keys(currentItems).forEach(function (id) {
+    var compKey = prefix + delim + id;
+    var newVal = currentItems[id];
+    var oldVal = window.plugin.drawTools.itemMap[compKey];
+    if (!oldVal || JSON.stringify(oldVal) !== JSON.stringify(newVal)) {
+      window.plugin.drawTools.itemMap[compKey] = newVal;
+      changed.push(compKey);
+    }
+  });
+
+  if (changed.length > 0) {
+    changed.forEach(function (k) {
+      window.plugin.drawTools.updateQueue[k] = true;
+    });
+    window.plugin.drawTools.delaySync();
+  }
 
   console.log('draw-tools: saved to localStorage');
 };
@@ -287,6 +360,7 @@ window.plugin.drawTools.import = function (data) {
         break;
     }
     if (layer) {
+      layer._drawToolsId = item.id || window.plugin.drawTools.generateId();
       window.plugin.drawTools.drawnItems.addLayer(layer);
     }
   });
@@ -610,6 +684,7 @@ window.plugin.drawTools.optReset = function () {
     localStorage[window.plugin.drawTools.KEY_STORAGE] = '[]';
     window.plugin.drawTools.drawnItems.clearLayers();
     window.plugin.drawTools.load();
+    window.plugin.drawTools.save(); // reconcile itemMap and push deletions through sync
     console.log('DRAWTOOLS: reset all drawn items');
     window.plugin.drawTools.optAlert('Reset Successful. ');
     window.runHooks('pluginDrawTools', { event: 'clear' });
@@ -980,11 +1055,172 @@ window.plugin.drawTools.getLocationFilters = function () {
   return filters;
 };
 
+// ---------------------------------------------------------------------------------
+// SYNC (via plugins/sync.js)
+// ---------------------------------------------------------------------------------
+
+// Enumerate every localStorage key that holds draw-tools data: the default project plus
+// any MPE-managed projects. Falls back to just the default key when MPE is absent.
+window.plugin.drawTools.getAllProjectKeys = function () {
+  var keys = [window.plugin.drawTools.DEFAULT_KEY_STORAGE];
+  if (window.plugin.mpe && window.plugin.mpe.obj && window.plugin.mpe.obj.projects && window.plugin.mpe.obj.projects.drawTools) {
+    var pj = window.plugin.mpe.obj.projects.drawTools.pj || [];
+    pj.forEach(function (k) {
+      if (keys.indexOf(k) === -1) keys.push(k);
+    });
+  }
+  return keys;
+};
+
+// Walk every known project's localStorage, mint missing ids, write back, and populate
+// itemMap. Called once before sync registration so the seeded field reflects all projects.
+// Returns true if the active project's localStorage was rewritten (caller must reload the
+// active FeatureGroup to keep layer ids in sync with the canonicalized data).
+window.plugin.drawTools.seedItemMap = function () {
+  window.plugin.drawTools.itemMap = {};
+  var delim = window.plugin.drawTools.KEY_DELIMITER;
+  var activePrefix = window.plugin.drawTools.KEY_STORAGE;
+  var activeMutated = false;
+  window.plugin.drawTools.getAllProjectKeys().forEach(function (prefix) {
+    var raw = localStorage[prefix];
+    if (!raw) return;
+    var data;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      console.warn('draw-tools: failed to parse localStorage[' + prefix + '] during sync seed');
+      return;
+    }
+    if (!Array.isArray(data)) return;
+    var mutated = false;
+    data.forEach(function (item) {
+      if (!item || !item.type) return;
+      if (!item.id) {
+        item.id = window.plugin.drawTools.generateId();
+        mutated = true;
+      }
+      window.plugin.drawTools.itemMap[prefix + delim + item.id] = item;
+    });
+    if (mutated) {
+      localStorage[prefix] = JSON.stringify(data);
+      if (prefix === activePrefix) activeMutated = true;
+    }
+  });
+  return activeMutated;
+};
+
+window.plugin.drawTools.delaySync = function () {
+  if (!window.plugin.drawTools.enableSync) return;
+  clearTimeout(window.plugin.drawTools.delaySync.timer);
+  window.plugin.drawTools.delaySync.timer = setTimeout(function () {
+    window.plugin.drawTools.delaySync.timer = null;
+    window.plugin.drawTools.syncNow();
+  }, window.plugin.drawTools.SYNC_DELAY);
+};
+
+window.plugin.drawTools.syncNow = function () {
+  if (!window.plugin.drawTools.enableSync) return;
+  var keys = Object.keys(window.plugin.drawTools.updateQueue);
+  if (keys.length === 0) return;
+  window.plugin.drawTools.updateQueue = {};
+  window.plugin.sync.updateMap('drawTools', 'itemMap', keys);
+};
+
+// Called by sync.js after a successful pull from Drive. fullUpdated is true only when the
+// remote replaced our local state (another device pushed while we were offline). We then
+// rebuild every project's localStorage from itemMap and refresh the active FeatureGroup.
+window.plugin.drawTools.remoteCallback = function (pluginName, fieldName, e, fullUpdated) {
+  if (!fullUpdated) return;
+  if (fieldName !== 'itemMap') return;
+
+  var byPrefix = {};
+  Object.keys(window.plugin.drawTools.itemMap).forEach(function (compKey) {
+    var p = window.plugin.drawTools.parseKey(compKey);
+    if (!p) return;
+    var item = window.plugin.drawTools.itemMap[compKey];
+    if (!item) return;
+    byPrefix[p.prefix] = byPrefix[p.prefix] || [];
+    byPrefix[p.prefix].push(item);
+  });
+
+  // Also clear any locally-known project that has no entries remotely.
+  var knownPrefixes = window.plugin.drawTools.getAllProjectKeys();
+  knownPrefixes.forEach(function (prefix) {
+    if (!byPrefix[prefix]) byPrefix[prefix] = [];
+  });
+
+  Object.keys(byPrefix).forEach(function (prefix) {
+    localStorage[prefix] = JSON.stringify(byPrefix[prefix]);
+  });
+
+  // Let MPE pick up any projects that arrived purely from the remote.
+  if (window.plugin.mpe && window.plugin.mpe.data && typeof window.plugin.mpe.data.scanStorageForOne === 'function') {
+    window.plugin.mpe.data.scanStorageForOne('drawTools');
+  }
+
+  // Refresh the active project's on-map layers from the new localStorage state.
+  window.plugin.drawTools.drawnItems.clearLayers();
+  window.plugin.drawTools.load();
+
+  // Drop any pending local writes — the remote view is now authoritative.
+  window.plugin.drawTools.updateQueue = {};
+
+  console.log('draw-tools: rebuilt from remote sync');
+};
+
+window.plugin.drawTools.syncInitialized = function (pluginName, fieldName) {
+  if (fieldName !== 'itemMap') return;
+  window.plugin.drawTools.enableSync = true;
+  if (Object.keys(window.plugin.drawTools.updateQueue).length > 0) {
+    window.plugin.drawTools.delaySync();
+  }
+};
+
+// MPE fires this after every project switch, including the implicit switch that follows a
+// project deletion. We use it to drop itemMap entries whose project prefix no longer exists
+// so deletions propagate through sync.
+window.plugin.drawTools.reconcileAfterMpeChange = function (data) {
+  if (!data || !data.data || data.data.namespace !== 'drawTools') return;
+  var validPrefixes = {};
+  window.plugin.drawTools.getAllProjectKeys().forEach(function (p) {
+    validPrefixes[p] = true;
+  });
+  var dropped = [];
+  Object.keys(window.plugin.drawTools.itemMap).forEach(function (compKey) {
+    var p = window.plugin.drawTools.parseKey(compKey);
+    if (!p) return;
+    if (!validPrefixes[p.prefix]) {
+      delete window.plugin.drawTools.itemMap[compKey];
+      dropped.push(compKey);
+    }
+  });
+  if (dropped.length > 0) {
+    dropped.forEach(function (k) {
+      window.plugin.drawTools.updateQueue[k] = true;
+    });
+    window.plugin.drawTools.delaySync();
+  }
+};
+
+window.plugin.drawTools.registerFieldForSyncing = function () {
+  if (!window.plugin.sync) return;
+  // If seed had to mint ids for the active project, reload its layers so layer._drawToolsId
+  // values match the canonicalized localStorage data.
+  var activeMutated = window.plugin.drawTools.seedItemMap();
+  if (activeMutated) {
+    window.plugin.drawTools.drawnItems.clearLayers();
+    window.plugin.drawTools.load();
+  }
+  window.addHook('mpe', window.plugin.drawTools.reconcileAfterMpeChange);
+  window.plugin.sync.registerMapForSync('drawTools', 'itemMap', window.plugin.drawTools.remoteCallback, window.plugin.drawTools.syncInitialized);
+};
+
 function setup() {
   loadExternals(); // initialize leaflet
   window.plugin.drawTools.boot(); // initialize drawtools
   window.plugin.drawTools.initMPE(); // register to MPE if available
   window.plugin.drawTools.initEDF(); // initialize empty drawn fields
+  window.plugin.drawTools.registerFieldForSyncing(); // register with sync.js if available
 
   var filterEvents = new L.Evented();
   window.map.on('draw:created draw:edited draw:deleted', function (e) {

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -8,7 +8,13 @@
 /* exported setup, changelog --eslint */
 
 var changelog = [
-  { version: '0.13.0', changes: ['Sync drawn items across devices via the Sync plugin (Multi-Projects-Extension aware)'] },
+  {
+    version: '0.13.0',
+    changes: [
+      'Sync drawn items across devices via the Sync plugin (Multi-Projects-Extension aware)',
+      'Register with the Sync plugin regardless of plugin load order',
+    ],
+  },
   { version: '0.12.1', changes: ['Refactoring: update Leaflet API usage'] },
   {
     version: '0.11.0',
@@ -1178,7 +1184,11 @@ window.plugin.drawTools.reconcileAfterMpeChange = (data) => {
 };
 
 window.plugin.drawTools.registerFieldForSyncing = () => {
-  if (!window.plugin.sync) return;
+  // sync may not be loaded yet, and fires this hook once it is
+  if (!window.plugin.sync) {
+    window.addHook('pluginSyncReady', window.plugin.drawTools.registerFieldForSyncing);
+    return;
+  }
   // seeding rewrote storage, so the layers already on the map still carry no ids
   if (window.plugin.drawTools.seedItemMap()) {
     window.plugin.drawTools.drawnItems.clearLayers();

--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -1,13 +1,14 @@
 // @author         breunigs
 // @name           Draw tools
 // @category       Draw
-// @version        0.12.1
+// @version        0.13.0
 // @description    Allow drawing things onto the current map so you may plan your next move. Supports Multi-Project-Extension.
 
 /* global IITC, L -- eslint */
 /* exported setup, changelog --eslint */
 
 var changelog = [
+  { version: '0.13.0', changes: ['Sync drawn items across devices via the Sync plugin (Multi-Projects-Extension aware)'] },
   { version: '0.12.1', changes: ['Refactoring: update Leaflet API usage'] },
   {
     version: '0.11.0',
@@ -41,7 +42,17 @@ var changelog = [
 // use own namespace for plugin
 window.plugin.drawTools = function () {};
 
-window.plugin.drawTools.KEY_STORAGE = 'plugin-draw-tools-layer';
+window.plugin.drawTools.DEFAULT_KEY_STORAGE = 'plugin-draw-tools-layer';
+// MPE points this at the active project's key, while DEFAULT_KEY_STORAGE keeps naming the default one
+window.plugin.drawTools.KEY_STORAGE = window.plugin.drawTools.DEFAULT_KEY_STORAGE;
+
+// Field synced by plugins/sync.js, keyed by "<projectStorageKey>::<uuid>" so that one
+// registered field covers every MPE project
+window.plugin.drawTools.itemMap = {};
+window.plugin.drawTools.updateQueue = {};
+window.plugin.drawTools.enableSync = false;
+window.plugin.drawTools.SYNC_DELAY = 5000;
+window.plugin.drawTools.KEY_DELIMITER = '::';
 
 window.plugin.drawTools.merge = {};
 window.plugin.drawTools.merge.status = true;
@@ -214,36 +225,93 @@ window.plugin.drawTools.getSnapLatLng = function (unsnappedLatLng) {
   return new L.LatLng(candidates[0][1].lat, candidates[0][1].lng); // return a clone of the portal location
 };
 
-window.plugin.drawTools.save = function () {
-  var data = [];
+window.plugin.drawTools.generateId = () => {
+  if (window.plugin.sync?.generateUUID) return window.plugin.sync.generateUUID();
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+  });
+};
 
-  window.plugin.drawTools.drawnItems.eachLayer(function (layer) {
-    var item = {};
-    if (layer instanceof L.GeodesicCircle || layer instanceof L.Circle) {
-      item.type = 'circle';
-      item.latLng = layer.getLatLng();
-      item.radius = layer.getRadius();
-      item.color = layer.options.color;
-    } else if (layer instanceof L.GeodesicPolygon || layer instanceof L.Polygon) {
-      item.type = 'polygon';
-      item.latLngs = layer.getLatLngs();
-      item.color = layer.options.color;
-    } else if (layer instanceof L.GeodesicPolyline || layer instanceof L.Polyline) {
-      item.type = 'polyline';
-      item.latLngs = layer.getLatLngs();
-      item.color = layer.options.color;
-    } else if (layer instanceof L.Marker) {
-      item.type = 'marker';
-      item.latLng = layer.getLatLng();
-      item.color = layer.options.icon.options.color;
-    } else {
+window.plugin.drawTools.makeKey = (prefix, id) => prefix + window.plugin.drawTools.KEY_DELIMITER + id;
+
+window.plugin.drawTools.parseKey = (composite) => {
+  // ids are UUIDs, so splitting from the right holds without relying on MPE to keep delimiters out of project keys
+  const idx = composite.lastIndexOf(window.plugin.drawTools.KEY_DELIMITER);
+  if (idx === -1) return null;
+  return { prefix: composite.slice(0, idx), id: composite.slice(idx + window.plugin.drawTools.KEY_DELIMITER.length) };
+};
+
+// null for a layer type draw-tools does not persist
+window.plugin.drawTools.serializeLayer = function (layer) {
+  const item = {};
+  if (layer instanceof L.GeodesicCircle || layer instanceof L.Circle) {
+    item.type = 'circle';
+    item.latLng = layer.getLatLng();
+    item.radius = layer.getRadius();
+    item.color = layer.options.color;
+  } else if (layer instanceof L.GeodesicPolygon || layer instanceof L.Polygon) {
+    item.type = 'polygon';
+    item.latLngs = layer.getLatLngs();
+    item.color = layer.options.color;
+  } else if (layer instanceof L.GeodesicPolyline || layer instanceof L.Polyline) {
+    item.type = 'polyline';
+    item.latLngs = layer.getLatLngs();
+    item.color = layer.options.color;
+  } else if (layer instanceof L.Marker) {
+    item.type = 'marker';
+    item.latLng = layer.getLatLng();
+    item.color = layer.options.icon.options.color;
+  } else {
+    return null;
+  }
+  return item;
+};
+
+window.plugin.drawTools.save = function () {
+  const data = [];
+  const currentItems = {};
+  const prefix = window.plugin.drawTools.KEY_STORAGE;
+  const itemMap = window.plugin.drawTools.itemMap;
+
+  window.plugin.drawTools.drawnItems.eachLayer((layer) => {
+    const item = window.plugin.drawTools.serializeLayer(layer);
+    if (!item) {
       console.warn('Unknown layer type when saving draw tools layer');
       return; // .eachLayer 'continue'
     }
-
+    // a merge import can bring in ids already in use, and the duplicate would overwrite its twin in currentItems
+    if (!layer._drawToolsId || currentItems[layer._drawToolsId]) {
+      layer._drawToolsId = window.plugin.drawTools.generateId();
+    }
+    item.id = layer._drawToolsId;
+    currentItems[item.id] = item;
     data.push(item);
   });
-  localStorage[window.plugin.drawTools.KEY_STORAGE] = JSON.stringify(data);
+  localStorage[prefix] = JSON.stringify(data);
+
+  const changed = [];
+  Object.keys(itemMap).forEach((compKey) => {
+    const parsed = window.plugin.drawTools.parseKey(compKey);
+    if (!parsed || parsed.prefix !== prefix || currentItems[parsed.id]) return;
+    delete itemMap[compKey];
+    changed.push(compKey);
+  });
+  Object.entries(currentItems).forEach(([id, item]) => {
+    const compKey = window.plugin.drawTools.makeKey(prefix, id);
+    const newStr = JSON.stringify(item);
+    if (itemMap[compKey] && JSON.stringify(itemMap[compKey]) === newStr) return;
+    // serializeLayer hands back Leaflet's own latLng arrays and a vertex edit mutates them in place, so a stored reference compares equal to itself
+    itemMap[compKey] = JSON.parse(newStr);
+    changed.push(compKey);
+  });
+
+  if (changed.length > 0) {
+    changed.forEach((k) => {
+      window.plugin.drawTools.updateQueue[k] = true;
+    });
+    window.plugin.drawTools.delaySync();
+  }
 
   console.log('draw-tools: saved to localStorage');
 };
@@ -287,6 +355,7 @@ window.plugin.drawTools.import = function (data) {
         break;
     }
     if (layer) {
+      layer._drawToolsId = item.id || window.plugin.drawTools.generateId();
       window.plugin.drawTools.drawnItems.addLayer(layer);
     }
   });
@@ -610,6 +679,7 @@ window.plugin.drawTools.optReset = function () {
     localStorage[window.plugin.drawTools.KEY_STORAGE] = '[]';
     window.plugin.drawTools.drawnItems.clearLayers();
     window.plugin.drawTools.load();
+    window.plugin.drawTools.save(); // reconcile itemMap and push deletions through sync
     console.log('DRAWTOOLS: reset all drawn items');
     window.plugin.drawTools.optAlert('Reset Successful. ');
     window.runHooks('pluginDrawTools', { event: 'clear' });
@@ -898,7 +968,7 @@ window.plugin.drawTools.initMPE = function () {
       window.plugin.drawTools.KEY_STORAGE = newKey;
     },
     // Native value of localstorage key
-    defaultKey: 'plugin-draw-tools-layer',
+    defaultKey: window.plugin.drawTools.DEFAULT_KEY_STORAGE,
     // This function is run before the localstorage key change
     func_pre: function () {},
     // This function is run after the localstorage key change
@@ -980,11 +1050,150 @@ window.plugin.drawTools.getLocationFilters = function () {
   return filters;
 };
 
+// ---------------------------------------------------------------------------------
+// SYNC (via plugins/sync.js)
+// ---------------------------------------------------------------------------------
+
+// localStorage keys holding draw-tools data: the default project plus any MPE projects
+window.plugin.drawTools.getAllProjectKeys = () => {
+  const keys = [window.plugin.drawTools.DEFAULT_KEY_STORAGE];
+  // MPE prefixes every project key with 'MPE_', so none of them can collide with the default one
+  keys.push(...(window.plugin.mpe?.obj?.projects?.drawTools?.pj ?? []));
+  return keys;
+};
+
+// Mints ids for legacy id-less drawings in every project and populates itemMap
+// Returns true when the active project was rewritten, leaving its layers out of step with storage
+window.plugin.drawTools.seedItemMap = () => {
+  const itemMap = {};
+  const activePrefix = window.plugin.drawTools.KEY_STORAGE;
+  let activeMutated = false;
+
+  window.plugin.drawTools.getAllProjectKeys().forEach((prefix) => {
+    const raw = localStorage[prefix];
+    if (!raw) return;
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      console.warn(`draw-tools: failed to parse localStorage[${prefix}] during sync seed`);
+      return;
+    }
+    if (!Array.isArray(data)) return;
+
+    let mutated = false;
+    data.forEach((item) => {
+      if (!item?.type) return;
+      if (!item.id) {
+        item.id = window.plugin.drawTools.generateId();
+        mutated = true;
+      }
+      itemMap[window.plugin.drawTools.makeKey(prefix, item.id)] = item;
+    });
+    if (!mutated) return;
+    localStorage[prefix] = JSON.stringify(data);
+    if (prefix === activePrefix) activeMutated = true;
+  });
+
+  window.plugin.drawTools.itemMap = itemMap;
+  return activeMutated;
+};
+
+window.plugin.drawTools.delaySync = () => {
+  if (!window.plugin.drawTools.enableSync) return;
+  clearTimeout(window.plugin.drawTools.delaySync.timer);
+  window.plugin.drawTools.delaySync.timer = setTimeout(() => {
+    window.plugin.drawTools.delaySync.timer = null;
+    window.plugin.drawTools.syncNow();
+  }, window.plugin.drawTools.SYNC_DELAY);
+};
+
+window.plugin.drawTools.syncNow = () => {
+  if (!window.plugin.drawTools.enableSync) return;
+  const keys = Object.keys(window.plugin.drawTools.updateQueue);
+  if (keys.length === 0) return;
+  window.plugin.drawTools.updateQueue = {};
+  window.plugin.sync.updateMap('drawTools', 'itemMap', keys);
+};
+
+// fullUpdated is set whenever the file was last written by another client, meaning sync has
+// just replaced itemMap wholesale, so every project's localStorage is rebuilt from it
+window.plugin.drawTools.remoteCallback = (pluginName, fieldName, e, fullUpdated) => {
+  if (!fullUpdated || fieldName !== 'itemMap') return;
+
+  const byPrefix = {};
+  Object.entries(window.plugin.drawTools.itemMap).forEach(([compKey, item]) => {
+    const parsed = window.plugin.drawTools.parseKey(compKey);
+    if (!parsed || !item) return;
+    (byPrefix[parsed.prefix] ??= []).push(item);
+  });
+
+  // a project the remote no longer lists has to be emptied here, not left as it was
+  window.plugin.drawTools.getAllProjectKeys().forEach((prefix) => {
+    byPrefix[prefix] ??= [];
+  });
+  Object.entries(byPrefix).forEach(([prefix, items]) => {
+    localStorage[prefix] = JSON.stringify(items);
+  });
+
+  // so MPE learns about projects that arrived only from the remote
+  window.plugin.mpe?.data?.scanStorageForOne?.('drawTools');
+
+  window.plugin.drawTools.drawnItems.clearLayers();
+  window.plugin.drawTools.load();
+
+  // sync already replaced itemMap, so anything still queued refers to values that are gone
+  const discarded = Object.keys(window.plugin.drawTools.updateQueue).length;
+  window.plugin.drawTools.updateQueue = {};
+
+  console.log('draw-tools: rebuilt from remote sync');
+  if (discarded > 0) console.warn(`draw-tools: ${discarded} local change(s) were overwritten before they reached sync`);
+};
+
+window.plugin.drawTools.syncInitialized = (pluginName, fieldName) => {
+  if (fieldName !== 'itemMap') return;
+  window.plugin.drawTools.enableSync = true;
+  if (Object.keys(window.plugin.drawTools.updateQueue).length > 0) {
+    window.plugin.drawTools.delaySync();
+  }
+};
+
+// MPE has no delete event: a deletion surfaces as the implicit switch back to the default
+// project, so entries left pointing at a vanished prefix are what tells us it is gone
+window.plugin.drawTools.reconcileAfterMpeChange = (data) => {
+  if (data?.data?.namespace !== 'drawTools') return;
+
+  const validPrefixes = new Set(window.plugin.drawTools.getAllProjectKeys());
+  const dropped = Object.keys(window.plugin.drawTools.itemMap).filter((compKey) => {
+    const parsed = window.plugin.drawTools.parseKey(compKey);
+    return parsed && !validPrefixes.has(parsed.prefix);
+  });
+  if (dropped.length === 0) return;
+
+  dropped.forEach((compKey) => {
+    delete window.plugin.drawTools.itemMap[compKey];
+    window.plugin.drawTools.updateQueue[compKey] = true;
+  });
+  window.plugin.drawTools.delaySync();
+};
+
+window.plugin.drawTools.registerFieldForSyncing = () => {
+  if (!window.plugin.sync) return;
+  // seeding rewrote storage, so the layers already on the map still carry no ids
+  if (window.plugin.drawTools.seedItemMap()) {
+    window.plugin.drawTools.drawnItems.clearLayers();
+    window.plugin.drawTools.load();
+  }
+  window.addHook('mpe', window.plugin.drawTools.reconcileAfterMpeChange);
+  window.plugin.sync.registerMapForSync('drawTools', 'itemMap', window.plugin.drawTools.remoteCallback, window.plugin.drawTools.syncInitialized);
+};
+
 function setup() {
   loadExternals(); // initialize leaflet
   window.plugin.drawTools.boot(); // initialize drawtools
   window.plugin.drawTools.initMPE(); // register to MPE if available
   window.plugin.drawTools.initEDF(); // initialize empty drawn fields
+  window.plugin.drawTools.registerFieldForSyncing(); // register with sync.js if available
 
   var filterEvents = new L.Evented();
   window.map.on('draw:created draw:edited draw:deleted', function (e) {

--- a/plugins/keys.js
+++ b/plugins/keys.js
@@ -1,12 +1,13 @@
 // @author         xelio
 // @name           Keys
 // @category       Misc
-// @version        0.4.3
+// @version        0.4.4
 // @description    Allow manual entry of key counts for each portal. Use the 'keys-on-map' plugin to show the numbers on the map, and 'sync' to share between multiple browsers or desktop/mobile.
 
 /* exported setup, changelog --eslint */
 
 var changelog = [
+  { version: '0.4.4', changes: ['Register with the Sync plugin regardless of plugin load order'] },
   {
     version: '0.4.3',
     changes: ['Refactoring: fix eslint'],
@@ -101,9 +102,12 @@ window.plugin.keys.syncNow = function () {
   window.plugin.sync.updateMap('keys', 'keys', Object.keys(window.plugin.keys.updatingQueue));
 };
 
-// Call after IITC and all plugin loaded
-window.plugin.keys.registerFieldForSyncing = function () {
-  if (!window.plugin.sync) return;
+window.plugin.keys.registerFieldForSyncing = () => {
+  // sync may not be loaded yet, and fires this hook once it is
+  if (!window.plugin.sync) {
+    window.addHook('pluginSyncReady', window.plugin.keys.registerFieldForSyncing);
+    return;
+  }
   window.plugin.sync.registerMapForSync('keys', 'keys', window.plugin.keys.syncCallback, window.plugin.keys.syncInitialed);
 };
 

--- a/plugins/missions.js
+++ b/plugins/missions.js
@@ -1,13 +1,14 @@
 // @author         jonatkins
 // @name           Missions
 // @category       Info
-// @version        0.3.6
+// @version        0.3.7
 // @description    View missions. Marking progress on waypoints/missions basis. Showing mission paths on the map.
 
 /* exported setup, changelog --eslint */
 /* global IITC, L -- eslint */
 
 var changelog = [
+  { version: '0.3.7', changes: ['Register with the Sync plugin regardless of plugin load order'] },
   { version: '0.3.6', changes: ['Refactoring: update Leaflet API usage'] },
   {
     version: '0.3.5',
@@ -1323,10 +1324,16 @@ window.plugin.missions = {
     window.addHook('plugin-missions-waypoint-changed', this.onWaypointChanged.bind(this));
     window.addHook('plugin-missions-waypoints-refreshed', this.onWaypointsRefreshed.bind(this));
 
-    if (window.plugin.sync) {
+    const registerFieldsForSyncing = () => {
+      // sync may not be loaded yet, and fires this hook once it is
+      if (!window.plugin.sync) {
+        window.addHook('pluginSyncReady', registerFieldsForSyncing);
+        return;
+      }
       window.plugin.sync.registerMapForSync('missions', 'checkedMissions', this.syncCallback.bind(this), this.syncInitialed.bind(this));
       window.plugin.sync.registerMapForSync('missions', 'checkedWaypoints', this.syncCallback.bind(this), this.syncInitialed.bind(this));
-    }
+    };
+    registerFieldsForSyncing();
 
     setTimeout(this.onIITCLoaded.bind(this));
   },

--- a/plugins/sync.js
+++ b/plugins/sync.js
@@ -1,13 +1,17 @@
 // @author         xelio
 // @name           Sync
 // @category       Misc
-// @version        0.5.3
+// @version        0.5.4
 // @description    Sync data between clients via Google Drive API. Only syncs data from specific plugins (currently: Keys, Bookmarks, Uniques). Sign in via the 'Sync' link. Data is synchronized every 3 minutes.
 
 /* exported setup, changelog --eslint */
 /* global IITC -- eslint */
 
 var changelog = [
+  {
+    version: '0.5.4',
+    changes: ['Add sign-out button and display logged-in account email'],
+  },
   {
     version: '0.5.3',
     changes: ['Refactoring: fix eslint'],
@@ -558,6 +562,7 @@ window.plugin.sync.Authorizer = function (options) {
   this.authCallback = options['authCallback'];
   this.authorizing = false;
   this.authorized = false;
+  this._userInitiatedAuth = false;
   this.isAuthed = this.isAuthed.bind(this);
   this.isAuthorizing = this.isAuthorizing.bind(this);
   this.authorize = this.authorize.bind(this);
@@ -601,13 +606,17 @@ window.plugin.sync.Authorizer.prototype.updateSigninStatus = function (self, isS
   } else {
     self.authorized = false;
     window.plugin.sync.logger.log('all', 'Not authorized');
-    window.gapi.auth2.getAuthInstance().signIn();
+    if (self._userInitiatedAuth) {
+      self._userInitiatedAuth = false;
+      window.gapi.auth2.getAuthInstance().signIn();
+    }
   }
 };
 
 window.plugin.sync.Authorizer.prototype.authorize = function () {
   this.authorizing = true;
   this.authorized = false;
+  this._userInitiatedAuth = true;
   const self = this;
 
   window.gapi.client
@@ -737,6 +746,69 @@ window.plugin.sync.toggleAuthButton = function () {
 
   $('#sync-authButton').attr('disabled', authed || authorizing);
   $('#sync-authButton').toggleClass('sync-authButton-dimmed', authed || authorizing);
+
+  $('#sync-signOutButton').toggle(authed === true);
+};
+
+window.plugin.sync.updateAccountInfo = function () {
+  var accountDiv = $('#sync-account');
+  if (accountDiv.length === 0) return;
+
+  if (window.plugin.sync.authorizer.isAuthed()) {
+    try {
+      var profile = window.gapi.auth2.getAuthInstance().currentUser.get().getBasicProfile();
+      accountDiv.text('Signed in as: ' + profile.getEmail());
+    } catch (e) {
+      accountDiv.text('Signed in');
+    }
+  } else {
+    accountDiv.text('');
+  }
+};
+
+window.plugin.sync.signOut = function () {
+  window.gapi.auth2.getAuthInstance().signOut().then(function () {
+    window.plugin.sync.authorizer.authorized = false;
+    window.plugin.sync.authorizer.authorizing = false;
+
+    window.plugin.sync.stopAllIntervals();
+
+    window.plugin.sync.parentFolderID = null;
+    window.plugin.sync.parentFolderIDrequested = false;
+
+    window.plugin.sync.toggleAuthButton();
+    window.plugin.sync.toggleDialogLink();
+    window.plugin.sync.updateAccountInfo();
+
+    window.plugin.sync.logger.log('all', 'Signed out');
+    window.plugin.sync.updateLog(window.plugin.sync.logger.getLogs());
+  });
+};
+
+window.plugin.sync.stopAllIntervals = function () {
+  var fields = window.plugin.sync.registeredPluginsFields;
+  if (!fields || !fields.pluginsfields) return;
+
+  $.each(fields.pluginsfields, function (pluginName, fieldMap) {
+    $.each(fieldMap, function (fieldName, registeredMap) {
+      if (registeredMap.intervalID) {
+        clearInterval(registeredMap.intervalID);
+        registeredMap.intervalID = null;
+      }
+      registeredMap.initialized = false;
+      registeredMap.initializing = false;
+      registeredMap.failed = false;
+      registeredMap.forceFileSearch = true;
+    });
+  });
+
+  $.each(fields.pluginsfields, function (pluginName, fieldMap) {
+    $.each(fieldMap, function (fieldName, registeredMap) {
+      fields.waitingInitialize[registeredMap.getFileName()] = registeredMap;
+    });
+  });
+
+  fields.anyFail = false;
 };
 
 window.plugin.sync.toggleDialogLink = function () {
@@ -753,6 +825,7 @@ window.plugin.sync.showDialog = function () {
   window.dialog({ html: window.plugin.sync.dialogHTML, title: 'Sync', modal: true, id: 'sync-setting' });
   window.plugin.sync.toggleAuthButton();
   window.plugin.sync.toggleDialogLink();
+  window.plugin.sync.updateAccountInfo();
   window.plugin.sync.updateLog(window.plugin.sync.logger.getLogs());
 };
 
@@ -762,6 +835,9 @@ window.plugin.sync.setupDialog = function () {
     '<button id="sync-authButton" class="sync-authButton-dimmed" ' +
     'onclick="setTimeout(function(){window.plugin.sync.authorizer.authorize(true)}, 1)" ' +
     'disabled="disabled">Authorize</button>' +
+    '<button id="sync-signOutButton" style="display:none" ' +
+    'onclick="window.plugin.sync.signOut()">Sign Out</button>' +
+    '<div id="sync-account"></div>' +
     '<div id="sync-log"></div>' +
     '</div>';
   IITC.toolbox.addButton({
@@ -800,6 +876,15 @@ window.plugin.sync.setupCSS = function () {
           .sync-log-message {\
             margin: 0;\
             text-align: right;\
+          }\
+          #sync-signOutButton {\
+            margin-left: 0.5em;\
+          }\
+          #sync-account {\
+            margin: 0.5em 0;\
+            font-size: 0.9em;\
+            color: #ccc;\
+            word-break: break-all;\
           }'
     )
     .appendTo('head');
@@ -812,7 +897,7 @@ var setup = function () {
   window.plugin.sync.setupDialog();
 
   window.plugin.sync.authorizer = new window.plugin.sync.Authorizer({
-    authCallback: [window.plugin.sync.toggleAuthButton, window.plugin.sync.toggleDialogLink],
+    authCallback: [window.plugin.sync.toggleAuthButton, window.plugin.sync.toggleDialogLink, window.plugin.sync.updateAccountInfo],
   });
   window.plugin.sync.registeredPluginsFields = new window.plugin.sync.RegisteredPluginsFields({
     authorizer: window.plugin.sync.authorizer,

--- a/plugins/sync.js
+++ b/plugins/sync.js
@@ -1,7 +1,7 @@
 // @author         xelio
 // @name           Sync
 // @category       Misc
-// @version        0.5.4
+// @version        0.6.0
 // @description    Sync data between clients via Google Drive API. Only syncs data from specific plugins (currently: Keys, Bookmarks, Uniques). Sign in via the 'Sync' link. Data is synchronized every 3 minutes.
 
 /* exported setup, changelog --eslint */
@@ -9,7 +9,7 @@
 
 var changelog = [
   {
-    version: '0.5.4',
+    version: '0.6.0',
     changes: ['Add sign-out button and display logged-in account email'],
   },
   {
@@ -696,7 +696,7 @@ window.plugin.sync.generateUUID = function () {
   } else {
     var d = new Date().getTime();
     var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-      var r = (d + Math.random() * 16) % 16 | 0;
+      var r = ((d + Math.random() * 16) % 16) | 0;
       d = Math.floor(d / 16);
       return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
     });
@@ -758,7 +758,7 @@ window.plugin.sync.updateAccountInfo = function () {
     try {
       var profile = window.gapi.auth2.getAuthInstance().currentUser.get().getBasicProfile();
       accountDiv.text('Signed in as: ' + profile.getEmail());
-    } catch (e) {
+    } catch {
       accountDiv.text('Signed in');
     }
   } else {
@@ -767,22 +767,25 @@ window.plugin.sync.updateAccountInfo = function () {
 };
 
 window.plugin.sync.signOut = function () {
-  window.gapi.auth2.getAuthInstance().signOut().then(function () {
-    window.plugin.sync.authorizer.authorized = false;
-    window.plugin.sync.authorizer.authorizing = false;
+  window.gapi.auth2
+    .getAuthInstance()
+    .signOut()
+    .then(function () {
+      window.plugin.sync.authorizer.authorized = false;
+      window.plugin.sync.authorizer.authorizing = false;
 
-    window.plugin.sync.stopAllIntervals();
+      window.plugin.sync.stopAllIntervals();
 
-    window.plugin.sync.parentFolderID = null;
-    window.plugin.sync.parentFolderIDrequested = false;
+      window.plugin.sync.parentFolderID = null;
+      window.plugin.sync.parentFolderIDrequested = false;
 
-    window.plugin.sync.toggleAuthButton();
-    window.plugin.sync.toggleDialogLink();
-    window.plugin.sync.updateAccountInfo();
+      window.plugin.sync.toggleAuthButton();
+      window.plugin.sync.toggleDialogLink();
+      window.plugin.sync.updateAccountInfo();
 
-    window.plugin.sync.logger.log('all', 'Signed out');
-    window.plugin.sync.updateLog(window.plugin.sync.logger.getLogs());
-  });
+      window.plugin.sync.logger.log('all', 'Signed out');
+      window.plugin.sync.updateLog(window.plugin.sync.logger.getLogs());
+    });
 };
 
 window.plugin.sync.stopAllIntervals = function () {

--- a/plugins/sync.js
+++ b/plugins/sync.js
@@ -1,13 +1,17 @@
 // @author         xelio
 // @name           Sync
 // @category       Misc
-// @version        0.6.0
-// @description    Sync data between clients via Google Drive API. Only syncs data from specific plugins (currently: Keys, Bookmarks, Uniques). Sign in via the 'Sync' link. Data is synchronized every 3 minutes.
+// @version        0.6.1
+// @description    Sync data between clients via Google Drive API. Only syncs data from specific plugins (currently: Keys, Bookmarks, Uniques, Draw Tools). Sign in via the 'Sync' link. Data is synchronized every 3 minutes.
 
 /* exported setup, changelog --eslint */
 /* global IITC -- eslint */
 
 var changelog = [
+  {
+    version: '0.6.1',
+    changes: ['Note Draw Tools as a synced plugin in the description'],
+  },
   {
     version: '0.6.0',
     changes: ['Add sign-out button and display logged-in account email'],

--- a/plugins/sync.js
+++ b/plugins/sync.js
@@ -744,7 +744,7 @@ window.plugin.sync.toggleAuthButton = function () {
 
   $('#sync-authButton').html(authed ? 'Authorized' : 'Authorize');
 
-  $('#sync-authButton').attr('disabled', authed || authorizing);
+  $('#sync-authButton').prop('disabled', authed || authorizing);
   $('#sync-authButton').toggleClass('sync-authButton-dimmed', authed || authorizing);
 
   $('#sync-signOutButton').toggle(authed === true);

--- a/plugins/sync.js
+++ b/plugins/sync.js
@@ -10,7 +10,7 @@
 var changelog = [
   {
     version: '0.6.1',
-    changes: ['Note Draw Tools as a synced plugin in the description'],
+    changes: ['Note Draw Tools as a synced plugin in the description', 'Let plugins register synced fields regardless of plugin load order'],
   },
   {
     version: '0.6.0',
@@ -72,6 +72,8 @@ window.plugin.sync.updateMap = function (pluginName, fieldName, keyArray) {
   registeredMap.updateMap(keyArray);
 };
 
+const pendingRegistrations = [];
+
 // Other plugin call this to register a field as CollaborativeMap to sync with Google Drive API
 // example: plugin.sync.registerMapForSync('keys', 'keysdata', plugin.keys.updateCallback, plugin.keys.initializedCallback)
 // which register plugin.keys.keysdata
@@ -83,7 +85,16 @@ window.plugin.sync.updateMap = function (pluginName, fieldName, keyArray) {
 //
 // initializedCallback function format: function(pluginName, fieldName)
 // initializedCallback will be fired when the storage finished initialize and good to use
+//
+// Callable from the moment plugin.sync exists: setup replays whatever registered before it ran.
+// Earlier than that there is nothing to call, so those plugins wait for the 'pluginSyncReady' hook
 window.plugin.sync.registerMapForSync = function (pluginName, fieldName, callback, initializedCallback) {
+  // authorizer and uuid only exist from setup, so buffer the arguments and register from there
+  if (!window.plugin.sync.registeredPluginsFields) {
+    pendingRegistrations.push([pluginName, fieldName, callback, initializedCallback]);
+    return;
+  }
+
   var options, registeredMap;
   options = {
     pluginName: pluginName,
@@ -914,6 +925,11 @@ var setup = function () {
   $.getScript(GOOGLEAPI).done(function () {
     window.gapi.load('client:auth2', window.plugin.sync.authorizer.authorize);
   });
+
+  pendingRegistrations.splice(0).forEach((args) => window.plugin.sync.registerMapForSync(...args));
+
+  // lets plugins that ran before this one was loaded register their fields
+  window.runHooks('pluginSyncReady');
 };
 
 setup.priority = 'high';

--- a/plugins/uniques.js
+++ b/plugins/uniques.js
@@ -1,13 +1,14 @@
 // @author         3ch01c
 // @name           Uniques
 // @category       Misc
-// @version        0.2.7
+// @version        0.2.8
 // @description    Allow manual entry of portals visited/captured. Use the 'highlighter-uniques' plugin to show the uniques on the map, and 'sync' to share between multiple browsers or desktop/mobile. It will try and guess which portals you have captured from COMM/portal details, but this will not catch every case.
 
 /* exported setup, changelog --eslint */
 /* global IITC -- eslint */
 
 var changelog = [
+  { version: '0.2.8', changes: ['Register with the Sync plugin regardless of plugin load order'] },
   {
     version: '0.2.7',
     changes: ['Refactoring: fix eslint'],
@@ -320,9 +321,12 @@ window.plugin.uniques.syncQueue = function () {
   }, window.plugin.uniques.SYNC_DELAY);
 };
 
-// Call after IITC and all plugin loaded
-window.plugin.uniques.registerFieldForSyncing = function () {
-  if (!window.plugin.sync) return;
+window.plugin.uniques.registerFieldForSyncing = () => {
+  // sync may not be loaded yet, and fires this hook once it is
+  if (!window.plugin.sync) {
+    window.addHook('pluginSyncReady', window.plugin.uniques.registerFieldForSyncing);
+    return;
+  }
   window.plugin.sync.registerMapForSync('uniques', 'uniques', window.plugin.uniques.syncCallback, window.plugin.uniques.syncInitialed);
 };
 


### PR DESCRIPTION
## Summary

Wires `plugins/draw-tools.js` into the existing `plugins/sync.js` infrastructure so drawn items (polylines, polygons, circles, markers) are kept in sync across browsers and devices through the user's Google Drive. Previously the only cross-device option was manual JSON export/import.

## How it works

- Each drawn item now carries a stable UUID that round-trips through `save()` / `load()` and the share/import flow.
- The synced field `window.plugin.drawTools.itemMap` is a flat map keyed by `"<projectStorageKey>::<uuid>"`. This keeps the per-item incremental granularity Sync expects while letting a **single registered field cover every Multi-Projects-Extension project** — including projects that arrive purely from a peer device.
- MPE project deletions are propagated by listening to the `mpe` hook and dropping orphaned entries from the synced map.
- Legacy id-less drawings are migrated once at boot: ids are minted, the canonicalized JSON is written back to localStorage, and (if the active project was rewritten) its on-map layers are reloaded so layer ids match the persisted data.
- Local edits are debounced (5s) before pushing through `plugin.sync.updateMap`, mirroring the Keys/Uniques pattern.
- On a remote `fullUpdated` (offline catch-up from a peer), every project's localStorage is rewritten from `itemMap`, MPE is asked to rescan, and the active project's layers are rebuilt — firing the existing `pluginDrawTools` `import` hook so dependent plugins (Cross-Links, Done-Links, Wayfarer-Range, etc.) stay coherent.

## Compatibility

Verified compatibility with every plugin that touches `window.plugin.drawTools` or the `pluginDrawTools` hook — no consumer changes required:

- `cross-links.js`, `done-links.js`, `wayfarer-range.js` — already handle non-`layerCreated` events by re-checking, so they react correctly to the `import` event fired after a remote rebuild.
- `bookmarks.js` — fires `draw:created` on the map; our existing handler routes it through `save()`, which mints the id.
- `layer-count.js`, `link-show-direction.js`, `tidy-links.js`, `fly-links.js` — only iterate `drawnItems` / use `filterEvents`; both contracts preserved.

`sync.js` description was updated to include Draw Tools in the list of synced plugins (patch bump to push the metadata refresh to existing installs).

## Versions

- `draw-tools` 0.12.1 → **0.13.0** (new feature)
- `sync` 0.6.0 → **0.6.1** (description update)

## Test plan

- [ ] Two browsers signed into the same Google account, both with Draw Tools and Sync enabled. Draw a polyline in A → after the 3-min poll the polyline appears in B.
- [ ] Edit / delete the item in A → propagates to B.
- [ ] Install MPE in both. Create a second project in A, draw a marker only in that project, switch back to default → marker is hidden locally, present in `itemMap`, syncs to B, and appears in B when B switches to that project.
- [ ] Pre-populate `localStorage['plugin-draw-tools-layer']` with id-less legacy data → confirm load mints UUIDs, persists them back, and seeds `itemMap` correctly.
- [ ] Disable network mid-edit, draw items, re-enable → confirm queue flushes after re-auth.
- [ ] Confirm Cross-Links re-evaluates after a remote rebuild and Wayfarer-Range circles re-attach to incoming markers.