### PR TITLE
Show core log output in the Debug console and filter it by level

### DIFF
--- a/core/code/comm.js
+++ b/core/code/comm.js
@@ -324,7 +324,7 @@ function _genPostData(channel, getOlderMsgs, ...args) {
   const CHAT_BOUNDINGBOX_SAME_FACTOR = 0.1;
   // if the old and new box contain each other, after expanding by the factor, don't reset comm
   if (!(b.pad(CHAT_BOUNDINGBOX_SAME_FACTOR).contains(_oldBBox) && _oldBBox.pad(CHAT_BOUNDINGBOX_SAME_FACTOR).contains(b))) {
-    log.log(`Bounding Box changed, comm will be cleared (old: ${_oldBBox.toBBoxString()}; new: ${b.toBBoxString()})`);
+    log.debug(`Bounding Box changed, comm will be cleared (old: ${_oldBBox.toBBoxString()}; new: ${b.toBBoxString()})`);
 
     // need to reset these flags now because clearing will only occur
     // after the request is finished – i.e. there would be one almost

--- a/core/code/dialog.js
+++ b/core/code/dialog.js
@@ -183,7 +183,7 @@ window.dialog = function (options) {
           window.DIALOGS[$(this).data('id')] = this;
           window.DIALOG_COUNT++;
 
-          log.log('window.dialog: ' + $(this).data('id') + ' (' + $(this).dialog('option', 'title') + ') opened. ' + window.DIALOG_COUNT + ' remain.');
+          log.debug('window.dialog: ' + $(this).data('id') + ' (' + $(this).dialog('option', 'title') + ') opened. ' + window.DIALOG_COUNT + ' remain.');
         },
         close: function () {
           // Run the close callback if we have one
@@ -200,7 +200,7 @@ window.dialog = function (options) {
           delete window.DIALOGS[$(this).data('id')];
 
           window.DIALOG_COUNT--;
-          log.log('window.dialog: ' + $(this).data('id') + ' (' + $(this).dialog('option', 'title') + ') closed. ' + window.DIALOG_COUNT + ' remain.');
+          log.debug('window.dialog: ' + $(this).data('id') + ' (' + $(this).dialog('option', 'title') + ') closed. ' + window.DIALOG_COUNT + ' remain.');
 
           // remove from DOM and destroy
           $(this).dialog('destroy').remove();

--- a/core/code/extract_niantic_parameters.js
+++ b/core/code/extract_niantic_parameters.js
@@ -40,7 +40,7 @@ window.extractFromStock = function () {
 
               var match = reVersion.exec(funcStr);
               if (match) {
-                log.log('Found former CURRENT_VERSION in ' + topLevel + '.prototype.' + secLevel);
+                log.debug('Found former CURRENT_VERSION in ' + topLevel + '.prototype.' + secLevel);
                 window.niantic_params.CURRENT_VERSION = match[1];
               }
             }
@@ -110,8 +110,8 @@ window.extractFromStock = function () {
         '<p>This can happen after Niantic update the standard intel site. A fix will be needed from the IITC developers.</p>',
     });
 
-    log.log('Discovered parameters');
-    log.log(JSON.stringify(window.niantic_params, null, 2));
+    log.debug('Discovered parameters');
+    log.debug(JSON.stringify(window.niantic_params, null, 2));
 
     throw new Error('Error: IITC failed to extract CURRENT_VERSION string - cannot continue');
   }

--- a/core/code/idle.js
+++ b/core/code/idle.js
@@ -25,7 +25,7 @@ var idlePoll = function () {
     window._idleTimeLimit = window.REFRESH; // set a small time limit before entering idle mode
   }
   if (!wasIdle && window.isIdle()) {
-    log.log('idlePoll: entering idle mode');
+    log.debug('idlePoll: entering idle mode');
   }
 };
 
@@ -39,7 +39,7 @@ setInterval(idlePoll, IDLE_POLL_TIME * 1000);
 window.idleReset = function () {
   // update immediately when the user comes back
   if (window.isIdle()) {
-    log.log('idleReset: leaving idle mode');
+    log.debug('idleReset: leaving idle mode');
     window.idleTime = 0;
     $.each(window._onResumeFunctions, function (ind, f) {
       f();
@@ -60,7 +60,7 @@ window.idleSet = function () {
   window._idleTimeLimit = 0; // a zero time here will cause idle to start immediately
 
   if (!wasIdle && window.isIdle()) {
-    log.log('idleSet: entering idle mode');
+    log.debug('idleSet: entering idle mode');
   }
 };
 

--- a/core/code/map.js
+++ b/core/code/map.js
@@ -91,13 +91,13 @@ function getPosition() {
   const latE6 = url('latE6');
   const lngE6 = url('lngE6');
   if (latE6 && lngE6) {
-    log.log('mappos: reading email URL params');
+    log.debug('mappos: reading email URL params');
     return normLL(parseInt(latE6) / 1e6, parseInt(lngE6) / 1e6, zoom);
   }
 
   let ll = url('ll') || url('pll');
   if (ll) {
-    log.log('mappos: reading stock Intel URL params');
+    log.debug('mappos: reading stock Intel URL params');
     ll = ll.split(',');
     return normLL(ll[0], ll[1], zoom);
   }
@@ -105,7 +105,7 @@ function getPosition() {
   const lat = window.readCookie('ingress.intelmap.lat');
   const lng = window.readCookie('ingress.intelmap.lng');
   if (lat && lng) {
-    log.log('mappos: reading cookies');
+    log.debug('mappos: reading cookies');
     return normLL(lat, lng, window.readCookie('ingress.intelmap.zoom'));
   }
 }

--- a/core/code/map_renderer.js
+++ b/core/code/map_renderer.js
@@ -219,7 +219,7 @@ IITC.map.Renderer.prototype.endRenderPass = function () {
     }
   }
 
-  log.log(`Render: end cleanup: removed ${countp} portals, ${countl} links, ${countf} fields`);
+  log.debug(`Render: end cleanup: removed ${countp} portals, ${countl} links, ${countf} fields`);
 
   // reorder portals to be after links/fields
   this.bringPortalsToFront();
@@ -577,7 +577,7 @@ IITC.map.Renderer.prototype.rescalePortalMarkers = function () {
   if (this.portalMarkerScale === undefined || this.portalMarkerScale !== IITC.portal.marker.scale()) {
     this.portalMarkerScale = IITC.portal.marker.scale();
 
-    log.log(`Render: map zoom ${window.map.getZoom()} changes portal scale to ${IITC.portal.marker.scale()} - redrawing all portals`);
+    log.debug(`Render: map zoom ${window.map.getZoom()} changes portal scale to ${IITC.portal.marker.scale()} - redrawing all portals`);
 
     // NOTE: we're not calling this because it resets highlights - we're calling it as it
     // resets the style (inc size) of all portal markers, applying the new scale

--- a/core/code/map_request.js
+++ b/core/code/map_request.js
@@ -110,7 +110,7 @@ IITC.map.Request.prototype.start = function () {
  * @memberof IITC.map.Request
  */
 IITC.map.Request.prototype.mapMoveStart = function () {
-  log.log('refresh map movestart');
+  log.debug('refresh map movestart');
 
   this.setStatus('paused');
   this.clearTimeout();
@@ -157,7 +157,7 @@ IITC.map.Request.prototype.idleResume = function () {
   // if we have no timer set and there are no active requests, refresh has gone idle and the timer needs restarting
 
   if (this.idle) {
-    log.log('refresh map idle resume');
+    log.debug('refresh map idle resume');
     this.idle = false;
     this.setStatus('idle restart', undefined, -1);
     this.refreshOnTimeout(this.IDLE_RESUME_REFRESH);
@@ -172,7 +172,7 @@ IITC.map.Request.prototype.idleResume = function () {
  */
 IITC.map.Request.prototype.clearTimeout = function () {
   if (this.timer) {
-    log.log('cancelling existing map refresh timer');
+    log.debug('cancelling existing map refresh timer');
     clearTimeout(this.timer);
     this.timer = undefined;
   }
@@ -188,7 +188,7 @@ IITC.map.Request.prototype.clearTimeout = function () {
 IITC.map.Request.prototype.refreshOnTimeout = function (seconds) {
   this.clearTimeout();
 
-  log.log(`starting map refresh in ${seconds} seconds`);
+  log.debug(`starting map refresh in ${seconds} seconds`);
 
   // double setTimeout used to ensure the delay occurs after any browser-related rendering/updating/etc
   this.timer = setTimeout(() => {
@@ -235,7 +235,7 @@ IITC.map.Request.prototype.getStatus = function () {
 IITC.map.Request.prototype.refresh = function () {
   // if we're idle, don't refresh
   if (window.isIdle()) {
-    log.log('suspending map refresh - is idle');
+    log.debug('suspending map refresh - is idle');
     this.setStatus('idle');
     this.idle = true;
     return;
@@ -291,7 +291,7 @@ IITC.map.Request.prototype.refresh = function () {
 
   window.runHooks('mapDataEntityInject', { callback: this.renderer.processGameEntities.bind(this.renderer) });
 
-  log.log(
+  log.debug(
     `requesting data tiles at zoom ${dataZoom} (L${tileParams.level}+ portals, ${tileParams.tilesPerEdge} tiles per global edge), map zoom is ${mapZoom}`
   );
 
@@ -361,7 +361,7 @@ IITC.map.Request.prototype.refresh = function () {
   // so as far as plugins are concerned, it should be treated as a finished request
   window.runHooks('requestFinished', { success: true });
 
-  log.log('done request preparation (cleared out-of-bounds and invalid for zoom, and rendered cached data)');
+  log.debug('done request preparation (cleared out-of-bounds and invalid for zoom, and rendered cached data)');
 
   if (Object.keys(this.queuedTiles).length > 0) {
     // queued requests - don't start processing the download queue immediately - start it after a short delay
@@ -649,7 +649,7 @@ IITC.map.Request.prototype.handleResponse = function (data, tiles, success) {
   if (errorTiles.length) statusMsg += ', ' + errorTiles.length + ' failed';
   if (unaccountedTiles.length) statusMsg += ', ' + unaccountedTiles.length + ' unaccounted';
   statusMsg += '. delay ' + nextQueueDelay + ' seconds';
-  log.log(statusMsg);
+  log.debug(statusMsg);
 
   // requeue any 'timeout' tiles immediately
   if (timeoutTiles.length > 0) {
@@ -813,7 +813,7 @@ IITC.map.Request.prototype.processRenderQueue = function () {
     const endTime = Date.now();
     const duration = (endTime - this.refreshStartTime) / 1000;
 
-    log.log(`finished requesting data! (took ${duration} seconds to complete)`);
+    log.debug(`finished requesting data! (took ${duration} seconds to complete)`);
 
     window.runHooks('mapDataRefreshEnd', {});
 

--- a/core/code/ornaments.js
+++ b/core/code/ornaments.js
@@ -143,7 +143,7 @@ window.ornaments = {
         if (ornament in this.icon) {
           if (this.icon[ornament].layer) {
             if (this.layers[this.icon[ornament].layer] === undefined) {
-              log.log('Add missing layer: ', this.icon[ornament].layer);
+              log.debug('Add missing layer: ', this.icon[ornament].layer);
               window.ornaments.createLayer(window.ornaments.icon[ornament].layer);
             }
             layer = this.layers[window.ornaments.icon[ornament].layer];

--- a/core/code/portal.js
+++ b/core/code/portal.js
@@ -589,7 +589,7 @@ const selectWhenLoadedByLatLng = (latLng) => {
 
 const testPortalLatLng = (data) => {
   if (data.portal.getLatLng().equals(urlPortalLL)) {
-    log.log(`urlPortalLL ${urlPortalLL.toString()} matches portal GUID ${data.portal.options.guid}`);
+    log.debug(`urlPortalLL ${urlPortalLL.toString()} matches portal GUID ${data.portal.options.guid}`);
     window.selectedPortal = data.portal.options.guid;
     IITC.portal.display.renderDetails(window.selectedPortal, true);
     urlPortalLL = undefined;
@@ -616,7 +616,7 @@ const selectWhenLoadedByGuid = (guid) => {
 
 const testPortalGuid = (data) => {
   if (data.portal.options.guid === urlPortal) {
-    log.log(`urlPortal GUID ${window.urlPortal} found - selecting...`);
+    log.debug(`urlPortal GUID ${window.urlPortal} found - selecting...`);
     window.selectedPortal = urlPortal;
     IITC.portal.display.renderDetails(window.selectedPortal, true);
     urlPortal = undefined;

--- a/core/total-conversion-build.js
+++ b/core/total-conversion-build.js
@@ -770,13 +770,14 @@ window.fields = {};
 // overwrite data
 if (typeof window.plugin !== 'function') window.plugin = function () {};
 
-// eslint-disable-next-line no-unused-vars
 const ulog = (function (module) {
   '@include_raw:external/ulog.min.js@';
   return module;
 })({}).exports;
 
+// Root logger. Core modules get a `log` local at build time; this keeps the name resolvable when
+// a plugin monkey-patches a core function through toString() + eval, and exposes `log.level`
+window.log = ulog;
+
 // eslint-disable-next-line
 '@bundle_code@';
-
-/* exported ulog -- eslint */

--- a/plugins/debug-console.css
+++ b/plugins/debug-console.css
@@ -10,12 +10,33 @@
     color: #eee
 }
 
-#chatdebug td mark.error {
-    color: #FF424D
+/* the level colour marks the label and the message, the timestamp stays neutral */
+#chatdebug tr.error td mark,
+#chatdebug tr.error td pre {
+    color: #FF424D;
 }
 
-#chatdebug td mark.warning {
-    color: #FFDE42
+#chatdebug tr.warning td mark,
+#chatdebug tr.warning td pre {
+    color: #FFDE42;
+}
+
+#chatdebug tr.info td mark,
+#chatdebug tr.info td pre {
+    color: #6ECBFF;
+}
+
+#chatdebug tr.debug td mark,
+#chatdebug tr.debug td pre {
+    color: #9E9E9E;
+}
+
+/* core/style.css styles .warning for page-level notices, which also matches these rows */
+#chatdebug tr.warning,
+#chatdebug tr.warning td mark {
+    font-weight: normal;
+    text-shadow: none;
+    text-align: left;
 }
 
 #chatdebug td pre {
@@ -26,4 +47,76 @@
 
 #chatinput.debug mark {
     color: #bbb;
+}
+
+.debug-filters {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    display: flex;
+    justify-content: flex-end;
+    gap: 3px;
+}
+
+.debug-filters button {
+    padding: 0 5px;
+    border: 1px solid #20A8B1;
+    border-radius: 2px;
+    background: rgb(8, 48, 78);
+    color: #eee;
+    font-size: 11px;
+    line-height: 16px;
+    cursor: pointer;
+    opacity: 0.4;
+    transition: opacity 0.15s;
+}
+
+.debug-filters:hover button {
+    opacity: 1;
+}
+
+.debug-filters button.error {
+    color: #FF424D
+}
+
+/* the global .warning class reaches this button too */
+.debug-filters button.warning {
+    color: #FFDE42;
+    font-weight: normal;
+    text-shadow: none;
+}
+
+.debug-filters button.info {
+    color: #6ECBFF
+}
+
+.debug-filters button.debug {
+    color: #9E9E9E
+}
+
+.debug-filters button.off {
+    border-color: #444;
+    color: #666;
+}
+
+/* touch targets take the full width, and there is no pointer to reveal them on hover */
+.debug-filters.mobile button {
+    flex: 1;
+    opacity: 1;
+    padding: 4px 0;
+    font-size: 13px;
+    line-height: 24px;
+}
+
+/* the filter can hide the last row, which is what core/style.css uses to absorb surplus height */
+#chatdebug table {
+    min-height: 0;
+}
+
+#chatdebug.hide-error tr.error,
+#chatdebug.hide-warning tr.warning,
+#chatdebug.hide-log tr.log,
+#chatdebug.hide-info tr.info,
+#chatdebug.hide-debug tr.debug {
+    display: none;
 }

--- a/plugins/debug-console.js
+++ b/plugins/debug-console.js
@@ -14,6 +14,7 @@ var changelog = [
       'Fix auto-scroll to the bottom',
       'Do not let a failed log line break the code that logged it',
       'Show the message and stack of logged errors instead of {}',
+      'Show log messages coming from IITC core, not just from plugins',
     ],
   },
   {
@@ -183,6 +184,13 @@ function overwriteNative() {
   overwrite('error');
   overwrite('debug');
   overwrite('info');
+
+  // ulog bound the console its loggers saw at creation; re-assigning the level rebinds them all
+  // to the console installed above, so core output reaches this tab too
+  if (window.log) {
+    var level = window.log.level;
+    window.log.level = level;
+  }
 }
 
 // Old API utils

--- a/plugins/debug-console.js
+++ b/plugins/debug-console.js
@@ -1,7 +1,7 @@
 // @author         jaiperdu
 // @name           Debug console tab
 // @category       Debug
-// @version        0.2.1
+// @version        0.3.0
 // @description    Add a debug console tab
 
 /* exported setup, changelog --eslint */
@@ -9,12 +9,13 @@
 
 var changelog = [
   {
-    version: '0.2.1',
+    version: '0.3.0',
     changes: [
       'Fix auto-scroll to the bottom',
       'Do not let a failed log line break the code that logged it',
       'Show the message and stack of logged errors instead of {}',
-      'Show log messages coming from IITC core, not just from plugins',
+      'Capture messages logged through ulog, not just console.* calls',
+      'Add per-level filter buttons, with debug hidden by default; hidden levels are kept and can be shown again',
     ],
   },
   {
@@ -33,6 +34,24 @@ var changelog = [
 ];
 
 var debugTab = {};
+
+// ulog level numbers, compared against the browser console threshold
+var LEVELS = { error: 1, warn: 2, info: 3, log: 4, debug: 5, trace: 6 };
+var ROW_TYPES = { error: 'error', warn: 'warning', info: 'info', log: 'log', debug: 'debug', trace: 'debug' };
+// row type with the button label
+var FILTERS = [
+  { type: 'error', label: 'errors' },
+  { type: 'warning', label: 'warnings' },
+  { type: 'info', label: 'info' },
+  { type: 'log', label: 'logs' },
+  { type: 'debug', label: 'debug' },
+];
+var FILTER_KEY = 'plugin-debug-console-hidden';
+var MAX_ROWS = 2000;
+
+var nativeConsole;
+// core logs its internal diagnostics at debug level, so start with that noise folded away
+var hidden = { debug: true };
 
 // DEBUGGING TOOLS ///////////////////////////////////////////////////
 // meant to be used from browser debugger tools and the like.
@@ -59,6 +78,64 @@ debugTab.create = function () {
     },
   });
 };
+
+function saveFilters() {
+  try {
+    localStorage[FILTER_KEY] = JSON.stringify(
+      FILTERS.filter(function (filter) {
+        return hidden[filter.type];
+      }).map(function (filter) {
+        return filter.type;
+      })
+    );
+  } catch {
+    // the filter still applies, it just will not be remembered
+  }
+}
+
+function loadFilters() {
+  try {
+    var stored = localStorage[FILTER_KEY];
+    if (!stored) return;
+    hidden = {};
+    JSON.parse(stored).forEach(function (type) {
+      hidden[type] = true;
+    });
+  } catch {
+    // malformed state, keep the defaults
+  }
+}
+
+function applyFilters(container) {
+  FILTERS.forEach(function (filter) {
+    container.classList.toggle('hide-' + filter.type, !!hidden[filter.type]);
+  });
+}
+
+function buildFilterBar(container) {
+  var bar = document.createElement('div');
+  bar.className = 'debug-filters';
+  if (IITC.utils.isSmartphone()) bar.classList.add('mobile');
+
+  FILTERS.forEach(function (filter) {
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = filter.type;
+    button.textContent = filter.label;
+    button.title = 'Toggle ' + filter.label;
+    button.classList.toggle('off', !!hidden[filter.type]);
+    button.addEventListener('click', function () {
+      hidden[filter.type] = !hidden[filter.type];
+      button.classList.toggle('off', !!hidden[filter.type]);
+      applyFilters(container);
+      saveFilters();
+    });
+    bar.append(button);
+  });
+
+  container.insertBefore(bar, container.firstChild);
+  applyFilters(container);
+}
 
 debugTab.renderLine = function (errorType, args) {
   // Convert arguments to an array
@@ -116,7 +193,7 @@ debugTab.renderLine = function (errorType, args) {
   var time = document.createElement('time');
   var d = new Date();
   time.textContent = d.toLocaleTimeString();
-  time.title = d.toLocaleString();
+  time.title = IITC.utils.unixTimeToDateTimeString(d.getTime(), true);
   time.dataset.timestamp = d.getTime();
 
   // Type element creation (for log type)
@@ -129,21 +206,27 @@ debugTab.renderLine = function (errorType, args) {
   pre.textContent = text;
 
   var debugContainer = document.getElementById('chatdebug');
+  if (!debugContainer.querySelector('.debug-filters')) buildFilterBar(debugContainer);
   var scrollBefore = IITC.utils.scrollBottom(debugContainer);
 
   // Insert a new row in the debug table
   var table = debugContainer.querySelector('table');
   var row = table.insertRow();
+  row.className = errorType;
   row.insertCell().append(time);
   row.insertCell().append(type);
   row.insertCell().append(pre);
+
+  while (table.rows.length > MAX_ROWS) {
+    table.deleteRow(0);
+  }
 
   IITC.chat.keepScrollPosition(debugContainer, scrollBefore, false);
 };
 
 debugTab.console = {};
 debugTab.console.log = function () {
-  debugTab.renderLine('notice', arguments);
+  debugTab.renderLine('log', arguments);
 };
 
 debugTab.console.warn = function () {
@@ -163,7 +246,7 @@ debugTab.console.info = function () {
 };
 
 function overwriteNative() {
-  var nativeConsole = window.console;
+  nativeConsole = window.console;
   window.console = L.extend({}, window.console);
 
   function overwrite(which) {
@@ -184,13 +267,37 @@ function overwriteNative() {
   overwrite('error');
   overwrite('debug');
   overwrite('info');
+}
 
-  // ulog bound the console its loggers saw at creation; re-assigning the level rebinds them all
-  // to the console installed above, so core output reaches this tab too
-  if (window.log) {
-    var level = window.log.level;
-    window.log.level = level;
+// ulog binds whatever con() returns at logger creation, so a private sink gives this tab every
+// level while the console keeps its threshold; assigning the level rebinds the existing loggers
+function installLogSink() {
+  if (!window.log) return;
+
+  var consoleLevel = window.log.level;
+  // ?debug=<module> raises the level for a single module, which a flat threshold cannot express
+  if (consoleLevel < LEVELS.debug && (/[?&]debug=/.test(location.search) || localStorage.debug)) {
+    consoleLevel = LEVELS.debug;
   }
+
+  var sink = {};
+  Object.keys(LEVELS).forEach(function (method) {
+    sink[method] = function () {
+      try {
+        debugTab.renderLine(ROW_TYPES[method], arguments);
+      } catch {
+        // never break the caller: log.* is called from arbitrary code
+      }
+      if (nativeConsole && LEVELS[method] <= consoleLevel) {
+        (nativeConsole[method] || nativeConsole.log).apply(nativeConsole, arguments);
+      }
+    };
+  });
+
+  window.log.con = function () {
+    return sink;
+  };
+  window.log.level = 'trace';
 }
 
 // Old API utils
@@ -212,8 +319,10 @@ debugTab.show = function () {
 
 function setup() {
   window.plugin.debug = debugTab;
+  loadFilters();
   debugTab.create();
   overwriteNative();
+  installLogSink();
 
   $('<style>').prop('type', 'text/css').text('@include_string:debug-console.css@').appendTo('head');
 

--- a/plugins/debug-console.js
+++ b/plugins/debug-console.js
@@ -10,7 +10,11 @@
 var changelog = [
   {
     version: '0.2.1',
-    changes: ['Fix auto-scroll to the bottom', 'Do not let a failed log line break the code that logged it'],
+    changes: [
+      'Fix auto-scroll to the bottom',
+      'Do not let a failed log line break the code that logged it',
+      'Show the message and stack of logged errors instead of {}',
+    ],
   },
   {
     version: '0.2.0',
@@ -60,10 +64,22 @@ debugTab.renderLine = function (errorType, args) {
   args = Array.prototype.slice.call(args);
   var text = [];
 
+  // JSON.stringify renders an Error as {}: name/message/stack are non-enumerable
+  function errorToText(e) {
+    var head = String(e);
+    var stack = e.stack ? String(e.stack) : '';
+    if (!stack) return head;
+    // Chrome heads the stack with "Name: message"; Firefox and Safari list frames only
+    return stack.indexOf(head) === 0 ? stack : head + '\n' + stack;
+  }
+
   // Function to safely stringify objects with depth limitation
   function safeStringify(obj, depth = 5) {
     let cache = [];
     return JSON.stringify(obj, function (key, value) {
+      if (value instanceof Error) {
+        return errorToText(value);
+      }
       if (typeof value === 'object' && value !== null) {
         // Detect circular references or if the depth exceeds the limit
         if (cache.indexOf(value) !== -1 || cache.length > depth) {
@@ -77,8 +93,10 @@ debugTab.renderLine = function (errorType, args) {
   }
 
   args.forEach(function (v) {
-    // If v is not a string or number, attempt to stringify
-    if (typeof v !== 'string' && typeof v !== 'number') {
+    if (v instanceof Error) {
+      v = errorToText(v);
+    } else if (typeof v !== 'string' && typeof v !== 'number') {
+      // If v is not a string or number, attempt to stringify
       try {
         v = safeStringify(v);
       } catch {


### PR DESCRIPTION
- The tab now shows messages logged through ulog, not just direct `console.*` calls
- `debug-console` points ulog's `con()` hook at a private sink instead of swapping the console, so the tab gets every level while the browser console keeps its threshold
- Per-level filter buttons, named as in the Firefox console; rows are hidden with CSS rather than dropped, and `debug` starts hidden
- Logged errors show their message and stack instead of `{}`
- `window.log` exposes the root logger, so a core function patched via `.toString()` + `eval()` still resolves its injected `log` local - same failure as #952
- Core's refresh, render and idle traces moved to `log.debug`; the boot banner stays at `log`

<img width="713" height="111" alt="screenshot desktop" src="https://github.com/user-attachments/assets/16aab9ec-467f-41ae-984c-b2f9b24e9425" />
<img width="490" height="522" alt="screenshot mobile" src="https://github.com/user-attachments/assets/b6c9ed83-332e-4865-9d44-18f78982a534" />
