### PR TITLE
Fix Draw Tools location filters going stale after zoom

### DIFF
--- a/plugins/draw-tools.js
+++ b/plugins/draw-tools.js
@@ -13,6 +13,7 @@ var changelog = [
     changes: [
       'Sync drawn items across devices via the Sync plugin (Multi-Projects-Extension aware)',
       'Register with the Sync plugin regardless of plugin load order',
+      'Fix drawn area used by Tidy Links and Fly Links being misplaced after zooming',
     ],
   },
   { version: '0.12.1', changes: ['Refactoring: update Leaflet API usage'] },
@@ -999,11 +1000,8 @@ window.plugin.drawTools.initMPE = function () {
   });
 };
 
-var cachedFilters;
+// one filter per drawn polygon; each compares layer points, so it is valid only for the view it was built in
 window.plugin.drawTools.getLocationFilters = function () {
-  if (cachedFilters) {
-    return cachedFilters;
-  }
   var filters;
   if (!window.map.hasLayer(window.plugin.drawTools.drawnItems)) {
     return [];
@@ -1052,7 +1050,6 @@ window.plugin.drawTools.getLocationFilters = function () {
       return window.pnpoly(poly, point);
     };
   });
-  cachedFilters = filters;
   return filters;
 };
 
@@ -1208,9 +1205,6 @@ function setup() {
   var filterEvents = new L.Evented();
   window.map.on('draw:created draw:edited draw:deleted', function (e) {
     filterEvents.fire('changed', { originalEvent: e });
-  });
-  filterEvents.on('changed', function () {
-    cachedFilters = null;
   });
   window.plugin.drawTools.filterEvents = filterEvents;
 }

--- a/plugins/tidy-links.js
+++ b/plugins/tidy-links.js
@@ -29,9 +29,6 @@ window.plugin.tidyLinks = tidyLinks;
 
 tidyLinks.MAX_PORTALS_TO_LINK = 200; // N.B.: this limit is not about performance
 
-// zoom level used for projecting points between latLng and pixel coordinates. may affect precision of triangulation
-tidyLinks.PROJECT_ZOOM = 16;
-
 // https://leafletjs.com/reference-1.4.0.html#polyline-stroke
 tidyLinks.STROKE_STYLE = {
   color: 'red',


### PR DESCRIPTION
With a Draw Tools polygon on the map, Tidy Links and Fly Links drew for an area offset from the polygon, and often the wrong size, once the map had been zoomed.

`getLocationFilters()` cached filters that compare Leaflet layer points, which are recomputed on every reprojection, while the cache was cleared only on `draw:created`/`edited`/`deleted`.

- the cache is dropped rather than invalidated: rebuilding is one pass over the drawn items, and the same staleness also hit `import`, sync and MPE project switches, which never fired those events either
- `tidy-links` loses its unused `PROJECT_ZOOM` constant

fixes #925