### PR TITLE
Proof-of-concept of using Material Icons or Material Symbols.

### DIFF
--- a/core/code/boot.js
+++ b/core/code/boot.js
@@ -270,6 +270,33 @@ function updateControlBarZIndex() {
   });
 }
 
+function setupWebComponents() {
+
+  class MaterialSymbolIcon extends HTMLElement {
+    // This could be used to implement a fallback if necessary.
+    static #ready = false;
+
+    connectedCallback() {
+      console.log('ready', this.constructor.#ready);
+      this.classList.add('material-symbols-outlined', 'mat-resolved');
+    }
+
+    static {
+      document.fonts.ready.then((fontSet) => {
+        fontSet.forEach((font) => {
+          if (font.family === '"Material Symbols Outlined"') {
+            font.loaded.then(() => {
+              MaterialSymbolIcon.#ready = true;
+            });
+          }
+        });
+      });
+    }
+
+  }
+
+  customElements.define('mat-icon', MaterialSymbolIcon);
+}
 
 /**
  * The main boot function that initializes IITC. It is responsible for setting up the map,
@@ -287,6 +314,7 @@ function boot() {
   var loadPlugins = prepPluginsToLoad();
   loadPlugins('boot');
 
+  setupWebComponents();
   window.setupDialogs();
   checkingIntelURL();
   setupIngressMarkers();

--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -147,28 +147,80 @@ window.renderPortalToSideBar = function (portal) {
       $('<h3>', { class: 'title' })
         .text(title)
         .prepend(
-          $('<svg><use xlink:href="#ic_place_24px"/><title>Click to move to portal</title></svg>')
+          $('<svg><use xlink:href="#ic_place_24px"/></svg>')
             .attr({
-              class: 'material-icons icon-button',
+              class: 'material-icons0 icon-button',
               style: 'float: left',
+              title: 'Click to move to portal',
             })
             .click(function () {
               window.zoomToAndShowPortal(guid, [details.latE6 / 1e6, details.lngE6 / 1e6]);
               if (window.isSmartphone()) {
                 window.show('map');
               }
-            })
+            }),
+          $('<span>')
+            .text('place')
+            .attr({
+              class: 'material-icons icon-button',
+              style: 'float: left',
+              title: 'old style material icon',
+            }),
+          $('<span>')
+            .text('location_on')
+            .attr({
+              class: 'material-symbols-outlined icon-button',
+              style: 'float: left; font-variation-settings: "FILL" 1;',
+              title: 'new style material symbol (filled)',
+            }),
+          $('<span>')
+            .text('location_on')
+            .attr({
+              class: 'material-symbols-outlined icon-button',
+              style: 'float: left; font-variation-settings: "FILL" 0;',
+              title: 'new style material symbol (open)',
+            }),
         ),
 
       $('<span>')
-        .attr({
+        .append(
+          $('<span>')
+            .text('close_small')
+            .attr({
+              class: 'material-symbols-outlined',
+              style: 'font-size: revert;',
+              title: 'new style material symbol (small)',
+            }),
+          $('<span>')
+            .text('close')
+            .attr({
+              class: 'material-symbols-outlined',
+              style: 'font-size: revert;',
+              title: 'new style material symbol',
+            }),
+          $('<span>')
+            .text('close')
+            .attr({
+              class: 'material-icons',
+              style: 'font-size: revert;',
+              title: 'old style material icon',
+            }),
+          $('<span>')
+            .text('x')
+            .attr({
+              title: 'small x',
+            }),
+          $('<span>')
+            .text('X')
+            .attr({
+              title: 'Close [w]',
+              accesskey: 'w',
+            })
+            .click(function () {
+              window.renderPortalDetails(null);
+            })
+        ).attr({
           class: 'close',
-          title: 'Close [w]',
-          accesskey: 'w',
-        })
-        .text('X')
-        .click(function () {
-          window.renderPortalDetails(null);
         }),
 
       // help cursor via ".imgpreview img"

--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -160,13 +160,6 @@ window.renderPortalToSideBar = function (portal) {
               }
             }),
           $('<span>')
-            .text('place')
-            .attr({
-              class: 'material-icons icon-button',
-              style: 'float: left',
-              title: 'old style material icon',
-            }),
-          $('<span>')
             .text('location_on')
             .attr({
               class: 'material-symbols-outlined icon-button',
@@ -197,13 +190,6 @@ window.renderPortalToSideBar = function (portal) {
               class: 'material-symbols-outlined',
               style: 'font-size: revert;',
               title: 'new style material symbol',
-            }),
-          $('<span>')
-            .text('close')
-            .attr({
-              class: 'material-icons',
-              style: 'font-size: revert;',
-              title: 'old style material icon',
             }),
           $('<span>')
             .text('x')

--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -147,11 +147,11 @@ window.renderPortalToSideBar = function (portal) {
       $('<h3>', { class: 'title' })
         .text(title)
         .prepend(
-          $('<span>')
-            .text('location_on')
+          $('<mat-icon>')
+            .text('place')
             .attr({
-              class: 'material-symbols-outlined icon-button',
-              style: 'float: left; font-variation-settings: "FILL" 1;',
+              class: 'mat-fill icon-button',
+              style: 'float: left;',
               title: 'Click to move to portal',
             })
             .click(function () {
@@ -164,10 +164,9 @@ window.renderPortalToSideBar = function (portal) {
 
       $('<span>')
         .append(
-          $('<span>')
+          $('<mat-icon>')
             .text('close')
             .attr({
-              class: 'material-symbols-outlined',
               style: 'font-size: revert;',
               title: 'Close [w]',
               accesskey: 'w',

--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -147,10 +147,11 @@ window.renderPortalToSideBar = function (portal) {
       $('<h3>', { class: 'title' })
         .text(title)
         .prepend(
-          $('<svg><use xlink:href="#ic_place_24px"/></svg>')
+          $('<span>')
+            .text('location_on')
             .attr({
-              class: 'material-icons0 icon-button',
-              style: 'float: left',
+              class: 'material-symbols-outlined icon-button',
+              style: 'float: left; font-variation-settings: "FILL" 1;',
               title: 'Click to move to portal',
             })
             .click(function () {
@@ -158,47 +159,16 @@ window.renderPortalToSideBar = function (portal) {
               if (window.isSmartphone()) {
                 window.show('map');
               }
-            }),
-          $('<span>')
-            .text('location_on')
-            .attr({
-              class: 'material-symbols-outlined icon-button',
-              style: 'float: left; font-variation-settings: "FILL" 1;',
-              title: 'new style material symbol (filled)',
-            }),
-          $('<span>')
-            .text('location_on')
-            .attr({
-              class: 'material-symbols-outlined icon-button',
-              style: 'float: left; font-variation-settings: "FILL" 0;',
-              title: 'new style material symbol (open)',
-            }),
+            })
         ),
 
       $('<span>')
         .append(
           $('<span>')
-            .text('close_small')
-            .attr({
-              class: 'material-symbols-outlined',
-              style: 'font-size: revert;',
-              title: 'new style material symbol (small)',
-            }),
-          $('<span>')
             .text('close')
             .attr({
               class: 'material-symbols-outlined',
               style: 'font-size: revert;',
-              title: 'new style material symbol',
-            }),
-          $('<span>')
-            .text('x')
-            .attr({
-              title: 'small x',
-            }),
-          $('<span>')
-            .text('X')
-            .attr({
               title: 'Close [w]',
               accesskey: 'w',
             })

--- a/core/code/sidebar.js
+++ b/core/code/sidebar.js
@@ -12,7 +12,6 @@
  */
 window.setupSidebar = function () {
   window.setupStyles();
-  setupIcons();
   window.setupPlayerStat();
   setupSidebarToggle();
   setupLargeImagePreview();
@@ -40,27 +39,6 @@ window.setupStyles = function () {
       '</style>'
   );
 };
-
-/**
- * Sets up custom icons by appending SVG definitions to the DOM.
- *
- * @function setupIcons
- */
-function setupIcons() {
-  // TODO: Delete this function as this icon would no longer be needed.
-  $(
-    [
-      '<svg>',
-      // Material Icons
-
-      // portal_detail_display.js
-      '<symbol id="ic_place_24px" viewBox="0 0 24 24">',
-      '<path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5a2.5 2.5 0 0 1 0-5 2.5 2.5 0 0 1 0 5z"/>',
-      '</symbol>',
-      '</svg>',
-    ].join('\\n')
-  ).appendTo('body');
-}
 
 /**
  * Renders player details into the website. Since the player info is

--- a/core/code/sidebar.js
+++ b/core/code/sidebar.js
@@ -47,6 +47,7 @@ window.setupStyles = function () {
  * @function setupIcons
  */
 function setupIcons() {
+  // TODO: Delete this function as this icon would no longer be needed.
   $(
     [
       '<svg>',

--- a/core/style.css
+++ b/core/style.css
@@ -51,12 +51,6 @@ body {
   margin: 0;
 }
 
-/* Material Icons */
-.material-icons0 {
-  width: 24px;
-  height: 24px;
-}
-
 .icon-button {
   cursor: pointer;
 }

--- a/core/style.css
+++ b/core/style.css
@@ -52,7 +52,7 @@ body {
 }
 
 /* Material Icons */
-.material-icons {
+.material-icons0 {
   width: 24px;
   height: 24px;
 }
@@ -735,7 +735,7 @@ input[type="search"], input[type="url"] {
 
 /* portal title and image */
 h3.title {
-  padding-right: 17px; /* to not overlap with close button */
+  padding-right: 40px; /* to not overlap with close button */
   margin: 2px 0;
   line-height: 24px;
   overflow: hidden;

--- a/core/style.css
+++ b/core/style.css
@@ -729,7 +729,7 @@ input[type="search"], input[type="url"] {
 
 /* portal title and image */
 h3.title {
-  padding-right: 40px; /* to not overlap with close button */
+  padding-right: 17px; /* to not overlap with close button */
   margin: 2px 0;
   line-height: 24px;
   overflow: hidden;

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -193,7 +193,10 @@ document.head.innerHTML =
   '@include_string:style.css@' +
   '</style>' +
   // note: smartphone.css injection moved into code/smartphone.js
+  '<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:FILL@0..1"/>' +
+  '<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons"/>' +
   '<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:100,100italic,300,300italic,400,400italic,500,500italic,700,700italic&subset=latin,cyrillic-ext,greek-ext,greek,vietnamese,latin-ext,cyrillic"/>';
+
 
 // remove body element entirely to remove event listeners
 document.body = document.createElement('body');

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -194,7 +194,6 @@ document.head.innerHTML =
   '</style>' +
   // note: smartphone.css injection moved into code/smartphone.js
   '<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:FILL@0..1"/>' +
-  '<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/icon?family=Material+Icons"/>' +
   '<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:100,100italic,300,300italic,400,400italic,500,500italic,700,700italic&subset=latin,cyrillic-ext,greek-ext,greek,vietnamese,latin-ext,cyrillic"/>';
 
 

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -192,6 +192,18 @@ document.head.innerHTML =
   '<style>' +
   '@include_string:style.css@' +
   '</style>' +
+  '<style>' +
+  '  :root {' +
+  '    --mat-fill: 0;' +
+  '  }' +
+  '  .mat-fill {' +
+  '    --mat-fill: 1;' +
+  '  }' +
+  '  .mat-resolved {' +
+  '    font-variation-settings: "FILL" var(--mat-fill);' +
+  '    text-transform: capitalize;' +
+  '  }' +
+  '</style>' +
   // note: smartphone.css injection moved into code/smartphone.js
   '<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:FILL@0..1"/>' +
   '<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:100,100italic,300,300italic,400,400italic,500,500italic,700,700italic&subset=latin,cyrillic-ext,greek-ext,greek,vietnamese,latin-ext,cyrillic"/>';

--- a/plugins/bookmarks.css
+++ b/plugins/bookmarks.css
@@ -291,6 +291,12 @@
 	overflow:hidden;
 	background-repeat:no-repeat;
 }
+#bmrksStarWip {
+    color: #fff;
+}
+#bmrksStarWip.favorite {
+    color: #ffce00;
+}
 .bkmrksStar span, .bkmrksStar.favorite:focus span{
 	background-position:left top;
 }

--- a/plugins/bookmarks.css
+++ b/plugins/bookmarks.css
@@ -270,38 +270,22 @@
 #bkmrksTrigger:hover{
 	margin-top:0;
 }
-.portal-list-bookmark span {
-	display:inline-block;
-	margin: -3px;
-	width:16px;
-	height:15px;
-	overflow:hidden;
-	background-repeat:no-repeat;
-	cursor:pointer;
-}
-#bkmrksTrigger, .bkmrksStar span, .portal-list-bookmark span {
-	background-image:url(images/bookmarks-img.png);
-}
-.bkmrksStar span{
-	display:inline-block;
-	float:left;
-	margin:3px 1px 0 4px;
-	width:16px;
-	height:15px;
-	overflow:hidden;
-	background-repeat:no-repeat;
-}
-#bmrksStarWip {
+
+.bkmrksStar {
     color: #fff;
 }
-#bmrksStarWip.favorite {
+.bkmrksStar.favorite, .portal-list-bookmark.favorite > * {
     color: #ffce00;
 }
-.bkmrksStar span, .bkmrksStar.favorite:focus span{
-	background-position:left top;
+
+.portal-list-bookmark > * {
+        font-size: larger;
+	overflow:hidden;
+	cursor:pointer;
 }
-.bkmrksStar:focus span, .bkmrksStar.favorite span, .portal-list-bookmark.favorite span{
-	background-position:right top;
+
+#bkmrksTrigger {
+	background-image:url(images/bookmarks-img.png);
 }
 #bookmarksBox .bookmarkList .bookmarkFolder{
 	overflow:hidden;
@@ -564,12 +548,6 @@
 #bookmarksBox.mobile .bookmarkList li.bookmarkFolder ul{
 	display:none !important;
 	min-height:37px !important;
-}
-#updatestatus .bkmrksStar{
-	float:left;
-	margin:-19px 0 0 -5px;
-	padding:0 3px 1px 4px;
-	background:#262c32;
 }
 #bookmarksBox.mobile .bookmarkList .bookmarkFolder .folderLabel .bookmarksAnchor span,
 #bookmarksBox.mobile .bookmarkList .bookmarkFolder .folderLabel > span,

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -1319,7 +1319,6 @@ window.plugin.bookmarks.setupContent = function () {
   window.plugin.bookmarks.htmlStar =
     '<a class="bkmrksStar" accesskey="b" onclick="window.plugin.bookmarks.switchStarPortal();return false;" title="Save this portal in your bookmarks [b]"><span></span>' +
     '<foo id="bmrksStarWip">' +
-    '<bar class="material-icons" style="float: left">star</bar>' +
     '<bar class="material-symbols-outlined" style="float: left; font-variation-settings: \'FILL\' 1;">star</bar>' +
     '<bar class="material-symbols-outlined" style="float: left; font-variation-settings: \'FILL\' 1;">bookmark_star</bar>' +
     '</foo>' +

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -1265,7 +1265,11 @@ window.plugin.bookmarks.setupPortalsList = function () {
       $(cell).addClass('portal-list-bookmark').attr('data-list-bookmark', guid);
 
       // for some reason, jQuery removes event listeners when the list is sorted. Therefore we use DOM's addEventListener
-      $('<span>')
+      $('<mat-icon>')
+        .text('star')
+        .attr({
+          class: 'mat-fill',
+        })
         .appendTo(cell)[0]
         .addEventListener(
           'click',
@@ -1317,11 +1321,8 @@ window.plugin.bookmarks.setupContent = function () {
 
   window.plugin.bookmarks.htmlDisabledMessage = '<div title="Your browser do not support localStorage">Plugin Bookmarks disabled*.</div>';
   window.plugin.bookmarks.htmlStar =
-    '<a class="bkmrksStar" accesskey="b" onclick="window.plugin.bookmarks.switchStarPortal();return false;" title="Save this portal in your bookmarks [b]"><span></span>' +
-    '<foo id="bmrksStarWip">' +
-    '<bar class="material-symbols-outlined" style="float: left; font-variation-settings: \'FILL\' 1;">star</bar>' +
-    '<bar class="material-symbols-outlined" style="float: left; font-variation-settings: \'FILL\' 1;">bookmark_star</bar>' +
-    '</foo>' +
+    '<a class="bkmrksStar" accesskey="b" onclick="window.plugin.bookmarks.switchStarPortal();return false;" title="Save this portal in your bookmarks [b]">' +
+    '<mat-icon class="mat-fill" style="float: left;">star</bar>' +
     '</a>';
   window.plugin.bookmarks.htmlMoveBtn =
     '<a id="bookmarksMove" class="btn" onclick="window.plugin.bookmarks.moveMode();return false;">Show/Hide "Move" button</a>';

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -358,6 +358,7 @@ window.plugin.bookmarks.onPortalSelected = function () {
 window.plugin.bookmarks.updateStarPortal = function () {
   var guid = window.selectedPortal;
   $('.bkmrksStar').removeClass('favorite');
+  $('#bmrksStarWip').removeClass('favorite');
   $('.bkmrk a.bookmarksLink.selected').removeClass('selected');
 
   // If current portal is into bookmarks: select bookmark portal from portals list and select the star
@@ -366,6 +367,7 @@ window.plugin.bookmarks.updateStarPortal = function () {
     if (bkmrkData) {
       $('.bkmrk#' + bkmrkData['id_bookmark'] + ' a.bookmarksLink').addClass('selected');
       $('.bkmrksStar').addClass('favorite');
+      $('#bmrksStarWip').addClass('favorite');
     }
   }
 };
@@ -1315,7 +1317,13 @@ window.plugin.bookmarks.setupContent = function () {
 
   window.plugin.bookmarks.htmlDisabledMessage = '<div title="Your browser do not support localStorage">Plugin Bookmarks disabled*.</div>';
   window.plugin.bookmarks.htmlStar =
-    '<a class="bkmrksStar" accesskey="b" onclick="window.plugin.bookmarks.switchStarPortal();return false;" title="Save this portal in your bookmarks [b]"><span></span></a>';
+    '<a class="bkmrksStar" accesskey="b" onclick="window.plugin.bookmarks.switchStarPortal();return false;" title="Save this portal in your bookmarks [b]"><span></span>' +
+    '<foo id="bmrksStarWip">' +
+    '<bar class="material-icons" style="float: left">star</bar>' +
+    '<bar class="material-symbols-outlined" style="float: left; font-variation-settings: \'FILL\' 1;">star</bar>' +
+    '<bar class="material-symbols-outlined" style="float: left; font-variation-settings: \'FILL\' 1;">bookmark_star</bar>' +
+    '</foo>' +
+    '</a>';
   window.plugin.bookmarks.htmlMoveBtn =
     '<a id="bookmarksMove" class="btn" onclick="window.plugin.bookmarks.moveMode();return false;">Show/Hide "Move" button</a>';
 


### PR DESCRIPTION
This is not expected to be submitted, but rather a demonstration and playground.

It demonstrates how icons could be replaced using either the older Material Icons (considered deprecated) or the newer Material Symbols.

In this example, I updated three icons in the portal details: core map pin, close, and bookmarks plugin's star.  In all cases, I kept the current icon and added multiple examples of replacements using both sets.

I researched a few of the existing issues on this topic (last discussed in 2019/2020).  In this case, I am using the fonts rather than svg equivalents (as currently used for the map pin).

I did ZERO testing with the Android app.  The "close" icons look a little funky on Firefox on Android, but I am probably the only user of that configuration.

Based upon the previous discussions:

* Icons are available 'out-of-the-box'
* Fairly easy to use (just `<span class='material-icons'>...</span>`), though specifying a filled variant can be cumbersome with Symbols.
* Symbols does use excessive resources [See optimization docs](https://developers.google.com/fonts/docs/material_symbols#optimize_the_icon_font), but they seem cached on page reloads.  As currently specified, Icons weigh in at 130kB and Symbols at 458kB.

Specific details about this PoC:

* Renamed the old `material-icons` class (only kept so that existing map icon could be shown against new ones).
* This uses the live web version, which avoids the need to keep local assets. Related, as in Safari, Firefox makes it trivial for users to block webfonts (I actually do this), but I think that can be considered self-inflicted pain.
* Did not even consider Font Awesome, unsure if it needs JS support or not.
* The change from `<title>...</title>` to an attr `title:` is not necessary, but made for consistency in the demo.
* Heavily tweaked `h3.title` to deal with the excessive number of icons.

Personal thoughts:

* I think the old map pin (Icons) looks better, but as demonstrated with the bookmark stars, Symbols has more variations.
* The function `setupIcons()` can probably go away.
* If Symbols are used, it might be possible to reduce the download size.  A test for just the icons used in this demo is 2.8kB, but the names must be alphabetical.  That means each plugin would have to register what they want, then an appropriate `<style>` header created.  Feels fragile.

Related: #45, #88, #236, #312, #414