### PR TITLE
Fix: plugins are not truncated on update

### DIFF
--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_StorageManager.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_StorageManager.java
@@ -272,6 +272,6 @@ public class IITC_StorageManager {
      * Open output stream for writing plugin content
      */
     public OutputStream openPluginOutputStream(DocumentFile plugin) throws IOException {
-        return context.getContentResolver().openOutputStream(plugin.getUri());
+        return context.getContentResolver().openOutputStream(plugin.getUri(), "wt");
     }
 }

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/async/UpdateScript.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/async/UpdateScript.java
@@ -105,7 +105,7 @@ public class UpdateScript extends AsyncTask<String, Void, Boolean> {
             Log.d("Updating plugin file...");
 
             // Write updated script
-            try (OutputStream stream = mContext.getContentResolver().openOutputStream(file.getUri())) {
+            try (OutputStream stream = mContext.getContentResolver().openOutputStream(file.getUri(), "wt")) {
                 stream.write(updatedScript.getBytes());
             }
 


### PR DESCRIPTION
Plugins are not truncated on update leading to corrupted files

https://developer.android.com/reference/android/content/ContentResolver#openOutputStream(android.net.Uri,%20java.lang.String)
https://issuetracker.google.com/issues/180526528?pli=1
https://developer.android.com/reference/android/os/ParcelFileDescriptor#parseMode(java.lang.String)