### PR TITLE
IITC-Mobile: target Android 16 (SDK 36)

### DIFF
--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -78,7 +78,7 @@ android {
         }
     }
 
-    lintOptions {
+    lint {
         abortOnError false
     }
     compileOptions {

--- a/mobile/app/build.gradle
+++ b/mobile/app/build.gradle
@@ -22,12 +22,12 @@ def metaFDroid(File apkDir, variant) {
 }
 
 android {
-    compileSdkVersion 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "org.exarhteam.iitc_mobile"
-        minSdkVersion 21
-        targetSdkVersion 35
+        minSdk 21
+        targetSdk 36
         versionCode = getVersionCodeTimeStamps()
         versionName "0.42.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -61,7 +61,7 @@
 
         <activity
             android:name="org.exarhteam.iitc_mobile.IITC_Mobile"
-            android:configChanges="orientation|keyboard|keyboardHidden|screenSize|uiMode"
+            android:configChanges="orientation|keyboard|keyboardHidden|screenSize|smallestScreenSize|screenLayout|uiMode"
             android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTask">

--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -136,6 +136,7 @@
             android:theme="@style/AppPrefTheme"
             android:exported="false"
             android:configChanges="orientation|keyboard|keyboardHidden|screenSize"
+            android:enableOnBackInvokedCallback="false"
             android:label="@string/activity_settings"/>
 
         <activity
@@ -143,6 +144,7 @@
             android:exported="true"
             android:theme="@style/AppPrefTheme"
             android:configChanges="orientation|keyboard|keyboardHidden|screenSize"
+            android:enableOnBackInvokedCallback="false"
             android:label="@string/activity_plugins">
             <!-- Handles external user plugins -->
             <intent-filter>

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -40,6 +40,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import android.os.Build;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.SearchView;
@@ -128,6 +129,7 @@ public class IITC_Mobile extends AppCompatActivity
     private final Stack<Pane> mBackStack = new Stack<IITC_NavigationHelper.Pane>();
     private Pane mCurrentPane = Pane.MAP;
     private boolean mBackButtonPressed = false;
+    private OnBackPressedCallback mBackPressedCallback;
 
     // Setup receiver to detect if Samsung DeX mode has been changed
 	private final BroadcastReceiver mDesktopModeReceiver = new BroadcastReceiver() {
@@ -205,6 +207,14 @@ public class IITC_Mobile extends AppCompatActivity
 
         // Setup window insets for edge-to-edge display
         WindowInsetsHelper.setupMainActivityInsets(this);
+
+        mBackPressedCallback = new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                handleBackPressed();
+            }
+        };
+        getOnBackPressedDispatcher().addCallback(this, mBackPressedCallback);
 
         debugScrollButton = findViewById(R.id.debugScrollButton);
 
@@ -720,8 +730,7 @@ public class IITC_Mobile extends AppCompatActivity
     }
 
     // we want a self defined behavior for the back button
-    @Override
-    public void onBackPressed() {
+    private void handleBackPressed() {
         // exit fullscreen mode if it is enabled and action bar is disabled or the back stack is empty
         if (mIitcWebView.isInFullscreen() && mBackStack.isEmpty()) {
             mIitcWebView.toggleFullscreen();
@@ -752,7 +761,11 @@ public class IITC_Mobile extends AppCompatActivity
         }
 
         if (mBackButtonPressed || !mSharedPrefs.getBoolean("pref_press_twice_to_exit", false)) {
-            super.onBackPressed();
+            // let the system handle this press, then take the events over again:
+            // back on the task root sends the app to the background without destroying it
+            mBackPressedCallback.setEnabled(false);
+            getOnBackPressedDispatcher().onBackPressed();
+            mBackPressedCallback.setEnabled(true);
         } else {
             mBackButtonPressed = true;
             Toast.makeText(this, getString(R.string.toast_press_twice_to_exit), Toast.LENGTH_SHORT).show();

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_WebView.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_WebView.java
@@ -1,7 +1,6 @@
 package org.exarhteam.iitc_mobile;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
@@ -9,12 +8,14 @@ import android.net.NetworkInfo;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.util.AttributeSet;
-import android.view.MotionEvent;
-import android.view.WindowManager;
 import android.webkit.CookieManager;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.widget.Toast;
+
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 import org.exarhteam.iitc_mobile.async.CheckHttpResponse;
 
@@ -39,7 +40,7 @@ public class IITC_WebView extends WebView {
     private IITC_Mobile mIitc;
     private SharedPreferences mSharedPrefs;
     private int mFullscreenStatus = 0;
-    private Runnable mNavHider;
+    private WindowInsetsControllerCompat mInsetsController;
     private boolean mDisableJs = false;
     private int defaultZoom;
     private int mSafeAreaTopPx = 0;
@@ -80,22 +81,6 @@ public class IITC_WebView extends WebView {
         mJsInterface = new IITC_JSInterface(mIitc);
 
         addJavascriptInterface(mJsInterface, "app");
-
-        mNavHider = new Runnable() {
-            @Override
-            public void run() {
-                if (isInFullscreen() && (getFullscreenStatus() & (FS_NAVBAR)) != 0) {
-                    int systemUiVisibility = SYSTEM_UI_FLAG_HIDE_NAVIGATION;
-                    // in immersive mode the user can interact with the app while the navbar is hidden
-                    // you can leave this mode by swiping down from the top of the screen. this does only work
-                    // when the app is in total-fullscreen mode
-                    if ((mFullscreenStatus & FS_SYSBAR) != 0) {
-                        systemUiVisibility |= SYSTEM_UI_FLAG_IMMERSIVE;
-                    }
-                    setSystemUiVisibility(systemUiVisibility);
-                }
-            }
-        };
 
         mIitcWebChromeClient = new IITC_WebChromeClient(mIitc);
         setWebChromeClient(mIitcWebChromeClient);
@@ -155,38 +140,47 @@ public class IITC_WebView extends WebView {
         }
     }
 
-    @SuppressLint("ClickableViewAccessibility")
-    @Override
-    public boolean onTouchEvent(final MotionEvent event) {
-        getHandler().removeCallbacks(mNavHider);
-        getHandler().postDelayed(mNavHider, 3000);
-        return super.onTouchEvent(event);
-    }
-
-    @Override
-    public void setSystemUiVisibility(final int visibility) {
-        if ((visibility & SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0) {
-            getHandler().postDelayed(mNavHider, 3000);
-        }
-        super.setSystemUiVisibility(visibility);
-    }
-
     @Override
     public void onWindowFocusChanged(final boolean hasWindowFocus) {
         if (hasWindowFocus) {
-            getHandler().postDelayed(mNavHider, 3000);
             // if the webView has focus, JS should always be enabled
             mDisableJs = false;
-        } else {
-            getHandler().removeCallbacks(mNavHider);
+            // the system brings the bars back while the window is out of focus,
+            // for example when the notification shade is pulled down
+            if (isInFullscreen()) {
+                hideSystemBars();
+            }
         }
         super.onWindowFocusChanged(hasWindowFocus);
+    }
+
+    private WindowInsetsControllerCompat getInsetsController() {
+        if (mInsetsController == null) {
+            mInsetsController = WindowCompat.getInsetsController(
+                    mIitc.getWindow(), mIitc.getWindow().getDecorView());
+        }
+        return mInsetsController;
+    }
+
+    // hide the bars selected in the fullscreen preference
+    private void hideSystemBars() {
+        final WindowInsetsControllerCompat controller = getInsetsController();
+        // the user can interact with the app while the bars are hidden and brings them
+        // back temporarily by swiping from the edge of the screen
+        controller.setSystemBarsBehavior(
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+
+        if ((mFullscreenStatus & FS_SYSBAR) != 0) {
+            controller.hide(WindowInsetsCompat.Type.statusBars());
+        }
+        if ((mFullscreenStatus & FS_NAVBAR) != 0) {
+            controller.hide(WindowInsetsCompat.Type.navigationBars());
+        }
     }
 
     public void toggleFullscreen() {
         mFullscreenStatus ^= FS_ENABLED;
 
-        final WindowManager.LayoutParams attrs = mIitc.getWindow().getAttributes();
         // toggle notification bar
         if (isInFullscreen()) {
             // show a toast with instructions to exit the fullscreen mode again
@@ -194,23 +188,15 @@ public class IITC_WebView extends WebView {
             if ((mFullscreenStatus & FS_ACTIONBAR) != 0) {
                 mIitc.getNavigationHelper().hideActionBar();
             }
-            if ((mFullscreenStatus & FS_SYSBAR) != 0) {
-                attrs.flags |= WindowManager.LayoutParams.FLAG_FULLSCREEN;
-            }
-            if ((mFullscreenStatus & FS_NAVBAR) != 0) {
-                getHandler().post(mNavHider);
-            }
+            hideSystemBars();
             if ((mFullscreenStatus & FS_STATUSBAR) != 0) {
                 loadUrl("javascript: $('#updatestatus').hide();");
             }
         } else {
-            attrs.flags &= ~WindowManager.LayoutParams.FLAG_FULLSCREEN;
+            getInsetsController().show(WindowInsetsCompat.Type.systemBars());
             mIitc.getNavigationHelper().showActionBar();
             loadUrl("javascript: $('#updatestatus').show();");
-            getHandler().removeCallbacks(mNavHider);
-            super.setSystemUiVisibility(SYSTEM_UI_FLAG_VISIBLE);
         }
-        mIitc.getWindow().setAttributes(attrs);
         mIitc.invalidateOptionsMenu();
 
         // Update safe area insets when fullscreen mode changes
@@ -226,10 +212,6 @@ public class IITC_WebView extends WebView {
         for (final String entry : entries) {
             mFullscreenStatus += Integer.parseInt(entry);
         }
-    }
-
-    int getFullscreenStatus() {
-        return mFullscreenStatus;
     }
 
     public boolean isInFullscreen() {

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -3,11 +3,10 @@
 buildscript {
     repositories {
         google()
-        jcenter()
-        
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.0'
+        classpath 'com.android.tools.build:gradle:8.13.0'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -23,5 +22,5 @@ allprojects {
 }
 
 task clean(type: Delete) {
-    delete rootProject.buildDir
+    delete rootProject.layout.buildDirectory
 }

--- a/mobile/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip


### PR DESCRIPTION
Google Play has been requiring app updates to target API 36 since 31 August 2026.

- AGP and Gradle updated to 8.13, since AGP 8.9 supports API 35 at most
- `compileSdk` and `targetSdk` raised to 36
- Back navigation moved to `OnBackPressedDispatcher`. API 36 no longer calls `Activity.onBackPressed()`, so without this back would simply close the app. The behaviour itself is unchanged
- The activity now survives window resizing on large screens instead of reloading IITC
- Fullscreen driven by `WindowInsetsControllerCompat` instead of the flags deprecated since API 30, which were already unreliable on targetSdk 35