### PR TITLE
Fix Debug console crash on startup and broken auto-scroll

### DIFF
--- a/core/code/chat.js
+++ b/core/code/chat.js
@@ -567,13 +567,14 @@ chat.setupTabs = () => {
 chat.setup = () => {
   chat.setupTabs();
 
-  if (localStorage['iitc-chat-tab']) {
-    chat.chooseTab(localStorage['iitc-chat-tab']);
-  }
-
+  // show the panel first: chooseTab() cannot apply the deferred needsScrollTop while hidden
   ['chatcontrols', 'chat', 'chatinput'].forEach((id) => {
     document.getElementById(id).style.display = '';
   });
+
+  if (localStorage['iitc-chat-tab']) {
+    chat.chooseTab(localStorage['iitc-chat-tab']);
+  }
 
   document.querySelector('#chatcontrols a').addEventListener('click', chat.toggle);
 

--- a/core/code/chat.js
+++ b/core/code/chat.js
@@ -380,7 +380,9 @@ chat.keepScrollPosition = (box, scrollBefore, isOldMsgs) => {
     return;
   }
 
-  if (scrollBefore === 0 || isOldMsgs) {
+  // within a pixel counts as at the bottom: a fresh container reports 1 (the table is kept
+  // taller than the panel) and a fractional devicePixelRatio makes scrollBottom subpixel
+  if (scrollBefore <= 1 || isOldMsgs) {
     state.ignoreNextScroll = true;
     elm.scrollTop = elm.scrollTop + (window.scrollBottom(elm) - scrollBefore);
   }

--- a/core/code/chat.js
+++ b/core/code/chat.js
@@ -387,17 +387,19 @@ chat.keepScrollPosition = (box, scrollBefore, isOldMsgs) => {
 };
 
 /**
- * Create and insert into the DOM/Mobile app the channel tab
+ * Create and insert into the DOM the channel message container
+ *
+ * Called both from addChannel(), so a channel provider can render into `#chat<id>` right
+ * away, and from createChannelTab() for the comm channels, so it stays idempotent and
+ * silently does nothing while the chat panel itself is missing from the DOM
  *
  * @param {ChannelDescription} channelDesc - channel description
- * @static
+ * @private
  */
-function createChannelTab(channelDesc) {
-  const chatControls = document.getElementById('chatcontrols');
+function createChannelContainer(channelDesc) {
   const chatDiv = document.getElementById('chat');
-  const accessLink = L.Util.template(chat.channelTabTemplate, channelDesc);
-  chatControls.insertAdjacentHTML('beforeend', accessLink);
-  chatControls.lastElementChild.addEventListener('click', chat.chooser);
+  // looked up inside the panel: document-wide, 'chat' + id would also hit #chatcontrols and friends
+  if (!chatDiv || chatDiv.querySelector(`[id="chat${channelDesc.id}"]`)) return;
 
   const channelDiv = L.Util.template(chat.channelContainerTemplate, channelDesc);
   chatDiv.insertAdjacentHTML('beforeend', channelDiv);
@@ -413,6 +415,21 @@ function createChannelTab(channelDesc) {
       if (window.scrollBottom(elm) === 0) channelDesc.request(channelDesc.id, false);
     });
   }
+}
+
+/**
+ * Create and insert into the DOM/Mobile app the channel tab
+ *
+ * @param {ChannelDescription} channelDesc - channel description
+ * @private
+ */
+function createChannelTab(channelDesc) {
+  const chatControls = document.getElementById('chatcontrols');
+  const accessLink = L.Util.template(chat.channelTabTemplate, channelDesc);
+  chatControls.insertAdjacentHTML('beforeend', accessLink);
+  chatControls.lastElementChild.addEventListener('click', chat.chooser);
+
+  createChannelContainer(channelDesc);
 
   // pane
   if (window.useAndroidPanes()) {
@@ -427,7 +444,8 @@ let isTabsSetup = false;
 /**
  * Add to the channel list a new channel description
  *
- * If tabs are already created, a tab is created for this channel as well
+ * The message container is created right away, so `#chat<id>` is usable as soon as this
+ * returns; the tab waits for chat.setupTabs(), which decides the final order and indices
  *
  * @memberof IITC.chat
  * @param {ChannelDescription} channelDesc - channel description
@@ -447,6 +465,7 @@ chat.addChannel = (channelDesc) => {
   channelDesc.index = chat.channels.length;
 
   if (isTabsSetup) createChannelTab(channelDesc);
+  else createChannelContainer(channelDesc);
 
   return true;
 };

--- a/plugins/debug-console.js
+++ b/plugins/debug-console.js
@@ -1,13 +1,17 @@
 // @author         jaiperdu
 // @name           Debug console tab
 // @category       Debug
-// @version        0.2.0
+// @version        0.2.1
 // @description    Add a debug console tab
 
 /* exported setup, changelog --eslint */
 /* global IITC, L */
 
 var changelog = [
+  {
+    version: '0.2.1',
+    changes: ['Fix auto-scroll to the bottom', 'Do not let a failed log line break the code that logged it'],
+  },
   {
     version: '0.2.0',
     changes: [
@@ -105,19 +109,17 @@ debugTab.renderLine = function (errorType, args) {
   var pre = document.createElement('pre');
   pre.textContent = text;
 
-  // Check if the last message is visible (scroll position)
   var debugContainer = document.getElementById('chatdebug');
-  var isAtBottom = debugContainer.scrollTop >= debugContainer.scrollTopMax;
+  var scrollBefore = IITC.utils.scrollBottom(debugContainer);
 
   // Insert a new row in the debug table
-  var table = document.querySelector('#chatdebug table');
+  var table = debugContainer.querySelector('table');
   var row = table.insertRow();
   row.insertCell().append(time);
   row.insertCell().append(type);
   row.insertCell().append(pre);
 
-  // Auto-scroll to the bottom if the user was at the bottom
-  if (isAtBottom) debugContainer.scrollTo(0, debugContainer.scrollTopMax);
+  IITC.chat.keepScrollPosition(debugContainer, scrollBefore, false);
 };
 
 debugTab.console = {};
@@ -150,7 +152,11 @@ function overwriteNative() {
       if (nativeConsole) {
         nativeConsole[which].apply(nativeConsole, arguments);
       }
-      debugTab.console[which].apply(debugTab.console, arguments);
+      try {
+        debugTab.console[which].apply(debugTab.console, arguments);
+      } catch {
+        // never break the caller: console.* is called from arbitrary code
+      }
     };
   }
 

--- a/test/chat.spec.js
+++ b/test/chat.spec.js
@@ -63,6 +63,37 @@ describe('chat.addChannel / getChannelDesc', () => {
     expect(chat.addChannel({ id: 'dup', name: 'Two' })).to.be.false;
     expect(chat.channels).to.have.length(1);
   });
+
+  it('creates the message container before the tabs are set up', () => {
+    document.body.innerHTML = '<div id="chatcontrols"><a></a></div><div id="chat"></div>';
+
+    chat.addChannel({ id: 'debug', name: 'Debug' });
+
+    // debug-console writes into its channel from a boot plugin, before chat.setup() runs
+    expect(document.getElementById('chatdebug')).to.exist;
+    expect(document.querySelector('#chatdebug table')).to.exist;
+    // the tab itself is deferred, so that comm channels keep the first slots
+    expect(document.querySelector('#chatcontrols a[data-channel="debug"]')).to.not.exist;
+  });
+
+  it('does not mistake an unrelated element for the container', () => {
+    document.body.innerHTML = '<div id="chatcontrols"><a></a></div><div id="chat"></div><form id="chatinput"></form>';
+
+    // 'chat' + id collides with the static markup for these two
+    chat.addChannel({ id: 'controls', name: 'Controls' });
+    chat.addChannel({ id: 'input', name: 'Input' });
+
+    expect(document.querySelector('#chat > [id="chatcontrols"]')).to.exist;
+    expect(document.querySelector('#chat > [id="chatinput"]')).to.exist;
+  });
+
+  it('tolerates a missing chat panel', () => {
+    document.body.innerHTML = '';
+
+    // only reachable while the tabs are not set up, hence ahead of the setupTabs specs
+    expect(() => chat.addChannel({ id: 'early', name: 'Early' })).to.not.throw();
+    expect(chat.getChannelDesc('early')).to.exist;
+  });
 });
 
 describe('chat.backgroundChannelData', () => {
@@ -142,6 +173,7 @@ describe('chat.setupTabs / chooseTab', () => {
   before(() => {
     document.body.innerHTML = '<div id="chatcontrols"></div><div id="chat"></div><div id="chatinput"><mark></mark></div>';
     chat.channels.length = 0;
+    chat.addChannel({ id: 'debug', name: 'Debug' });
     chat.setupTabs();
   });
 
@@ -154,6 +186,11 @@ describe('chat.setupTabs / chooseTab', () => {
     expect(chat.getChannelDesc('all')).to.be.ok;
     expect(chat.getChannelDesc('faction')).to.be.ok;
     expect(chat.getChannelDesc('alerts')).to.be.ok;
+  });
+
+  it('reuses the container a plugin channel created before the tabs existed', () => {
+    expect(document.querySelectorAll('#chatdebug')).to.have.length(1);
+    expect(document.querySelector('#chatcontrols a[data-channel="debug"]')).to.exist;
   });
 
   it('wires the legacy per-channel data references', () => {

--- a/test/chat.spec.js
+++ b/test/chat.spec.js
@@ -482,6 +482,28 @@ describe('chat.keepScrollPosition', () => {
     expect(chat.channelState(el).ignoreNextScroll).to.be.true;
   });
 
+  it('treats a subpixel scrollBottom as being at the bottom', () => {
+    document.body.innerHTML = '<div id="chatall"></div>';
+    sinon.stub(IITC.utils, '_isVisible').returns(true);
+    const el = document.getElementById('chatall');
+
+    // a fractional devicePixelRatio leaves scrollTop subpixel, so scrollBottom misses
+    // an exact 0 even at the very end
+    chat.keepScrollPosition(el, -0.2, false);
+
+    expect(chat.channelState(el).ignoreNextScroll).to.be.true;
+  });
+
+  it('does not scroll when the user is genuinely scrolled up', () => {
+    document.body.innerHTML = '<div id="chatall"></div>';
+    sinon.stub(IITC.utils, '_isVisible').returns(true);
+    const el = document.getElementById('chatall');
+
+    chat.keepScrollPosition(el, 40, false);
+
+    expect(chat.channelState(el).ignoreNextScroll).to.be.undefined;
+  });
+
   it('accepts a jQuery object as the box for legacy callers', () => {
     document.body.innerHTML = '<div id="chatall"></div>';
     sinon.stub(IITC.utils, '_isVisible').returns(true);


### PR DESCRIPTION
`debug-console` overrides `window.console` during boot, but its `#chatdebug` container only appeared later, in `IITC.chat.setup()`. Anything logging in between threw in `renderLine`, and `boot()` has no try/catch, so IITC did not load at all. Since jquery-migrate was added (#948) core's own `setupIdle()` logs right in that window, so the crash is deterministic.

The tab also never followed its output, which turned out to be two separate bugs in the channel scroll handling shared with the comm channels.

- `IITC.chat.addChannel()` now creates the `#chat<id>` message container right away, through a private `createChannelContainer()` split out of `createChannelTab()`. Tab creation stays in `chat.setupTabs()`, where the final tab order and accesskey indices are decided
- `chat.setup()` shows the panel before choosing the tab. `chooseTab()` is where a deferred `needsScrollTop` gets applied, and a hidden element cannot be scrolled, so the request was spent on nothing and the channel stayed pinned to the top
- `chat.keepScrollPosition()` allows a pixel of slack instead of testing `scrollBottom` against an exact 0. A fresh container reports 1, since the chat table is kept taller than the panel to stay scrollable, and a fractional devicePixelRatio leaves `scrollTop` subpixel, so on such devices the check never passed. Comm channels were hit by this too and only kept working through the `isOldMsgs` branch
- `debug-console` no longer lets a failed line escape the `console.*` override, and follows new output through `IITC.chat.keepScrollPosition()` instead of the Firefox-only `scrollTopMax`

Fixes #953.
