### PR TITLE
Fix LayerChooser early-restore crash on startup

### DIFF
--- a/core/code/layerchooser.js
+++ b/core/code/layerchooser.js
@@ -144,15 +144,15 @@ var LayerChooser = L.Control.Layers.extend({
         localStorage['iitc-base-map'] = data.name;
       };
       layer.on('add', data.statusTracking, this);
-      // --- Early restore of saved basemap (handles late-loading providers) ---
+      // Early restore of saved basemap (handles late-loading providers)
       try {
         var saved = this.lastBaseLayerName || localStorage['iitc-base-map'];
-        if (!this._earlyRestoreDone && map && saved && name === saved) {
+        if (!this._earlyRestoreDone && this._map && saved && name === saved) {
           this._earlyRestoreDone = true;
           this.showLayer(layer, true);
         }
       } catch (e) {
-        if (window.debug) log.warn('LayerChooser early-restore failed:', e);
+        log.warn('LayerChooser early-restore failed:', e);
       }
     }
   },


### PR DESCRIPTION
`LayerChooser early-restore failed: TypeError: Cannot read properties of undefined (reading 'hasLayer')` on startup, whenever the saved basemap is one of the default ones.

Those layers are passed to the `LayerChooser` constructor, so they get registered before the layer chooser itself is added to the map. The early-restore check added in https://github.com/IITC-CE/ingress-intel-total-conversion/pull/871 did not account for that and called `showLayer()`, which needs the map, too early. It now runs only once the layer chooser has been added to the map - the case it was written for anyway: base layers added later by plugins. The initial basemap is restored separately by `IITC.map.setup()`, so nothing visibly broke.

The warning was also hidden behind `if (window.debug)`, which is set only by the `debug-console` plugin, and is now logged unconditionally.
