### PR TITLE
ci: update Actions to node24 and harden token handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,15 +11,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.9'
 
@@ -63,7 +63,7 @@ jobs:
         with:
           allowUpdates: true
           artifactErrorsFailBuild: true
-          artifacts: "./build/${{ env.BUILD_TYPE }}/*.zip,./build/${{ env.BUILD_TYPE }}/*.apk"
+          artifacts: './build/${{ env.BUILD_TYPE }}/*.zip,./build/${{ env.BUILD_TYPE }}/*.apk'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Send APK to Telegram
@@ -88,7 +88,7 @@ jobs:
           echo $( ls ./artifact/build/ | grep '.zip' ) > ./artifact/.metadata/zip_filename
           echo $(date -u +'%Y-%m-%d_%H-%M' -d"$(stat -c %y ./artifact/build/total-conversion-build.user.js)") > ./artifact/.metadata/buildstamp
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build
           include-hidden-files: true

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -11,15 +11,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.9'
 
@@ -46,7 +46,7 @@ jobs:
           echo $( ls ./build/build/ | grep '.zip' ) > ./build/.metadata/zip_filename
           echo $(date -u +'%Y-%m-%d_%H-%M' -d"$(stat -c %y ./build/build/total-conversion-build.user.js)") > ./build/.metadata/buildstamp
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build
           include-hidden-files: true

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -4,8 +4,6 @@ name: Build PR
 # no access to secrets
 on:
   pull_request:
-    paths-ignore:
-      - '!.github/**'
 
 jobs:
   build:

--- a/.github/workflows/deploy_google_play.yml
+++ b/.github/workflows/deploy_google_play.yml
@@ -49,15 +49,15 @@ jobs:
       needs.check-release-commit.outputs.is_release == 'false'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.9'
 

--- a/.github/workflows/jsdoc.yml
+++ b/.github/workflows/jsdoc.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    paths-ignore:
-      - '!.github/**'
 
 jobs:
   deploy:

--- a/.github/workflows/jsdoc.yml
+++ b/.github/workflows/jsdoc.yml
@@ -13,19 +13,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+
+      - name: Install dependencies
+        run: npm install
 
       - name: Build
-        uses: zhennann/jsdoc-action@v1
-        with:
-          output_dir: ./out
-          config_file: jsdoc-conf.json
-          template: tui-jsdoc-template
-          front_page: README.md
+        run: npm run docs
 
       - name: Deploy
         if: github.event_name != 'pull_request'
         uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          publish_dir: ./out
+          publish_dir: ./docs

--- a/.github/workflows/merge_pr.yml
+++ b/.github/workflows/merge_pr.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           WEBSITE_REPO: ${{ secrets.WEBSITE_REPO }}
         if: ${{ env.WEBSITE_REPO != '' }}
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.API_TOKEN_GITHUB }}
           repository: ${{ env.WEBSITE_REPO }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: reviewdog/action-eslint@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -4,8 +4,6 @@ name: reviewdog
 # no access to secrets
 on:
   pull_request:
-    paths-ignore:
-      - '!.github/**'
 
 jobs:
   eslint:

--- a/.github/workflows/send_build_to_website.yml
+++ b/.github/workflows/send_build_to_website.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           WEBSITE_REPO: ${{ secrets.WEBSITE_REPO }}
         if: ${{ env.WEBSITE_REPO != '' }}
@@ -62,7 +62,7 @@ jobs:
         env:
           WEBSITE_REPO: ${{ secrets.WEBSITE_REPO }}
         if: ${{ env.WEBSITE_REPO != '' && github.event.workflow_run.event == 'pull_request' }}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: pr_release
           number: ${{ env.PR_NUMBER }}
@@ -79,7 +79,7 @@ jobs:
         env:
           WEBSITE_REPO: ${{ secrets.WEBSITE_REPO }}
         if: ${{ env.WEBSITE_REPO != '' }}
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.API_TOKEN_GITHUB }}
           repository: ${{ env.WEBSITE_REPO }}

--- a/.github/workflows/send_build_to_website.yml
+++ b/.github/workflows/send_build_to_website.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   upload:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: 'Download artifact'
@@ -52,11 +54,16 @@ jobs:
           WEBSITE_REPO: ${{ secrets.WEBSITE_REPO }}
         if: ${{ env.WEBSITE_REPO != '' && github.event.workflow_run.event == 'pull_request' }}
         run: |
-          echo "PR_NUMBER=$(cat ./.metadata/pr_number)" >> "$GITHUB_ENV"
-          echo "COMMIT_HASH=$(cat ./.metadata/commit)" >> "$GITHUB_ENV"
-          echo "BUILD_APK_FILENAME=$(cat ./.metadata/apk_filename)" >> "$GITHUB_ENV"
-          echo "BUILD_ZIP_FILENAME=$(cat ./.metadata/zip_filename)" >> "$GITHUB_ENV"
-          echo "BUILDSTAMP=$(cat ./.metadata/buildstamp)" >> "$GITHUB_ENV"
+          # metadata comes from an untrusted PR build artifact; keep only the
+          # first line of each value so it cannot inject extra GITHUB_ENV vars
+          read_meta() { head -n1 "$1" | tr -d '\r\n'; }
+          {
+            echo "PR_NUMBER=$(read_meta ./.metadata/pr_number)"
+            echo "COMMIT_HASH=$(read_meta ./.metadata/commit)"
+            echo "BUILD_APK_FILENAME=$(read_meta ./.metadata/apk_filename)"
+            echo "BUILD_ZIP_FILENAME=$(read_meta ./.metadata/zip_filename)"
+            echo "BUILDSTAMP=$(read_meta ./.metadata/buildstamp)"
+          } >> "$GITHUB_ENV"
 
       - name: Comment with build url for PR
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,20 +9,20 @@ name: Tests
 
 jobs:
   test:
-    name: 'Node.js v18'
+    name: 'Node.js LTS'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: 'lts/*'
       - name: 'Cache node_modules'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-18-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-18-
+            ${{ runner.os }}-node-
       - name: Install Dependencies
         run: npm install
       - name: Run All Node.js Tests

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ local*.py
 .pydevproject
 .DS_Store
 
-node_modules
+node_modules/
+docs/
 
 ### JetBrains IDE Ignores ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build:local": "./build.py local",
     "build:mobile": "./build.py mobile",
     "fileserver": "./web_server_local.py local",
+    "docs": "jsdoc -c jsdoc-conf.json -R README.md -d ./docs",
     "test": "mocha -r test/_mocks.js --exit"
   }
 }


### PR DESCRIPTION
- **Bump all GitHub Actions** to their latest releases (now on the node24 runtime).
- **Replace `zhennann/jsdoc-action`** (stuck on node16) with direct `npm run docs`; drop the EOL Node 18 pin in `test.yml` for `lts/*`.
- **Sanitize untrusted PR build metadata** before writing it to `$GITHUB_ENV` in the privileged `workflow_run` job, closing an env-var injection.
- **Scope `GITHUB_TOKEN` per job** so the default token can be set to read-only, and drop the no-op `paths-ignore: ['!.github/**']` filter.

close https://github.com/IITC-CE/ingress-intel-total-conversion/issues/936
