### PR TITLE
Resume map and comm updates when the page becomes visible

### DIFF
--- a/core/code/idle.js
+++ b/core/code/idle.js
@@ -88,6 +88,11 @@ var idleMouseMove = function (e) {
 window.setupIdle = function () {
   $('body').on('keypress', window.idleReset);
   $('body').on('mousemove', idleMouseMove);
+
+  // a hidden page goes idle within REFRESH seconds, so resume as soon as it is visible again
+  document.addEventListener('visibilitychange', function () {
+    if (!document.hidden) window.idleReset();
+  });
 };
 
 /**

--- a/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
+++ b/mobile/app/src/main/java/org/exarhteam/iitc_mobile/IITC_Mobile.java
@@ -642,13 +642,6 @@ public class IITC_Mobile extends AppCompatActivity
         if (mReloadNeeded) {
             Log.d("preference had changed...reload needed");
             reloadIITC();
-        } else {
-            // iitc is not fully booted...timer will be reset by the script itself
-            if (findViewById(R.id.imageLoading).getVisibility() == View.GONE) {
-                // enough idle...let's do some work
-                Log.d("resuming...reset idleTimer");
-                mIitcWebView.loadJS("(function(){if(window.idleReset) window.idleReset();})();");
-            }
         }
 
         mUserLocation.onStart();

--- a/test/_mocks.js
+++ b/test/_mocks.js
@@ -64,6 +64,8 @@ globalThis.window = {
   requests: { addRefreshFunction: () => {} },
   CHAT_REQUEST_SCROLL_TOP: 200,
   failedRequestCount: 0,
+  REFRESH: 30,
+  MAX_IDLE_TIME: 15 * 60,
 
   // game constants, mirrored from core/total-conversion-build.js (all indexed by numeric team id where relevant)
   TEAM_NONE: 0,

--- a/test/idle.spec.js
+++ b/test/idle.spec.js
@@ -1,0 +1,78 @@
+import { describe, it, before, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+/* eslint-disable no-unused-expressions */
+
+await import('../core/code/idle.js');
+
+// jsdom serves document.hidden from a prototype getter, so shadow it with an own property
+const setVisibility = (state) => {
+  Object.defineProperty(document, 'hidden', { value: state === 'hidden', configurable: true });
+  document.dispatchEvent(new document.defaultView.Event('visibilitychange'));
+};
+
+describe('idle handling', () => {
+  before(() => {
+    window.setupIdle();
+  });
+
+  beforeEach(() => {
+    window.idleTime = 0;
+    window._idleTimeLimit = window.MAX_IDLE_TIME;
+    window._onResumeFunctions = [];
+  });
+
+  // idle.js replaces the isIdle mock for the whole run, so leave the page awake for the other specs
+  afterEach(() => {
+    delete document.hidden;
+    window.idleTime = 0;
+    window._idleTimeLimit = window.MAX_IDLE_TIME;
+    window._onResumeFunctions = [];
+  });
+
+  describe('visibilitychange', () => {
+    it('leaves idle mode once the page is visible again', () => {
+      const resume = sinon.spy();
+      window.addResumeFunction(resume);
+      window.idleSet();
+      expect(window.isIdle()).to.be.true;
+
+      setVisibility('visible');
+
+      expect(window.isIdle()).to.be.false;
+      expect(window.idleTime).to.equal(0);
+      expect(window._idleTimeLimit).to.equal(window.MAX_IDLE_TIME);
+      expect(resume.calledOnce).to.be.true;
+    });
+
+    it('restores the full idle time limit lowered while the page was hidden', () => {
+      window._idleTimeLimit = window.REFRESH;
+      window.idleTime = window.REFRESH;
+
+      setVisibility('visible');
+
+      expect(window._idleTimeLimit).to.equal(window.MAX_IDLE_TIME);
+    });
+
+    it('keeps the page idle while it is still hidden', () => {
+      const resume = sinon.spy();
+      window.addResumeFunction(resume);
+      window.idleSet();
+
+      setVisibility('hidden');
+
+      expect(window.isIdle()).to.be.true;
+      expect(resume.called).to.be.false;
+    });
+
+    it('does not run the resume functions when the page was never idle', () => {
+      const resume = sinon.spy();
+      window.addResumeFunction(resume);
+
+      setVisibility('visible');
+
+      expect(resume.called).to.be.false;
+    });
+  });
+});

--- a/test/portal.spec.js
+++ b/test/portal.spec.js
@@ -255,7 +255,8 @@ describe('IITC.portal navigation', () => {
     window.DEFAULT_ZOOM = 17;
     window.portals = {};
     window.selectedPortal = undefined;
-    window.renderPortalDetails = sinon.spy();
+    // window.renderPortalDetails aliases this property, and sinon.restore() only undoes stubs
+    sinon.stub(IITC.portal.display, 'renderDetails');
     sinon.stub(window.map, 'setView');
   });
 

--- a/test/portal_display.spec.js
+++ b/test/portal_display.spec.js
@@ -10,17 +10,12 @@ function resonators(levels, owner = 'me') {
   return levels.map((level) => (level === null ? null : { level, energy: window.RESO_NRG[level], owner }));
 }
 
-// captured before other specs overwrite the renderPortalDetails alias with a bare spy
-let realRenderDetails;
-
 before(async () => {
   await import('../core/code/utils.js');
   await import('../core/code/portal.js');
   await import('../core/code/portal_details.js');
   await import('../core/code/portal_display.js');
   await import('../core/code/portal_display_tools.js');
-
-  realRenderDetails = IITC.portal.display.renderDetails;
 });
 
 afterEach(() => sinon.restore());
@@ -301,7 +296,6 @@ describe('IITC.portal.display.renderUrl', () => {
 
 describe('IITC.portal.display.renderDetails', () => {
   beforeEach(() => {
-    IITC.portal.display.renderDetails = realRenderDetails; // undo the alias overwrite from other specs
     window.portals = {};
     window.selectedPortal = undefined;
     IITC.statusbar = { portal: { update: sinon.spy() } };


### PR DESCRIPTION
IITC stops refreshing map data and COMM once the idle check in `idle.js` trips, and a hidden tab reaches that point after 30 seconds. Returning to it did not resume anything by itself - the page had to be interacted with first. IITC Mobile worked around this by calling `idleReset()` from `onStart()`; browsers and other apps had no equivalent.

- `setupIdle()` now leaves idle mode on `visibilitychange`, so returning to the tab or app resumes updates on its own
- the IITC Mobile workaround is dropped, as the core now covers it