### PR TITLE
Fix ReferenceError in window.show after plugins re-eval it

### DIFF
--- a/core/code/panes.js
+++ b/core/code/panes.js
@@ -15,22 +15,22 @@ window.currentPane = '';
 /**
  * Marks a pane or chat channel as the active tab in the chat controls.
  *
- * @function setActiveTab
+ * @function _setActiveTab
  * @param {string} id - The ID of the pane.
  */
-function setActiveTab(id) {
+window._setActiveTab = function (id) {
   document.querySelector('#chatcontrols .active')?.classList.remove('active');
   document.querySelector(`#chatcontrols a[data-channel='${id}']`)?.classList.add('active');
-}
+};
 
 /**
  * Shows the elements a pane consists of and marks its tab in the chat controls.
  * A comm channel is handed over to IITC.chat, which renders and marks it itself.
  *
- * @function applyPane
+ * @function _applyPane
  * @param {string} id - The ID of the pane to apply.
  */
-function applyPane(id) {
+window._applyPane = function (id) {
   if (IITC.chat.getChannelDesc(id)) {
     IITC.chat.show(id);
     return;
@@ -42,15 +42,15 @@ function applyPane(id) {
       IITC.statusbar.show();
       $('#portal_highlight_select').show();
       $('#farm_level_select').show();
-      setActiveTab(id);
+      window._setActiveTab(id);
       break;
     case 'info':
       $('#scrollwrapper').show();
       IITC.portal.display.resetScroll();
-      setActiveTab(id);
+      window._setActiveTab(id);
       break;
   }
-}
+};
 
 /**
  * Shows a specified pane and hides others.
@@ -67,7 +67,7 @@ window.show = function (id) {
     window.runHooks('paneChanged', id);
   }
 
-  applyPane(id);
+  window._applyPane(id);
 };
 
 /**


### PR DESCRIPTION
Plugins that patch `window.show` via `.toString()` + `eval()` (e.g. loadmorecommshistory) lost access to its module-local helpers `applyPane`/`setActiveTab`, throwing `ReferenceError: applyPane is not defined` on every pane switch.

Moved both helpers onto `window` as `_applyPane`/`_setActiveTab`, so they resolve as property lookups instead of scope-chain references and stay reachable from a re-eval'd copy.
