### PR TITLE
dialog: dialogClass workaround (closes #928)

### DIFF
--- a/core/code/dialog.js
+++ b/core/code/dialog.js
@@ -21,7 +21,7 @@ window.DIALOG_ID = 0;
  *                                                Text is auto-converted to HTML.
  * @param {string} [options.title] - The dialog's title.
  * @param {boolean} [options.modal=false] - Whether to open a modal dialog. Implies draggable=false;
- *                                          dialogClass='ui-dialog-modal'. Note that modal dialogs hijack
+ *                                          class set to 'ui-dialog-modal'. Note that modal dialogs hijack
  *                                          the entire screen and should only be used in specific cases.
  *                                          If IITC is running on mobile, modal will always be true.
  * @param {string} [options.id] - A unique ID for this dialog. If a dialog with this ID is already open,
@@ -38,7 +38,11 @@ window.DIALOG_ID = 0;
  *
  * @see {@link http://docs.jquery.com/UI/API/1.8/Dialog} for a list of all jQuery UI Dialog options.
  * If you previously applied a class to your dialog after creating it with alert(),
- * dialogClass may be particularly useful.
+ * classes may be particularly useful.
+ *
+ * NOTE:
+ *  options.dialogClass is deprecated!
+ *  use options.classes['ui-dialog'] = "myclass"
  */
 window.dialog = function (options) {
   // Override for smartphones. Preserve default behavior and create a modal dialog.
@@ -59,9 +63,12 @@ window.dialog = function (options) {
     html = window.convertTextToTableMagic('');
   }
 
+  // Backwards compatibility. dialogClass is deprecated.
+  options.classes = Object.assign({ 'ui-dialog': options.dialogClass }, options.classes);
+
   // Modal dialogs should not be draggable
   if (options.modal) {
-    options.dialogClass = (options.dialogClass ? options.dialogClass + ' ' : '') + 'ui-dialog-modal';
+    options.classes['ui-dialog'] = (options.classes['ui-dialog'] ? options.classes['ui-dialog'] + ' ' : '') + 'ui-dialog-modal';
     options.draggable = false;
   }
 


### PR DESCRIPTION
the dialogClass options was removed from JQueryUI in v14.0. Developers have to use the "classes" object.

this workaround will do this for old/unmaintained plugins.