### PR TITLE
Update how `.ui-dialog`'s `max-width` is set.

### DIFF
--- a/core/style.css
+++ b/core/style.css
@@ -1171,13 +1171,7 @@ h3.title {
 }
 
 .ui-dialog {
-  max-width: calc(100vw - 2px);
-}
-
-@media (min-width: 700px) {
-  .ui-dialog {
-    max-width: 600px;
-  }
+  max-width: calc(100vw - 1rem);
 }
 
 .ui-dialog-content-hidden {


### PR DESCRIPTION
This removes the `@media` variant and changes the default to be 1-rem narrower than the viewport.

Closes #504.