### PR TITLE
Add baseLayerChanged hook with light/dark map theme

### DIFF
--- a/core/code/app.js
+++ b/core/code/app.js
@@ -137,6 +137,13 @@ window.runOnAppBeforeBoot = function () {
     });
   }
 
+  // forward the base map theme (light/dark) to the app
+  if (window.app.setMapDarkMode) {
+    window.addHook('baseLayerChanged', function (data) {
+      window.app.setMapDarkMode(data.isDark);
+    });
+  }
+
   // overwrite some functions **************************************************
   if (window.app.copy) {
     window.androidCopy = function (text) {

--- a/core/code/hooks.js
+++ b/core/code/hooks.js
@@ -46,6 +46,8 @@
  *                         Parameters are guid, success, details.
  * - `paneChanged`: Called when the current pane has changed. On desktop, this changes the current chat pane;
  *                  on mobile, it also switches between map, info, and other panes defined by plugins.
+ * - `baseLayerChanged`: Called when the active base map layer changes, and once on initial load.
+ *                       Provides `{ name, layer, isDark }`, where `isDark` tells whether the map is dark-themed.
  * - `artifactsUpdated`: Called when the set of artifacts (including targets) has changed.
  *                       Parameters are old, new.
  * - `nicknameClicked`: Event triggered when a player's nickname is clicked.

--- a/core/code/layerchooser.js
+++ b/core/code/layerchooser.js
@@ -78,6 +78,12 @@ var LayerChooser = L.Control.Layers.extend({
     } else {
       delete layer._chooser;
     }
+    // base layer theme; `addBaseLayer` option wins over the layer's own options
+    if ('isDark' in options) {
+      data.isDark = options.isDark;
+    } else if (!('isDark' in data) && layer.options && 'isDark' in layer.options) {
+      data.isDark = layer.options.isDark;
+    }
     // provide stable sort order
     if ('sortPriority' in options) {
       data.sortPriority = options.sortPriority;
@@ -169,6 +175,8 @@ var LayerChooser = L.Control.Layers.extend({
    * @param {String} name - The name of the layer.
    * @param {Object} [options] - Additional options for the layer entry.
    * @param {Boolean} [options.persistent=true] - When set to `false`, the base layer's status is not tracked.
+   * @param {Boolean} [options.isDark] - Marks the base layer as dark- or light-themed, reported via the
+   *                                     `baseLayerChanged` hook. Defaults to dark when omitted.
    * @param {Number} [options.sortPriority] - Enforces a specific order in the control. Lower value means
    *                                          higher position in the list. If not specified, the value
    *                                          will be assigned implicitly in an increasing manner.
@@ -260,7 +268,7 @@ var LayerChooser = L.Control.Layers.extend({
   // Returns layer info by it's name in the control, or by layer object itself,
   // or label html element.
   // Info is internal data object with following properties:
-  // `layer`, `name`, `label`, `overlay`, `sortPriority`, `persistent`, `default`,
+  // `layer`, `name`, `label`, `overlay`, `isDark`, `sortPriority`, `persistent`, `default`,
   // `labelEl`, `inputEl`, `statusTracking`.
   /**
    * Retrieves layer info by its name in the control, or by the layer object itself, or its label HTML element.
@@ -325,6 +333,28 @@ var LayerChooser = L.Control.Layers.extend({
       map.removeLayer(data.layer);
     }
     return this;
+  },
+
+  /**
+   * Fires the `baseLayerChanged` hook for the currently active base layer, reporting its `name`,
+   * `layer` object and theme (`isDark`). Called on a basemap switch and once on initial load.
+   *
+   * @memberof LayerChooser
+   * @returns {void}
+   */
+  notifyBaseLayerChange: function () {
+    var map = this._map;
+    if (!map) {
+      return;
+    }
+    var active = this._layers.find(function (data) {
+      return !data.overlay && map.hasLayer(data.layer);
+    });
+    if (!active) {
+      return;
+    }
+    var isDark = active.isDark !== false; // default to dark
+    window.runHooks('baseLayerChanged', { name: active.name, layer: active.layer, isDark: isDark });
   },
 
   /**

--- a/core/code/map.js
+++ b/core/code/map.js
@@ -116,12 +116,13 @@ function createDefaultBaseMapLayers() {
   var cartoAttr =
     '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
   var cartoUrl = 'https://{s}.basemaps.cartocdn.com/{theme}/{z}/{x}/{y}.png';
-  baseLayers['CartoDB Dark Matter'] = L.tileLayer(cartoUrl, { attribution: cartoAttr, theme: 'dark_all' });
-  baseLayers['CartoDB Positron'] = L.tileLayer(cartoUrl, { attribution: cartoAttr, theme: 'light_all' });
+  baseLayers['CartoDB Dark Matter'] = L.tileLayer(cartoUrl, { attribution: cartoAttr, theme: 'dark_all', isDark: true });
+  baseLayers['CartoDB Positron'] = L.tileLayer(cartoUrl, { attribution: cartoAttr, theme: 'light_all', isDark: false });
 
   // Google Maps - including ingress default (using the stock-intel API-key)
   baseLayers['Google Default Ingress Map'] = new L.GridLayer.GoogleMutant({
     type: 'roadmap',
+    isDark: true,
     backgroundColor: '#0e3d4e',
     styles: [
       { featureType: 'all', elementType: 'all', stylers: [{ visibility: 'on' }, { hue: '#131c1c' }, { saturation: '-50' }, { invert_lightness: true }] },
@@ -131,16 +132,16 @@ function createDefaultBaseMapLayers() {
       { featureType: 'road', elementType: 'labels.icon', stylers: [{ invert_lightness: !0 }] },
     ],
   });
-  baseLayers['Google Roads'] = new L.GridLayer.GoogleMutant({ type: 'roadmap' });
-  var trafficMutant = new L.GridLayer.GoogleMutant({ type: 'roadmap' });
+  baseLayers['Google Roads'] = new L.GridLayer.GoogleMutant({ type: 'roadmap', isDark: false });
+  var trafficMutant = new L.GridLayer.GoogleMutant({ type: 'roadmap', isDark: false });
   trafficMutant.addGoogleLayer('TrafficLayer');
   baseLayers['Google Roads + Traffic'] = trafficMutant;
-  var transitMutant = new L.GridLayer.GoogleMutant({ type: 'roadmap' });
+  var transitMutant = new L.GridLayer.GoogleMutant({ type: 'roadmap', isDark: false });
   transitMutant.addGoogleLayer('TransitLayer');
   baseLayers['Google Roads + Transit'] = transitMutant;
-  baseLayers['Google Satellite'] = new L.GridLayer.GoogleMutant({ type: 'satellite' });
-  baseLayers['Google Hybrid'] = new L.GridLayer.GoogleMutant({ type: 'hybrid' });
-  baseLayers['Google Terrain'] = new L.GridLayer.GoogleMutant({ type: 'terrain' });
+  baseLayers['Google Satellite'] = new L.GridLayer.GoogleMutant({ type: 'satellite', isDark: true });
+  baseLayers['Google Hybrid'] = new L.GridLayer.GoogleMutant({ type: 'hybrid', isDark: true });
+  baseLayers['Google Terrain'] = new L.GridLayer.GoogleMutant({ type: 'terrain', isDark: false });
 
   return baseLayers;
 }
@@ -397,7 +398,11 @@ window.setupMap = function () {
     // leaflet no longer ensures the base layer zoom is suitable for the map (a bug? feature change?), so do so here
     map.on('baselayerchange', function () {
       map.setZoom(map.getZoom());
+      layerChooser.notifyBaseLayerChange();
     });
+
+    // also fire for the initial base layer
+    layerChooser.notifyBaseLayerChange();
 
     // Start map refresh (after Map location is set)
     window.mapDataRequest.start();

--- a/plugins/basemap-bing.js
+++ b/plugins/basemap-bing.js
@@ -28,15 +28,19 @@ var mapBing = {};
 mapBing.sets = {
   Road: {
     imagerySet: 'RoadOnDemand',
+    isDark: false,
   },
   Dark: {
     imagerySet: 'CanvasDark',
+    isDark: true,
   },
   Aerial: {
     imagerySet: 'Aerial',
+    isDark: true,
   },
   Hybrid: {
     imagerySet: 'AerialWithLabelsOnDemand',
+    isDark: true,
   },
 };
 
@@ -50,7 +54,7 @@ function setup() {
 
   for (var name in mapBing.sets) {
     var options = L.extend({}, mapBing.options, mapBing.sets[name]);
-    window.layerChooser.addBaseLayer(L.bingLayer(options), 'Bing ' + name);
+    window.layerChooser.addBaseLayer(L.bingLayer(options), 'Bing ' + name, { isDark: options.isDark });
   }
 }
 

--- a/plugins/basemap-blank.js
+++ b/plugins/basemap-blank.js
@@ -30,8 +30,8 @@ mapTileBlank.addLayer = function () {
   var blankWhite = new L.TileLayer('@include_img:images/basemap-blank-tile-white.png@', blankOpt);
   var blankBlack = new L.TileLayer('@include_img:images/basemap-blank-tile-black.png@', blankOpt);
 
-  window.layerChooser.addBaseLayer(blankWhite, 'Blank Map (White)');
-  window.layerChooser.addBaseLayer(blankBlack, 'Blank Map (Black)');
+  window.layerChooser.addBaseLayer(blankWhite, 'Blank Map (White)', { isDark: false });
+  window.layerChooser.addBaseLayer(blankBlack, 'Blank Map (Black)', { isDark: true });
 };
 
 function setup() {

--- a/plugins/basemap-gaode.js
+++ b/plugins/basemap-gaode.js
@@ -70,26 +70,26 @@ mapGaode.setup = function () {
     maxNativeZoom: 17,
   });
 
-  function add(name, layer) {
-    window.layerChooser.addBaseLayer(layer, name);
+  function add(name, layer, isDark) {
+    window.layerChooser.addBaseLayer(layer, name, { isDark: isDark });
     return layer;
   }
 
   var Roads = // en, zh_en
-    add('Gaode Roads [zh]', new GaodeLayer({ style: 7, maxNativeZoom: 20, lang: 'zh_cn' }));
+    add('Gaode Roads [zh]', new GaodeLayer({ style: 7, maxNativeZoom: 20, lang: 'zh_cn' }), false);
 
   // add('Gaode Roads',       new GaodeLayer({ style: 7, maxNativeZoom: 20 }));
   // add('Gaode Roads 7',     new GaodeLayer({ style: 7, site: 1 }));
   // add('Gaode Roads 8',     new GaodeLayer({ style: 8, site: 1 }));
   // add('Gaode Roads 8 [zh]',new GaodeLayer({ style: 8, site: 1, lang: 'zh_cn' }));
 
-  add('Gaode Roads + Traffic', new L.LayerGroup([Roads, new AmapTraffic({ opacity: 0.75 })]));
+  add('Gaode Roads + Traffic', new L.LayerGroup([Roads, new AmapTraffic({ opacity: 0.75 })]), false);
 
-  var Satellite = add('Gaode Satellite', new GaodeLayer({ style: 6, type: 'satellite' }));
+  var Satellite = add('Gaode Satellite', new GaodeLayer({ style: 6, type: 'satellite' }), true);
 
   // new GaodeLayer({ style: 8, type: 'roadnet', opacity: 0.75, lang: 'zh_cn', scl: 2 }), // (512*512 tile, w/o labels)
   // new GaodeLayer({ style: 8, type: 'labels', opacity: 0.75, lang: 'zh_cn', ltype: 4 }) // (feature mask) here: 2: roads, 4: labels)
-  add('Gaode Hybrid', new L.LayerGroup([Satellite, new GaodeLayer({ style: 8, type: 'roadnet', opacity: 0.75 })]));
+  add('Gaode Hybrid', new L.LayerGroup([Satellite, new GaodeLayer({ style: 8, type: 'roadnet', opacity: 0.75 })]), true);
 };
 
 function setup() {

--- a/plugins/basemap-google-gray.js
+++ b/plugins/basemap-google-gray.js
@@ -45,7 +45,7 @@ grayGMaps.addLayer = function () {
 
   var grayGMaps = new L.GridLayer.GoogleMutant(grayGMapsOptions);
 
-  window.layerChooser.addBaseLayer(grayGMaps, 'Google Gray');
+  window.layerChooser.addBaseLayer(grayGMaps, 'Google Gray', { isDark: false });
 };
 
 function setup() {

--- a/plugins/basemap-kartverket.js
+++ b/plugins/basemap-kartverket.js
@@ -91,7 +91,7 @@ mapKartverket.setup = function () {
   var l, layer;
   for (layer in L.tileLayer.kartverket.getLayers()) {
     l = L.tileLayer.kartverket(layer);
-    window.layerChooser.addBaseLayer(l, l._name);
+    window.layerChooser.addBaseLayer(l, l._name, { isDark: false });
   }
 };
 

--- a/plugins/basemap-openstreetmap.js
+++ b/plugins/basemap-openstreetmap.js
@@ -63,6 +63,6 @@ function setup() {
 
   for (var entry of mapOpenStreetMap.LAYERS) {
     var layer = new L.TileLayer(entry.url, entry.options);
-    window.layerChooser.addBaseLayer(layer, entry.name);
+    window.layerChooser.addBaseLayer(layer, entry.name, { isDark: false });
   }
 }

--- a/plugins/basemap-stamen.js
+++ b/plugins/basemap-stamen.js
@@ -49,14 +49,14 @@ mapStamen.setup = function () {
     },
   });
 
-  function addLayer(name, options) {
-    window.layerChooser.addBaseLayer(new L_StamenTileLayer(name, options), 'Stamen ' + name);
+  function addLayer(name, options, isDark) {
+    window.layerChooser.addBaseLayer(new L_StamenTileLayer(name, options), 'Stamen ' + name, { isDark: isDark });
   }
 
   var options = { minZoom: 0, maxNativeZoom: 20 };
-  addLayer('Toner', options);
-  addLayer('Toner Background', options);
-  addLayer('Toner Lite', options);
+  addLayer('Toner', options, false);
+  addLayer('Toner Background', options, false);
+  addLayer('Toner Lite', options, false);
   // transparent layers. could be useful over satellite imagery or similar
   // addLayer('Toner Hybrid',options);
   // addLayer('Toner Labels',options);
@@ -80,7 +80,7 @@ mapStamen.setup = function () {
       'under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
     ].join(''),
   };
-  addLayer('Watercolor', options);
+  addLayer('Watercolor', options, false);
 };
 
 function setup() {

--- a/plugins/basemap-yandex.js
+++ b/plugins/basemap-yandex.js
@@ -28,12 +28,15 @@ var mapYandex = {};
 mapYandex.types = {
   map: {
     type: 'map',
+    isDark: false,
   },
   satellite: {
     type: 'satellite',
+    isDark: true,
   },
   hybrid: {
     type: 'hybrid',
+    isDark: true,
   },
 };
 
@@ -47,7 +50,7 @@ function setup() {
 
   for (var name in mapYandex.types) {
     var options = L.extend({}, mapYandex.options, mapYandex.types[name]);
-    window.layerChooser.addBaseLayer(L.yandex(options), 'Yandex ' + name);
+    window.layerChooser.addBaseLayer(L.yandex(options), 'Yandex ' + name, { isDark: options.isDark });
   }
 }
 


### PR DESCRIPTION
Introduces a `baseLayerChanged` hook fired when the base map changes (and once on initial load), providing `{ name, layer, isDark }`.

This gives plugins a way to react to basemap switches (previously only possible via Leaflet's `baselayerchange` event), and lets the app and plugins adapt the UI to a light or dark map - e.g. the app can set the system status bar color via `window.app.setMapDarkMode(isDark)`.

Base layers declare their theme through a new `isDark` option of `addBaseLayer`; layers without it are treated as dark, keeping backwards compatibility with third-party map plugins. All bundled basemaps are annotated accordingly.
