### PR TITLE
Simplify how the side panel's portal title is constructed.

### DIFF
--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -144,32 +144,36 @@ window.renderPortalToSideBar = function (portal) {
     .html('') // to ensure it's clear
     .attr('class', window.TEAM_TO_CSS[window.teamStringToId(details.team)])
     .append(
-      $('<h3>', { class: 'title' })
-        .text(title)
-        .prepend(
+      // h3.title is kept for supporting plugins that reference it.
+      $('<h3>')
+        .attr({
+          id: 'portaltitle',
+          class: 'title',
+        })
+        .append(
           $('<svg><use xlink:href="#ic_place_24px"/><title>Click to move to portal</title></svg>')
             .attr({
               class: 'material-icons icon-button',
-              style: 'float: left',
             })
             .click(function () {
               window.zoomToAndShowPortal(guid, [details.latE6 / 1e6, details.lngE6 / 1e6]);
               if (window.isSmartphone()) {
                 window.show('map');
               }
+            }),
+          $('<span>', { class: 'value' })
+            .text(title),
+          $('<span>')
+            .attr({
+              class: 'close',
+              title: 'Close [w]',
+              accesskey: 'w',
             })
+            .text('X')
+            .click(function () {
+              window.renderPortalDetails(null);
+            }),
         ),
-
-      $('<span>')
-        .attr({
-          class: 'close',
-          title: 'Close [w]',
-          accesskey: 'w',
-        })
-        .text('X')
-        .click(function () {
-          window.renderPortalDetails(null);
-        }),
 
       // help cursor via ".imgpreview img"
       $('<div>')

--- a/core/code/portal_detail_display.js
+++ b/core/code/portal_detail_display.js
@@ -161,7 +161,10 @@ window.renderPortalToSideBar = function (portal) {
                 window.show('map');
               }
             }),
-          $('<span>', { class: 'value' })
+          $('<span>')
+            .attr({
+              class: 'value',
+            })
             .text(title),
           $('<span>')
             .attr({
@@ -172,7 +175,7 @@ window.renderPortalToSideBar = function (portal) {
             .text('X')
             .click(function () {
               window.renderPortalDetails(null);
-            }),
+            })
         ),
 
       // help cursor via ".imgpreview img"

--- a/core/code/sidebar.js
+++ b/core/code/sidebar.js
@@ -145,7 +145,7 @@ function setupSidebarToggle() {
  * @function setupLargeImagePreview
  */
 function setupLargeImagePreview() {
-  $('#portaldetails').on('click', '.imgpreview', function (e) {
+  $('#portaldetails').on('click', '.imgpreview', function () {
     var img = this.querySelector('img');
     // dialogs have 12px padding around the content
     var dlgWidth = Math.max(img.naturalWidth + 24, 500);
@@ -158,7 +158,7 @@ function setupLargeImagePreview() {
     var preview = new Image(img.width, img.height);
     preview.src = img.src;
     preview.style = 'margin: auto; display: block';
-    var title = e.delegateTarget.querySelector('.title').innerText;
+    const title = document.querySelector('#portaltitle .value')?.innerText || '';
     window.dialog({
       html: preview,
       title: title,

--- a/core/style.css
+++ b/core/style.css
@@ -732,17 +732,28 @@ input[type="search"], input[type="url"] {
   padding: 0;
 }
 
-
-/* portal title and image */
-h3.title {
-  padding-right: 17px; /* to not overlap with close button */
+#portaltitle {
+  display: flex;
   margin: 2px 0;
   line-height: 24px;
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+#portaltitle .value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+#portaltitle .close {
+  margin-right: 2px;
+  margin-top: -2px;
+  cursor: pointer;
+  color: #FFCE00;
+  font-weight: normal;
+}
+
+/* portal image */
 .imgpreview {
   height: 190px;
   background: no-repeat center center;
@@ -957,16 +968,6 @@ h3.title {
 
 #portaldetails {
   min-height: 63px;
-  position: relative; /* so the below '#portaldetails .close' is relative to this */
-}
-
-#portaldetails .close {
-  position: absolute;
-  top: -2px;
-  right: 2px;
-  cursor: pointer;
-  color: #FFCE00;
-  font-size: 16px;
 }
 
 /* history details */

--- a/core/style.css
+++ b/core/style.css
@@ -747,7 +747,6 @@ input[type="search"], input[type="url"] {
 
 #portaltitle .close {
   margin-right: 2px;
-  margin-top: -2px;
   cursor: pointer;
   color: #FFCE00;
   font-weight: normal;


### PR DESCRIPTION
The `h3` is now the whole title line (a `div` would be better, but at least bookmarks uses `h3.title` in a query), with immediate children all inline items (e.g., `svg` and `span`).  And an explicit id of `portaltitle`.

The `h3` is also changed to being a flex container to allow easier control of elements.  Rather than having to guess on what the right margin of the title string should be (e.g., `right-margin: 17px`), by using flex, the browser takes care of it automatically.

This also removes requiring `float: <side>` or absolute positioning.  They now simply show up in the order they are added.