### PR TITLE
keep dialog inside main window

### DIFF
--- a/core/code/dialog.js
+++ b/core/code/dialog.js
@@ -242,8 +242,10 @@ window.dialog = function (options) {
     // ui-modal includes overrides for modal dialogs
     dialog.parent().addClass('ui-modal');
   } else {
-    // Enable snapping
-    dialog.dialog().parents('.ui-dialog').draggable('option', 'snap', true);
+    const baseElement = dialog.dialog().parents('.ui-dialog');
+    baseElement.draggable('option', 'snap', true); // Enable snapping
+    baseElement.draggable('option', 'scroll', false); // Disable map scroll while dragging
+    baseElement.draggable('option', 'containment', 'window'); // prevent dragging outside of the window
   }
 
   // Run it

--- a/core/code/dialog.js
+++ b/core/code/dialog.js
@@ -242,10 +242,10 @@ window.dialog = function (options) {
     // ui-modal includes overrides for modal dialogs
     dialog.parent().addClass('ui-modal');
   } else {
-    const baseElement = dialog.dialog().parents('.ui-dialog');
-    baseElement.draggable('option', 'snap', true); // Enable snapping
-    baseElement.draggable('option', 'scroll', false); // Disable map scroll while dragging
-    baseElement.draggable('option', 'containment', 'window'); // prevent dragging outside of the window
+    const $wrapper = dialog.dialog('widget');
+    $wrapper.draggable('option', 'snap', true); // Enable snapping
+    $wrapper.draggable('option', 'scroll', false); // Disable map scroll while dragging
+    $wrapper.draggable('option', 'containment', 'window'); // prevent dragging outside of the window
   }
 
   // Run it


### PR DESCRIPTION
a) disable map scroll when dragging a dialog to the borders
b) disable moving dialogs outside the main window

I'm not sure what will happen with large, fixed size dialogs on small screens.
Even if dragging isn't possible on mobile, it could still have a negative impact in similar situations.