### PR TITLE
Fix getChatPortalName call in player-activity-tracker

### DIFF
--- a/plugins/player-activity-tracker.js
+++ b/plugins/player-activity-tracker.js
@@ -424,9 +424,9 @@ window.plugin.playerTracker.getPortalLink = function (data) {
   return $('<a>')
     .addClass('text-overflow-ellipsis')
     .css('max-width', '15em')
-    .text(IITC.chat.getChatPortalName(data))
+    .text(IITC.comm.getChatPortalName(data))
     .prop({
-      title: IITC.chat.getChatPortalName(data),
+      title: IITC.comm.getChatPortalName(data),
       href: IITC.portal.display.makePermalink(position),
     })
     .click(function (event) {


### PR DESCRIPTION
The plugin crashed with `TypeError: IITC.chat.getChatPortalName is not a function`.
The function belongs to the COMM API, so the call was moved from `IITC.chat` to `IITC.comm`.